### PR TITLE
Added Form2Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
+| [Form2Channel](https://form2channel.com) | Sending Forms To Email, GoogleSheet, Telegram or Slack | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |
 | [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |
 | [GETPing](https://www.getping.info) | Trigger an email notification with a simple GET request | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Form2Channel is a free service that converts html form submissions to messages and sends them via email, to GoogleSheets, via Slack or Telegram. Using an APIKey is an option, but not necessary.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [Y] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [Y] My addition is ordered alphabetically
- [Y] My submission has a useful description
- [Y] The description does not have more than 100 characters
- [Y] The description does not end with punctuation
- [Y] Each table column is padded with one space on either side
- [Y] I have searched the repository for any relevant issues or pull requests
- [Y] Any category I am creating has the minimum requirement of 3 items
- [Y] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
