### PR TITLE
Removed the entry for Let's Validate API, as suggested by Issue #1370

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ API | Description | Auth | HTTPS | CORS |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [Judge0](https://api.judge0.com/) | Compile and run source code | No | Yes | Unknown |
-| [Let's Validate](https://github.com/letsvalidate/api) | Uncovers the technologies used on websites and URL to thumbnail | No | Yes | Unknown |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [MAC address vendor lookup](https://macaddress.io) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
 | [Nationalize.io](https://nationalize.io) | Estimate the nationality of a first name | No | Yes | Yes |


### PR DESCRIPTION
Simply removed the entry for Let's Validate API from README.md, as it does appear the api is defunct.

The last update to their github page https://github.com/letsvalidate/api appears to have been 3 years ago and this issue https://github.com/letsvalidate/api/issues/14 open on their github shows the service is down and the api is not being maintained.