### PR TITLE
Add Metorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
+| [Metorial](https://github.com/metorial/metorial) | Connect AI agents to 600+ integrations with a single interface - OAuth, scaling, and monitoring included | `apiKey` | Yes | No |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |


### PR DESCRIPTION
Added Metorial to readme. Metorial makes it super easy to connect AI agents to 600+ integrations with a single interface - OAuth, scaling, and monitoring included.