### PR TITLE
fix: update IP2Country API link to aether.epias.ltd

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,7 +921,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Actinia Grass GIS](https://actinia.mundialis.de/api_docs/) | Actinia is an open source REST API for geographical data that uses GRASS GIS | `apiKey` | Yes | Unknown |
 | [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db) | Get all administrative divisions of a country | No | Yes | Yes |
 | [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | Address database of France, geocoding and reverse | No | Yes | Unknown |
-| [Airtel IP](https://sys.airtel.lv/ip2country/1.1.1.1/?full=true) | IP Geolocation API. Collecting data from multiple sources | No | Yes | Unknown |
+| - [IP2Country](https://sys.airtel.lv/ip2country/) - Get country by IP address.
++ [IP2Country](https://aether.epias.ltd/ip2country/{IP}) - Get country by IP address.
 | [Apiip](https://apiip.net/) | Get location information by IP address | `apiKey` | Yes | Yes |
 | [apilayer ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
 | [Battuta](http://battuta.medunes.net) | A (country/region/city) in-cascade location API | `apiKey` | No | Unknown |


### PR DESCRIPTION
The previous IP2Country API (sys.airtel.lv) is no longer functional and responds with an error.  
Updated the link to the correct working endpoint: https://aether.epias.ltd/ip2country/{IP}  
Tested with IP `1.1.1.1`, and it returns valid country codes.

Closes #4433