### PR TITLE
add OPSI (Slovenia Open Data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, Saudi Arabia](https://data.gov.sa) | Saudi Arabia Government Open Data | No | Yes | Unknown |
 | [Open Government, Singapore](https://data.gov.sg/) | Singapore Government Open Data | No | Yes | Unknown |
 | [Open Government, Slovakia](https://data.gov.sk/en/) | Slovakia Government Open Data | No | Yes | Unknown |
+| [Open Government, Slovenia](https://podatki.gov.si/) | Slovenia Government Open Data | No | Yes | No |
 | [Open Government, South Australian Government](https://data.sa.gov.au/) | South Australian Government Open Data | No | Yes | Unknown |
 | [Open Government, Spain](https://datos.gob.es/en) | Spain Government Open Data | No | Yes | Unknown |
 | [Open Government, Sweden](https://www.dataportal.se/en/dataservice/91_29789/api-for-the-statistical-database) | Sweden Government Open Data | No | Yes | Unknown |


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

Hi! I do know there was a previous PR filed, not that long ago, to do the same. This is PR #2338.

However, I believe the Slovenia government in fact does have an Open Data API. I will attempt to explain here how it works, as I understand it.

The main portal is available at https://podatki.gov.si/

This offers content in traditional "download a CSV"/"download a XML"-style, but also offers an API! Not sure if it wasn't available at the time of the previous PR, or if it was missed.
Items labelled as "PROG. VMESNIK" showcase having an API, and it seems there is a number of such items.

Example: https://podatki.gov.si/dataset/seznam-praznikov-in-dela-prostih-dni-v-republiki-sloveniji
Click on "Prog. vmesnik" and you can see the examples for how to query by clicking on "Poizvedovanje »".

It supports two ways of accessing:
- Normal access, e.g. just get parameters.
- SQL-like access (I can't say I super understand this)

Example, querying for holidays that occur on a Saturday: https://podatki.gov.si/api/3/action/datastore_search?resource_id=eb8b25ea-5c00-4817-a670-26e1023677c6&q=sobota

The website is built on CKAN.