### PR TITLE
Add Impala and Laya to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,9 @@ API | Description | Auth | HTTPS | CORS |
 | [Grab](https://developer.grab.com/docs/) | Track deliveries, ride fares, payments and loyalty points | `OAuth` | Yes | Unknown |
 | [GraphHopper](https://graphhopper.com/api/1/docs/) | A-to-B routing with turn-by-turn instructions | `apiKey` | Yes | Unknown |
 | [Icelandic APIs](http://docs.apis.is/) | Open APIs that deliver services in or regarding Iceland | No | Yes | Unknown |
+| [Impala Hotel Bookings](https://docs.impala.travel/docs/booking-api/) | Sell hotel rooms and earn commissions | `apiKey` | Yes | Unknown |
 | [Izi](http://api-docs.izi.travel/) | Audio guide for travellers | `apiKey` | Yes | Unknown |
+| [Laya](https://docs.laya.ai/) | Dynamic packaging for flights, cars and accommodation | `apiKey` | Yes | Unknown |
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://api.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Helping to resolve inactive PRs (from issue #2002)
The PR #1506 appears to be abandoned, the original PR moved the Amadeus link from the Transportation category into a new category called Travel and added two other API providers, Impala and Laya.

Since then, the Amadeus link has changed and the repo has the current correct link. The providers Impala and Laya have not yet been added to the repo. This PR adds them to the Transportation category, but I'm not 100% sure they should be in there since they are broader than transportation - Impala is all about selling hotel rooms and making commissions, while Laya deals with trip planning and suggests packages for flights, vehicles and accommodation.

I am not familiar with these APIs myself, if they are not super useful, it may not be worth adding to the repo, and PR #1506 could be closed out. I did check that the links are accurate, that they have free tiers, require API keys to use and support HTTPS. I was not able to verify CORS support.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
