### PR TITLE
Adds Go-APOD under Science & Math

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ API | Description | Auth | HTTPS | CORS |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |
+| [Go-APOD](go-apod.herokuapp.com/) | NASA's Astronomy Picture of the Day | No | Yes | Yes |
 | [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
 | [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | High Energy Physics info. system | No | Yes | Unknown |
 | [isEven (humor)](https://isevenapi.xyz/) | Check if a number is even | No | Yes | Unknown |


### PR DESCRIPTION

Adds Go-APOD, an API for fetching the Astronomy Picture of the Day and associated info.

Source: [github.com/lissy93/go-apod](https://github.com/lissy93/go-apod/)

This differs from what is available directly from NASA, as it has additional endpoints, including raw image, it's also CORS-enabled and doesn't require auth.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [X] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [X] My addition is ordered alphabetically
- [X] My submission has a useful description
- [X] The description does not have more than 100 characters
- [X] The description does not end with punctuation
- [X] Each table column is padded with one space on either side
- [X] I have searched the repository for any relevant issues or pull requests
- [X] Any category I am creating has the minimum requirement of 3 items
- [X] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
