### PR TITLE
docs: add Art Institute of Chicago API to Art & Design category

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Améthyste](https://api.amethyste.moe/) | Generate images for Discord users | `apiKey` | Yes | Unknown |
-| [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
+| [Art Institute of Chicago](https://api.artic.edu/docs/) | Access artworks and museum data | No | Yes | Unknown |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added the Art Institute of Chicago API to the Art & Design category.  
Provides access to artworks and museum data through a free REST API.  
This is a docs-only change.

Checklist:
- [x] My submission follows the formatting guidelines in CONTRIBUTING.md  
- [x] Entry is in alphabetical order  
- [x] Description under 100 characters and doesn’t end with punctuation  
- [x] Each column has one space padding on either side  
- [x] All changes squashed into a single commit