### PR TITLE
added my own unofficial APOD API to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Launch Library](https://launchlibrary.net/docs/1.3/api.html) | Upcoming Space Launches | No | Yes | Unknown |
 | [Minor Planet Center](http://www.asterank.com/mpc) | Asterank.com Information | No | No | Unknown |
 | [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | Unknown |
+| [NASA APOD (unofficial API)](https://apodapi.herokuapp.com/) | API for getting APOD (Astronomy Image of the Day) images along with metadata | No | Yes | Yes |
 | [Newton](https://newton.now.sh/) | Symbolic and Arithmetic Math Calculator | No | Yes | Unknown |
 | [Numbers](http://numbersapi.com) | Facts about numbers | No | No | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | Unknown |


### PR DESCRIPTION
I added my [unofficial API](https://github.com/PawelPleskaczynski/apod_api) for accessing NASA's APOD images along with metadata that supports HTTPS, CORS and caches requests