### PR TITLE
Add MusicBee API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LastFm](https://www.last.fm/api) | Music | `apiKey` | Yes | Unknown |
 | [Lyrics.ovh](https://lyricsovh.docs.apiary.io) | Simple API to retrieve the lyrics of a song | No | Yes | Unknown |
 | [Mixcloud](https://www.mixcloud.com/developers/) | Music | `OAuth` | Yes | Yes |
+| [MusicBee](https://www.getmusicbee.com/help/api/) | MusicBee API enables plugin developers to access information held in MusicBee and to control MusicBee. | No | Yes | Unkown |
 | [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music | No | Yes | Unknown |
 | [Musixmatch](https://developer.musixmatch.com/) | Music | `apiKey` | Yes | Unknown |
 | [Napster](https://developer.napster.com/api/v2.2) | Music | `apiKey` | Yes | Yes |


### PR DESCRIPTION
The MusicBee API allows users to retrieve and control information stored within the MusicBee platform, allowing developers to create neat plugins. 
