### PR TITLE
Add TinyURL to URL Shorteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CleanURI](https://cleanuri.com/docs) | URL shortener service | `No` | Yes | Yes |
 | [ClickMeter](https://support.clickmeter.com/hc/en-us/categories/201474986) | Monitor, compare and optimize your marketing links | `apiKey` | Yes | Unknown |
 | [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` | Yes | Unknown |
+| [TinyURL](https://gist.github.com/chand1012/96581b90c575d70bbf671ed00a74adde) | Unofficial TinyURL API for shortening URLs | `No` | Yes | Unknown |  
 
 **[⬆ Back to Index](#index)**
 ### Vehicle


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

I've been using TinyURL as an API in one of my personal projects for a while now and I thought it would be useful to this project as well. There were not official documentation on how to use TinyURL as an API so I wrote it myself, They have documentation listed on their [homepage](https://tinyurl.com/#toolbar) on how to make a browser toolbar shortcut that shortens a URL so I figured since making API requests wasn't any different that I can make an official API document found [here](https://gist.github.com/chand1012/96581b90c575d70bbf671ed00a74adde).
