### PR TITLE
Add Website Launches Domain Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
+| [Website Launches](https://websitelaunches.com/api/) | Domain intelligence: authority scores, age, launch detection, industry classification | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Added Website Launches Domain Intelligence API to the Business category.

**API Details:**
- Domain authority scores (0-100) based on Common Crawl data
- Domain age and registration dates
- Launch detection
- Industry classification
- Free tier: 3,000 requests/month (no signup required)

**Links:**
- API Documentation: https://websitelaunches.com/docs
- CLI Tool: https://github.com/WebsiteLaunches/webl-cli
- Website: https://websitelaunches.com