### PR TITLE
Remove Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,6 @@ API | Description | Auth | HTTPS | CORS |
 ### Social
 API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
-| [Buffer](https://buffer.com/developers/api) | Access to pending and sent updates in Buffer | `OAuth` | Yes | Unknown |
 | [Cisco Spark](https://developer.ciscospark.com) | Team Collaboration Software | `OAuth` | Yes | Unknown |
 | [Discord](https://discordapp.com/developers/docs/intro) | Make bots for Discord, integrate Discord onto an external platform | `OAuth` | Yes | Unknown |
 | [Disqus](https://disqus.com/api/docs/auth/) | Communicate with Disqus data | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
[Buffer](https://buffer.com/developers/api) no longer supports the registration of new developer applications.
