### PR TITLE
feat(machine-learning): Add Mistral AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
+| [Mistral AI](https://docs.mistral.ai/api/) | Open-source large language models API. | `apiKey` | Yes | Unknown |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Mistral AI API (https://docs.mistral.ai/api/) to the 'Machine Learning' category in README.md.

Mistral AI provides powerful open-source large language models, representing a significant and growing European alternative in the AI space. This API is a valuable resource for developers working with cutting-edge AI technologies.

Details:
- API Name: Mistral AI
- Description: Open-source large language models API.
- Auth: `apiKey`
- HTTPS: Yes
- CORS: Unknown (based on current documentation check)
- Link: https://docs.mistral.ai/api/

Submitted for Hacktoberfest 2025!