### PR TITLE
Deleted WeTransfer because public API retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ API | Description | Auth | HTTPS | CORS |
 | [OneDrive](https://dev.onedrive.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown |
 | [Pastebin](https://pastebin.com/api/) | Plain Text Storage | `apiKey` | Yes | Unknown |
 | [Temporal](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud) | IPFS based file storage and sharing with optional IPNS naming | `apiKey` | Yes | No |
-| [WeTransfer](https://developers.wetransfer.com) | File Sharing | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 ### Continuous Integration


### PR DESCRIPTION
WeTransfer retired their public API six months ago. See https://wetransfer.zendesk.com/hc/en-us/articles/360038551772-We-ve-retired-our-Public-API
