### PR TITLE
Add Built Simple AI to Development APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |
+| [Built Simple AI](https://built-simple.ai/) | Access Stack Overflow Q&A and Wikipedia content through simple REST APIs | No | Yes | Yes |
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |


### PR DESCRIPTION
## Summary
Add Built Simple AI to the Development section of public APIs.

Built Simple AI provides professional REST APIs for accessing Stack Overflow and Wikipedia data with lightning-fast response times.

## API Details
- **Name:** Built Simple AI
- **URL:** https://built-simple.ai/
- **Category:** Development
- **Authentication:** None (free tier), API Key (premium)
- **HTTPS:** Yes
- **CORS:** Yes

## Features
- **Stack Overflow API:** Access 54.2M questions and 86.4M answers
- **Wikipedia API:** Search 6.8M articles in 300+ languages
- **Performance:** Sub-200ms response times with built-in caching
- **Free Tier:** 1000 requests/hour with no authentication required
- **Documentation:** Comprehensive guides with interactive examples
- **SDKs:** Production-ready Python and JavaScript libraries

## Links
- **Homepage:** https://built-simple.ai/
- **Documentation:** https://built-simple.ai/docs/getting-started/
- **Interactive Examples:** https://built-simple.ai/examples/
- **OpenAPI Spec:** https://built-simple.ai/.well-known/openapi.yaml
- **Support:** https://built-simple.ai/support/

## Use Cases
Perfect for AI coding assistants, educational platforms, developer documentation sites, and research applications requiring Stack Overflow or Wikipedia data.

## Verification
- [x] API is publicly accessible
- [x] HTTPS enabled
- [x] CORS enabled for web applications
- [x] Comprehensive documentation available
- [x] Free tier available without authentication
- [x] Active support and maintenance

Thank you for considering this addition to the public APIs directory\!