### PR TITLE
fix: Remove dead PokéAPI (GraphQL) endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Path of Exile](https://www.pathofexile.com/developer/docs) | Path of Exile Game Information | `OAuth` | Yes | Unknown |
 | [PlayerDB](https://playerdb.co/) | Query Minecraft, Steam and XBox Accounts | No | Yes | Unknown |
 | [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
-| [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi) | The Unofficial GraphQL for PokeAPI | No | Yes | Yes |
 | [Pokémon TCG](https://pokemontcg.io) | Pokémon TCG Information | No | Yes | Unknown |
 | [Psychonauts](https://psychonauts-api.netlify.app/) | Psychonauts World Characters Information and PSI Powers | No | Yes | Yes |
 | [PUBG](https://developer.pubg.com/) | Access in-game PUBG data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description
This Pull Request resolves a bug by removing an invalid entry from the public API list.

The **PokéAPI (GraphQL)** link was found to be obsolete/dead (resulting in a 404 error). Removing it ensures the list maintains high quality and integrity for users.

## Changes Made
- Removed the entire table entry for PokéAPI (GraphQL) from the documentation file.

## Type of Change
- [x] Bug fix (Removed broken link/dead endpoint)
- [x] Documentation update

Ready for quick merge!