### PR TITLE
Remove broken link Russian State Duma Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |
 | [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members) | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No | No | Unknown |
 | [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis) | Contains D.C. government public datasets, including crime, GIS, financial data, and so on | No | Yes | Unknown |
-| [duma.gov.ru](http://api.duma.gov.ru) | Russian State Duma Open Data | `apiKey` | No | Unknown |
 | [EPA](https://developer.epa.gov/category/apis/) | Web services and data sets from the US Environmental Protection Agency | No | Yes | Unknown |
 | [FBI Wanted](https://www.fbi.gov/wanted/api) | Access information on the FBI Wanted program | No | Yes | Unknown |
 | [FEC](https://api.open.fec.gov/developers/) | Information on campaign donations in federal elections | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
ERR_CONNECTION_TIMED_OUT for `http://api.duma.gov.ru/` or `https://api.duma.gov.ru/`

> ping api.duma.gov.ru
> 
> Pinging old.duma.gov.ru [95.173.130.2] with 32 bytes of data:
> Request timed out.
> Request timed out.
> Request timed out.
> Request timed out.
> 
> Ping statistics for 95.173.130.2:
>     Packets: Sent = 4, Received = 0, Lost = 4 (100% loss),

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My submission has a useful description
- [x] Each table column is padded with one space on either side

