### PR TITLE
Set host header for link validator

### DIFF
--- a/build/validate_links.py
+++ b/build/validate_links.py
@@ -58,9 +58,9 @@ def validate_links(links):
                 
             resp = h.request(link, headers={
                 # Faking user agent as some hosting services block not-whitelisted UA
-                'user-agent': 'Mozilla/5.0'
+                'user-agent': 'Mozilla/5.0',
                 # setting host because Cloudflare returns 403 asking for captcha if host is missing
-                f'host: {host}'
+                'host': host
             })
             code = int(resp[0]['status'])
             # Checking status code errors


### PR DESCRIPTION
Cloudflare returns the HTTP status code 403 if the request doesn't contain the `Host` header. It is asking for a captcha because it recognizes the request as automated. Host header should contain the actual host (without www prefix).
