### PR TITLE
Add Moodedecode API to [Text Analysis]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,6 +1657,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Hirak Translation](https://translate.hirak.site/) | Translate between 21 of most used languages, accurate, unlimited requests | `apiKey` | Yes | Unknown |
 | [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/) | Translation API with free tier and reasonable prices | `apiKey` | Yes | Yes |
 | [LibreTranslate](https://libretranslate.com/docs) | Translation tool with 17 available languages | No | Yes | Unknown |
+| [Moodedecode] (https://github.com/neehubee/MOODCODE_API) | Detects user mood from text/audio | No | Yes | No | [Run in vercel ]https://moodcode-api.onrender.com/ |
+
 | [Semantria](https://semantria.readme.io/docs) | Text Analytics with sentiment analysis, categorization & named entity extraction | `OAuth` | Yes | Unknown |
 | [Sentiment Analysis](https://www.meaningcloud.com/developer/sentiment-analysis) | Multilingual sentiment analysis of texts from different sources | `apiKey` | Yes | Yes |
 | [Tisane](https://tisane.ai/) | Text Analytics with focus on detection of abusive content and law enforcement applications | `OAuth` | Yes | Yes |


### PR DESCRIPTION
This PR adds the Moodedecode API to the Text Analysis section of the API list.  
Moodedecode is a simple sentiment analysis API that detects mood from raw text input.  
The API does not require authentication, supports HTTPS, and does not support CORS.
