### PR TITLE
Add Collective APIs Site in the Alternative sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@
 <div align="center">
     <sub>Alternative sites for the project (unofficials)</sub>
     <br />
-    <a href="https://www.collective-api.ml">Collective APIs</a> •
     <a href="https://free-apis.github.io">Free APIs</a> •
     <a href="https://devresourc.es/tools-and-utilities/public-apis">Dev Resources</a> •
     <a href="https://www.public-apis.ml">Public APIs Site</a> •
-    <a href="https://apihouse.vercel.app">Apihouse</a>
+    <a href="https://apihouse.vercel.app">Apihouse</a> •
+    <a href="https://collective-api.vercel.app/">Collective APIs</a> 
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 <div align="center">
     <sub>Alternative sites for the project (unofficials)</sub>
     <br />
+    <a href="https://www.collective-api.ml">Collective APIs</a> •
     <a href="https://free-apis.github.io">Free APIs</a> •
     <a href="https://devresourc.es/tools-and-utilities/public-apis">Dev Resources</a> •
     <a href="https://www.public-apis.ml">Public APIs Site</a> •


### PR DESCRIPTION
Update link for [Collective APIs](https://collective-api.vercel.app/): Old domain had an unexpected _"Invalid Domain Configuration"_

I am unable to recover the old link, hence the default link: https://collective-api.vercel.app/

- **Landing Page**

![collective-apis header](https://user-images.githubusercontent.com/78056869/148945762-bc632c90-6ccb-4ee2-9973-df157af58fd8.jpg)

- **Results page**

![collective-apis results](https://user-images.githubusercontent.com/78056869/148945771-e1b22668-a9df-454a-982a-5125e67c02e7.jpg)

