### PR TITLE
Remove duplicate APIs and Fix title of API Setu

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [18F](http://18f.github.io/API-All-the-X/) | Unofficial US Federal Government API Development | No | No | Unknown |
-| [Apisetu.gov.in](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
+| [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | Unknown |
 | [Black History Facts](https://blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |


### PR DESCRIPTION
Just to correct a mistake of ours.

Some APIs were added by us and we thought they were independent, but they aren't. These APIs that I remove in this PR are sub-apis of the API Setu or its resources.

Therefore, I remove them to keep only the main link which is already showing all your APIs, Sub-APIs and resources available.