### PR TITLE
Add Warsaw (PL) City Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, New York Open Data](https://opendata.cityofnewyork.us/) | New York (US) City Open Data | No | Yes | Unknown |
 | [City, Prague Open Data](http://opendata.praha.eu/en) | Prague(CZ) City Open Data | No | No | Unknown |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
+| [City, Warsaw Open Data](https://api.um.warszawa.pl) | Warsaw (PL) City Open Data | `apiKey` | Yes | Unknown |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |


### PR DESCRIPTION
This PR adds the official Warsaw (PL) City Open Data API to the Open Data section.

- API: https://api.um.warszawa.pl
- Auth: apiKey
- HTTPS: Yes
- CORS: Unknown