### PR TITLE
Replacing the unsupported and disabled PunkAPI with a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
-| [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
+| [PunkAPI](https://github.com/alxiw/punkapi) | Brewdog Beer Recipes | No | Yes | Yes |
 | [Rustybeer](https://rustybeer.herokuapp.com/) | Beer brewing tools | No | Yes | No |
 | [Spoonacular](https://spoonacular.com/food-api) | Recipes, Food Products, and Meal Planning | `apiKey` | Yes | Unknown |
 | [Systembolaget](https://api-portal.systembolaget.se) | Govornment owned liqour store in Sweden | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
The [old project](https://github.com/sammdec/punkapi) has been abandoned by its developer, is no longer supported, and is currently disabled. The [website](https://github.com/sammdec/punkapi-site) is unavailable, and the GitHub project has been inactive since May 1, 2024.
I have decided to take over this project and enhance it by providing users with access to the BrewDog digital catalogue through an API, I propose replacing the outdated project with my [new one](https://github.com/alxiw/punkapi).

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit