### PR TITLE
Revert "Added Unixtime conversion service"

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ API | Description | Auth | HTTPS | CORS |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
-| [Unixtime](https://unixtime.co.za/) | Convert to and from Unixtime | No | Yes | Unknown |
 | [userstack](https://userstack.com/) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 


### PR DESCRIPTION
Reverts public-apis/public-apis#1361

Reverting this change due to duplicate URLs in the README.
