### PR TITLE
Add DummyJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1616,6 +1616,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
+| [DummyJSON](https://dummyjson.com/docs) | Fake data for testing and prototyping apps | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |


### PR DESCRIPTION
This PR adds DummyJSON API to the Test Data category. It’s a free and open-source fake data API useful for prototyping apps. No auth required, supports HTTPS and CORS.
