### PR TITLE
Add Krakow (PL) City Open Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, New York Open Data](https://opendata.cityofnewyork.us/) | New York (US) City Open Data | No | Yes | Unknown |
 | [City, Prague Open Data](http://opendata.praha.eu/en) | Prague(CZ) City Open Data | No | No | Unknown |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
+| [City, Warsaw Open Data](https://api.um.warszawa.pl) | Warsaw (PL) City Open Data | `apiKey` | Yes | Unknown |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, New York Open Data](https://opendata.cityofnewyork.us/) | New York (US) City Open Data | No | Yes | Unknown |
 | [City, Prague Open Data](http://opendata.praha.eu/en) | Prague(CZ) City Open Data | No | No | Unknown |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
+| [City, Krakow Open Data](https://otwartedane.um.krakow.pl) | Krakow (PL) City Open Data | No | Yes | Unknown |
 | [City, Warsaw Open Data](https://api.um.warszawa.pl) | Warsaw (PL) City Open Data | `apiKey` | Yes | Unknown |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |

--- a/SIGNING_TEST.md
+++ b/SIGNING_TEST.md
@@ -1,0 +1,1 @@
+# test podpisu sob 16 sie 21:39:56 2025 CEST

--- a/SIGNING_TEST.md
+++ b/SIGNING_TEST.md
@@ -1,1 +1,0 @@
-# test podpisu sob 16 sie 21:39:56 2025 CEST


### PR DESCRIPTION
This pull request adds the Krakow (Poland) Open Data API to the list of public APIs.
	•	API URL: https://api.dane.gov.pl/
	•	City portal: https://otwartedane.krakow.pl/
	•	Category: Government

The API provides access to various public datasets published by the City of Krakow, including:
	•	Transport and infrastructure
	•	Demographics and administration
	•	Culture and tourism
	•	Education and environment

This addition follows the same format as the recently added Warsaw entry and helps broaden the availability of Polish municipal open data sources in the repository.
