### PR TITLE
Fix broken link to CONTRIBUTING.md in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thank you for taking the time to work on a Pull Request for this project! -->
 <!-- To ensure your PR is dealt with swiftly please check the following: -->
-- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
+- [ ] My submission is formatted according to the guidelines in the [contributing guide](../blob/master/CONTRIBUTING.md)
 - [ ] My addition is ordered alphabetically
 - [ ] My submission has a useful description
 - [ ] The description does not have more than 100 characters


### PR DESCRIPTION
Fixes #3934 

Replace broken `/CONTRIBUTING.md` relative link ([as below](/CONTRIBUTING.md)) with [`../blob/master/CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
