### PR TITLE
Add Bored API to Games & Comics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Barter.VG](https://github.com/bartervg/barter.vg/wiki) | Provides information about Game, DLC, Bundles, Giveaways, Trading | No | Yes | Yes |
 | [Battle.net](https://develop.battle.net/documentation/guides/getting-started) | Diablo III, Hearthstone, StarCraft II and World of Warcraft game data APIs | `OAuth` | Yes | Yes |
 | [Board Game Geek](https://boardgamegeek.com/wiki/page/BGG_XML_API2) | Board games, RPG and videogames | No | Yes | No |
+| [Bored API](https://www.boredapi.com/)  | Find random activities when you're bored | No | Yes | Yes |
 | [Brawl Stars](https://developer.brawlstars.com) | Brawl Stars Game Information | `apiKey` | Yes | Unknown |
 | [Bugsnax](https://www.bugsnaxapi.com/) | Get information about Bugsnax | No | Yes | Yes |
 | [CheapShark](https://www.cheapshark.com/api) | Steam/PC Game Prices and Deals | No | Yes | Yes |


### PR DESCRIPTION
Added Bored API which returns fun activity suggestions to beat boredom. No Auth required, supports HTTPS and CORS.

