### PR TITLE
updated link of Excuser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
-| [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
+| [Excuser](http://ec2-13-233-208-44.ap-south-1.compute.amazonaws.com/) | Get random excuses for various situations | No | No | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |


### PR DESCRIPTION
Before the excuser API was hosted on Heroku, but now Heroku has stopped providing free dyno hours, so I had to redeploy it to AWS.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [X] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [X] My addition is ordered alphabetically
- [X] My submission has a useful description
- [X] The description does not have more than 100 characters
- [X] The description does not end with punctuation
- [X] Each table column is padded with one space on either side
- [X] I have searched the repository for any relevant issues or pull requests
- [X] Any category I am creating has the minimum requirement of 3 items
- [X] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
