### PR TITLE
Replace broken Random Words API link with alternate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1616,7 +1616,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
-| [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
+| [English Random Words](https://random-word-api.herokuapp.com/word?number=1) | Generate English random words — original endpoint returned error JSON on 2025-11-04; replaced with alternate endpoint. | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
 | [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |


### PR DESCRIPTION
Fixes #4912

The Random Words API endpoint listed in the Test Data section is currently broken and not functioning as expected.

Problem:
When I visited the listed endpoint https://random-words-api.vercel.app/word, instead of returning random words, it returns an error message:
{"error": "Something Went Wrong - Enter the Correct API URL"}

This means users trying to use this API from the public-apis list will encounter errors and won't be able to generate random words.

Solution:
I replaced the broken endpoint with a working alternative that provides the same functionality - generating random English words. The new endpoint is:
https://random-word-api.herokuapp.com/word?number=1

The replacement API is actually more flexible - you can control how many random words you want:
- number=1 returns 1 word: ["antiliterate"]
- number=2 returns 2 words: ["word1", "word2"]
- number=5 returns 5 words: ["word1", "word2", "word3", "word4", "word5"]

Simply change the number parameter to get the desired count of random words.

Testing:
I thoroughly tested the replacement endpoint and verified it works correctly. It returns random words in a clean JSON array format.

Changes Made:
1. Updated the API URL from the broken endpoint to the working alternative
2. Modified the description field to indicate that the original endpoint was broken (as of November 4, 2025) and has been replaced
3. The new API maintains the same functionality (No Auth, HTTPS: Yes, CORS: No)

This fix ensures that developers using the public-apis repository have access to a working Random Words API for their projects, with added flexibility to generate multiple words at once.