### PR TITLE
Count as error only for 4xx and 5xx http status codes

### DIFF
--- a/build/validate_links.py
+++ b/build/validate_links.py
@@ -57,7 +57,7 @@ def validate_links(links):
             })
             code = int(resp[0]['status'])
             # Checking status code errors
-            if (code >= 300):
+            if (code >= 400):
                 hasError = True
                 print(f"ERR:CLT:{code} : {link}")
         except TimeoutError:


### PR DESCRIPTION
3xx is not a real error. Redirecting tells where the resource is located now. It is common that some of the resources are being moved here and there. Therefore link validation should not fail if the HTTP status code is 3xx.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My addition is ordered alphabetically
- [ ] My submission has a useful description
- [ ] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [ ] Each table column is padded with one space on either side
- [ ] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
