### PR TITLE
fix: correct typo and description for Hong Kong Observatory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1860,7 +1860,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
 | [Foreca](https://developer.foreca.com) | Weather | `OAuth` | Yes | Unknown |
 | [HG Weather](https://hgbrasil.com/status/weather) | Provides weather forecast data for cities in Brazil | `apiKey` | Yes | Yes |
-| [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data | No | Yes | Unknown |
+| [Hong Kong Observatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provides weather and forecast data | No | Yes | Unknown |
 | [MetaWeather](https://www.metaweather.com/api/) | Weather | No | Yes | No |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
### What this PR does
Fixed a typo and improved the description for the Hong Kong Observatory API in the Weather section.

### Why this change is needed
The old entry had a small typo and unclear description, which could confuse users searching for the API.

### Additional context
Hi  I’m participating in Hacktoberfest 2025.  
Could you please add the `hacktoberfest-accepted` label to this PR so it counts toward my participation?  
Thank you! 
