### PR TITLE
Removed Excuser from entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,6 @@ API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
-| [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |


### PR DESCRIPTION
Removed Excuser from entertainment because when i try tried to vist its link it shows an application error from Heroku Here is the link if you want to try your own [Excuser](https://excuser.herokuapp.com/) Sorry for bad description cuz i dont know how should i describe it

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md) (I guess so)
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
