### PR TITLE
Add Open-Meteo API under Weather section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,6 +1880,7 @@ API | Description | Auth | HTTPS | CORS |
 | [WeatherAPI](https://www.weatherapi.com/) | Weather API with other stuff like Astronomy and Geolocation API | `apiKey` | Yes | Yes |
 | [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
 | [Yandex.Weather](https://yandex.com/dev/weather/) | Assesses weather condition in specific locations | `apiKey` | Yes | No |
+| [Open-Meteo](https://open-meteo.com/) | Free weather forecast API for open-source developers | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
This PR adds [Open-Meteo](https://open-meteo.com/) to the Weather section.  
Open-Meteo provides a free weather forecast API for open-source developers.  

- No authentication required  
- Supports HTTPS  
- CORS enabled  

This improves the Weather category by giving developers another reliable free API option.
