### PR TITLE
Add GG.deals API to Games & Comics sectionUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ API | Description | Auth | HTTPS | CORS |
 | [GDBrowser](https://gdbrowser.com/api) | Easy way to use the Geometry Dash Servers | No | Yes | Unknown |    
 | [Geek-Jokes](https://github.com/sameerkumar18/geek-joke-api) | Fetch a random geeky/programming related joke for use in all sorts of applications | No | Yes | Yes |
 | [Genshin Impact](https://genshin.dev) | Genshin Impact game data | No | Yes | Yes |
+| [GG.deals](https://gg.deals/api/) - Video game deals and historical pricing info | No | Yes | Unknown |
 | [Giant Bomb](https://www.giantbomb.com/api/documentation) | Video Games | `apiKey` | Yes | Unknown |
 | [GraphQL Pokemon](https://github.com/favware/graphql-pokemon) | GraphQL powered Pokemon API. Supports generations 1 through 8 | No | Yes | Yes |
 | [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | Guild Wars 2 Game Information | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- Added [GG.deals](https://gg.deals/api/) to the Games & Comics category.
- No authentication required.
- Provides data on video game deals and price history.
