### PR TITLE
Add xMath API for generating random math expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1448,7 +1448,7 @@ API | Description | Auth | HTTPS | CORS |
 | [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | No |
 | [USGS Water Services](https://waterservices.usgs.gov/) | Water quality and level info for rivers and lakes | No | Yes | No |
 | [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | World Data | No | Yes | No |
-| [xMath](https://x-math.herokuapp.com/) | Random mathematical expressions | No | Yes | Yes |
+| [xMath](https://x-math.azurewebsites.net/) | Random mathematical expressions | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
The xMath API has been down for a while due to Heroku pricing changes. We have seen users open [issues ](https://github.com/public-apis/public-apis/issues/3987) for deprecation.

Since most users still want to use this API, I forked the original project and recoded it in python then hosted it on Azure. I get some credits there so I should be able to host this project for a long time. Hopefully, it helps the previous users.

The index page has the documentation, structure of the api has not changed apart from url
