### PR TITLE
docs: fix grammar in Cataas API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ API | Description | Auth | HTTPS | CORS
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
-| [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
+| Cataas | Cat as a service (cat pictures and GIFs) | No | Yes | Unknown
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |
 | [Dog Facts](https://kinduff.github.io/dog-api/) | Random facts of Dogs | No | Yes | Yes |


### PR DESCRIPTION
his PR corrects a minor grammatical issue in the description of the Cataas API under the "Animals" category in the README. It updates "cats pictures and gifs" to "cat pictures and GIFs" for better clarity and proper English usage