### PR TITLE
Remove CoinDesk API

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
 | [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [CoinCap](https://docs.coincap.io/) | Real time Cryptocurrency prices through a RESTful API | No | Yes | Unknown |
-| [CoinDesk](http://www.coindesk.com/api/) | Bitcoin Price Index | No | No | Unknown |
 | [CoinGecko](http://www.coingecko.com/api) | Cryptocurrency Price, Market, and Developer/Social Data | No | Yes | Yes |
 | [Coinigy](https://coinigy.docs.apiary.io) | Interacting with Coinigy Accounts and Exchange Directly | `apiKey` | Yes | Unknown |
 | [Coinlib](https://coinlib.io/apidocs) | Crypto Currency Prices | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
The [CoinDesk](http://www.coindesk.com/api/) link was present, but pointed to a 404-page. The endpoint seems to still be working ([example](https://api.coindesk.com/v1/bpi/currentprice.json)), but is nowhere documented or mentioned by CoinDesk, hence the removal from this list.

Alternatively, we could update the CoinDesk API link to be this one endpoint, without any further context or documentation available.
```
| [CoinDesk](https://api.coindesk.com/v1/bpi/currentprice.json) | Bitcoin Price Index | No | No | Unknown |
```
