### PR TITLE
Added GeoDescription API entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Geokeo](https://geokeo.com) | Geokeo geocoding service- with 2500 free api requests daily | No | Yes | Yes |
 | [GeoNames](http://www.geonames.org/export/web-services.html) | Place names and other geographical data | No | No | Unknown |
 | [geoPlugin](https://www.geoplugin.com) | IP geolocation and currency conversion | No | Yes | Yes |
+| GeoDescription | Reverse geocoding service that converts latitude and longitude into human-readable location descriptions | apiKey | Yes | No |
 | [Google Earth Engine](https://developers.google.com/earth-engine/) | A cloud-based platform for planetary-scale environmental data analysis | `apiKey` | Yes | Unknown |
 | [Google Maps](https://developers.google.com/maps/) | Create/customize digital maps based on Google Maps data | `apiKey` | Yes | Unknown |
 | [Graph Countries](https://github.com/lennertVanSever/graphcountries) | Country-related data like currencies, languages, flags, regions+subregions and bordering countries | No | Yes | Unknown |


### PR DESCRIPTION
This pull request adds the GeoDescription API under the Geocoding category.
The GeoDescription API provides a reverse geocoding service that converts latitude and longitude coordinates into human-readable location descriptions such as street names, regions, and countries.

Key Features:

Converts geographic coordinates to descriptive addresses

Useful for mapping, logistics, and data labeling applications

Provides structured JSON responses with high accuracy

Supports HTTPS and requires an API key for access
