### PR TITLE
Add Platzi Fake Store API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mailsac](https://mailsac.com/docs/api) | Disposable Email | `apiKey` | Yes | Unknown |
 | [Metaphorsum](http://metaphorpsum.com/) | Generate demo paragraphs giving number of words and sentences | No | No | Unknown |
 | [Mockaroo](https://www.mockaroo.com/docs) | Generate fake data to JSON, CSV, TXT, SQL and XML | `apiKey` | Yes | Unknown |
+| [Platzi Fake Store API](https://fakeapi.platzi.com/) | Fake e-commerce REST API with products, categories, users and optional JWT auth for prototyping | No | Yes | Yes |
 | [QuickMocker](https://quickmocker.com) | API mocking tool to generate contextual, fake or random data | No | Yes | Yes |
 | [Random Data](https://random-data-api.com) | Random data generator | No | Yes | Unknown |
 | [Randommer](https://randommer.io/randommer-api) | Random data generator | `apiKey` | Yes | Yes |


### PR DESCRIPTION
This PR adds the Platzi Fake Store API to the Test Data category.
The API provides a free and realistic e-commerce backend including: Products, Categories, Users, Optional JWT authentication. It is useful for prototyping, frontend development, training exercises and demo projects.

- Auth: No
- HTTPS: Yes
- CORS: Yes
- Source: https://github.com/PlatziLabs/fake-api-docs
---
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
