### PR TITLE
Add Wolfram Alpha API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TLE](https://tle.ivanstanojevic.me/#/docs) | Satellite information | No | Yes | No |
 | [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | No |
 | [USGS Water Services](https://waterservices.usgs.gov/) | Water quality and level info for rivers and lakes | No | Yes | No |
+| [Wolfram Alpha](https://products.wolframalpha.com/api) | Computational knowledge engine | `apiKey` | Yes | Unknown |
 | [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | World Data | No | Yes | No |
 | [xMath](https://x-math.herokuapp.com/) | Random mathematical expressions | No | Yes | Yes |
 


### PR DESCRIPTION
Added Wolfram Alpha API to the Science & Math section.

Wolfram Alpha is a computational knowledge engine that can answer factual queries by computing answers from curated data. The API provides access to its vast knowledge base for mathematical computations, scientific data, and general knowledge queries.

- **API**: Wolfram Alpha
- **Category**: Science & Math
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Unknown
- **Documentation**: https://products.wolframalpha.com/api

This API is widely used and provides free tier access for developers.