### PR TITLE
Remove wunderlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Vector Express](http://vector.express) | Free vector file converting API | No | No | Yes |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
-| [Wunderlist](https://developer.wunderlist.com/documentation) | Todo Lists | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 ### Environment


### PR DESCRIPTION
Hey @yannbertrand 

just removing a dead link - Wunderlist has been aquired by Microsoft and integrated into their own product. The API is gone too afaik.

Cheers,
Peter