### PR TITLE
Remove MySocialApp for lack of free tier/abandonement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,6 @@ API | Description | Auth | HTTPS | CORS |
 | [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | The foundation of all digital integrations with LinkedIn | `OAuth` | Yes | Unknown |
 | [Meetup.com](https://www.meetup.com/meetup_api/) | Data about Meetups from Meetup.com | `apiKey` | Yes | Unknown |
 | [Microsoft Graph](https://docs.microsoft.com/en-us/graph/api/overview) | Access the data and intelligence in Microsoft 365, Windows 10, and Enterprise Mobility | `OAuth` | Yes | Unknown |
-| [MySocialApp](https://mysocialapp.io) | Seamless Social Networking features, API, SDK to any app | `apiKey` | Yes | Unknown |
 | [NAVER](https://developers.naver.com/main/) | NAVER Login, Share on NAVER, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
 | [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
It seems like there is no free tier, according to their [pricing page](https://mysocialapp.io/pricing). 

Also, the project seems abandoned for the following reasons:
 - There haven't been any commits on their GitHub repos in a very long time (1+ years for most of them). [Link](https://github.com/orgs/MySocialApp/repositories)
 - The `Early Access` buttons show an expired Typeform. There is no other way to get access to the app. (Fig. 1)
 - Their documentation page links to the same expired Typeform in the first step of getting started. [Link](https://docs.mysocialapp.io/docs/setup).

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

Fig. 1
![image](https://user-images.githubusercontent.com/24983797/138622887-743b63c5-8518-422f-b82c-97cc6444773e.png)
