### PR TITLE
Adds API-Football.com to sport & fitness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Sports & Fitness
 API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
+| [API-Football](https://www.api-football.com/documentation-v3) | API-Football Restful API for Football data | `apiKey` | Yes | Unknown |
 | [ApiMedic](https://apimedic.com/) | ApiMedic offers a medical symptom checker API primarily for patients | `apiKey` | Yes | Unknown |
 | [balldontlie](https://balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |
 | [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey` | Yes | No |


### PR DESCRIPTION
API-Football covers over 800 leagues and cups worldwide. With a free account you can make 100 requests per day to access their data.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [X] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [X] My addition is ordered alphabetically
- [X] My submission has a useful description
- [X] The description does not have more than 100 characters
- [X] The description does not end with punctuation
- [X] Each table column is padded with one space on either side
- [X] I have searched the repository for any relevant issues or pull requests
- [X] Any category I am creating has the minimum requirement of 3 items
- [X] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
