### PR TITLE
Remove Scraper.ai because it's discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,6 @@ API | Description | Auth | HTTPS | CORS |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |
 | [SavePage.io](https://www.savepage.io) | A free, RESTful API used to screenshot any desktop, or mobile website | `apiKey` | Yes | Yes |
-| [Scraper.AI](https://docs.scraper.ai/#/) | Extract and monitor data from any website | `apiKey` | Yes | Unknown |
 | [ScraperApi](https://www.scraperapi.com) | Easily build scalable web scrapers | `apiKey` | Yes | Unknown |
 | [scraperBox](https://scraperbox.com/) | Undetectable web scraping API | `apiKey` | Yes | Yes |
 | [scrapestack](https://scrapestack.com/) | Real-time, Scalable Proxy & Web Scraping REST API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
This service is permanently offline. Even though the documentation site is still available, the scraper.ai domain is unreachable. See Wayback Machine versions of their [homepage](https://web.archive.org/web/20210414175250/https://scraper.ai/) and [farewell post](https://web.archive.org/web/20210414163748/https://scraper.ai/halting) and Screenshots below

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

![image](https://user-images.githubusercontent.com/24983797/138633130-e3da44a3-23c7-4029-a5ae-2f13f6ed060a.png)

![image](https://user-images.githubusercontent.com/24983797/138633149-85b34ebd-5295-4cca-8fb9-ef4342e2b295.png)
