### PR TITLE
Updated a discontinued API to its successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,7 +1316,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [EPO](https://developers.epo.org/) | European patent search system api | `OAuth` | Yes | Unknown |
-| [PatentsView ](https://patentsview.org/apis/purpose) | API is intended to explore and visualize trends/patterns across the US innovation landscape | No | Yes | Unknown |
+| [PatentsView ](https://search.patentsview.org/docs/docs/Search%20API/SearchAPIReference/) | API is intended to explore and visualize trends/patterns across the US innovation landscape | `apiKey` | Yes | Unknown |
 | [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api | `apiKey` | Yes | Unknown |
 | [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility) | USA patent api services | No | Yes | Unknown |
 


### PR DESCRIPTION
The legacy API has entered maintenance mode and will soon be discontinued. This is an update to the link and that it requires a auth key for further requests.