### PR TITLE
Change Launch Library to Launch Libary 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ API | Description | Auth | HTTPS | CORS |
 | [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
 | [inspirehep.net](https://inspirehep.net/info/hep/api?ln=en) | High Energy Physics info. system | No | Yes | Unknown |
 | [ITIS](https://www.itis.gov/ws_description.html) | Integrated Taxonomic Information System | No | Yes | Unknown |
-| [Launch Library](https://launchlibrary.net/docs/1.3/api.html) | Upcoming Space Launches | No | Yes | Unknown |
+| [Launch Library 2](https://thespacedevs.com/llapi) | Upcoming Space Launches | No | Yes | Unknown |
 | [Minor Planet Center](http://www.asterank.com/mpc) | Asterank.com Information | No | No | Unknown |
 | [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | Unknown |
 | [NASA APOD (unofficial API)](https://apodapi.herokuapp.com/) | API for getting APOD (Astronomy Image of the Day) images along with metadata | No | Yes | Yes |


### PR DESCRIPTION
Hey, I saw this on the Launch Library [webiste](https://launchlibrary.net/):

> Due to time commitments of the old developer and due to the ending of financial support from our previous benefactor, Launch Library in its current state (LL1) will be closing down. However, the new owners, Caleb and Jacques along with the Space Launch Now team have created a new entity named The Space Devs which will manage and promote the successor of the Launch Library API.
The new API named Launch Library 2 (LL2) contains the same data as LL1 and much more. Support for LL1 has ended, however, we will ensure that the API remains active for some time allowing developers to migrate to the new API. Further detail can be found on TheSpaceDevs website and Discord server :
https://thespacedevs.com/
https://discord.gg/p7ntkNA

and updated repo with the new version of API with even more data and features.

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] Your additions are ordered alphabetically
- [x] Your submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
