### PR TITLE
Add Lexicala API to Dictionaries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Free Dictionary](https://dictionaryapi.dev/) | Definitions, phonetics, pronounciations, parts of speech, examples, synonyms | No | Yes | Unknown |
 | [Indonesia Dictionary](https://new-kbbi-api.herokuapp.com/) | Indonesia dictionary many words | No | Yes | Unknown |
 | [Lingua Robot](https://www.linguarobot.io) | Word definitions, pronunciations, synonyms, antonyms and others | `apiKey` | Yes | Yes |
+| [Lexicala](https://api.lexicala.com/) | Multilingual dictionary data for 50 languages with semantic, syntactic, and phonetic details |`apiKey` | Yes | Unknown |
 | [Merriam-Webster](https://dictionaryapi.com/) | Dictionary and Thesaurus Data | `apiKey` | Yes | Unknown |
 | [OwlBot](https://owlbot.info/) | Definitions with example sentence and photo if available | `apiKey` | Yes | Yes |
 | [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data | `apiKey` | Yes | No |


### PR DESCRIPTION
Added [Lexicala](https://api.lexicala.com/) under Dictionaries section
Provides multilingual dictionary data for 50 languages with semantic, syntactic, and phonetic details
Requires API key via RapidAPI. HTTPS supported. CORS: Unknown

