### PR TITLE
Add MarketsHost Currency Converter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangeratesapi.io](https://exchangeratesapi.io) | Exchange rates with currency conversion | `apiKey` | Yes | Yes |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
+| [MarketsHost Currency Converter API](https://www.marketshost.com/api/docs.php) | Convert 174 currencies with live
+  rates | No | Yes | Yes |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
 


### PR DESCRIPTION
Adding MarketsHost Currency Converter API to Currency Exchange category.

  - **API**: MarketsHost Currency Converter API
  - **Description**: Convert 174 currencies with live rates
  - **Category**: Currency Exchange
  - **Auth**: No
  - **HTTPS**: Yes
  - **CORS**: Yes
  - **Documentation**: https://www.marketshost.com/api/docs.php

  Features:
  - 174 world currencies supported
  - Real-time exchange rates (updated hourly)
  - JSON and XML formats
  - Free tier: 10,000 requests/day

  I have verified the API is working and publicly accessible.