### PR TITLE
Updated README.md to include the PRH Enhanced API

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ API | Description | Auth | HTTPS | CORS |
 | [GurbaniNow](https://github.com/GurbaniNow/api) | Fast and Accurate Gurbani RESTful API | No | Yes | Unknown |
 | [Gutendex](https://gutendex.com/) | Web-API for fetching data from Project Gutenberg Books Library | No | Yes | Unknown |
 | [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | No |
-| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Yes |
+| [Penguin Publishing (v1)](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | `apiKey` | Yes | Yes |
+| [Penguin Random House Publishing (Enhanced)](https://developer.penguinrandomhouse.com) | Books, book covers, authors, events and related data | `apiKey` | Yes | Yes |
 | [PoetryDB](https://github.com/thundercomb/poetrydb#readme) | Enables you to get instant data from our vast poetry collection | No | Yes | Yes |
 | [Quran](https://quran.api-docs.io/) | RESTful Quran API with multiple languages | No | Yes | Yes |
 | [Quran Cloud](https://alquran.cloud/api) | A RESTful Quran API to retrieve an Ayah, Surah, Juz or the entire Holy Quran | No | Yes | Yes |


### PR DESCRIPTION
Updated the ReadMe to include the PRH Enhanced API, marked the old API as "v1", updated the old PRH API to reference `apiKey` as the authentication method