### PR TITLE
Add Books Data API to Books section

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Books
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Books Data API](https://booksapi.datsx.com) | Structured book metadata, user demographics, and ratings for analytics and recommender systems | `apiKey` | Yes | Unknown |
 | [A Bíblia Digital](https://www.abibliadigital.com.br/en) | Do not worry about managing the multiple versions of the Bible | `apiKey` | Yes | No |
 | [Bhagavad Gita](https://docs.bhagavadgitaapi.in) | Open Source Shrimad Bhagavad Gita API including 21+ authors translation in Sanskrit/English/Hindi | `apiKey` | Yes | Yes |
 | [Bhagavad Gita](https://bhagavadgita.io/api) | Bhagavad Gita text | `OAuth` | Yes | Yes |


### PR DESCRIPTION
**Add Books Data API to Books**

- **Site**: https://booksapi.datsx.com  
- **Docs**: https://booksapi.datsx.com/docs  
- **Auth**: `apiKey` via `X-RapidAPI-Key` (and `X-RapidAPI-Host`)  
- **HTTPS**: Yes  
- **CORS**: Unknown  
- **Description**: Structured book metadata, user demographics, and ratings for analytics, research, and recommendation engines.

