### PR TITLE
docs: fix broken Gitter API link and update auth info

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ghost](https://ghost.org/) | Get Published content into your Website, App or other embedded media | `apiKey` | Yes | Yes |
 | [GitHub](https://docs.github.com/en/free-pro-team@latest/rest) | Make use of GitHub repositories, code and user info programmatically | `OAuth` | Yes | Yes |
 | [Gitlab](https://docs.gitlab.com/ee/api/) | Automate GitLab interaction programmatically | `OAuth` | Yes | Unknown |
-| [Gitter](https://developer.gitter.im/docs/welcome) | Chat for Developers | `OAuth` | Yes | Unknown |
+| [Gitter](https://gitter.im/docs/api/) | Chat for Developers | `OAuth` | Yes | Unknown |
 | [Glitterly](https://developers.glitterly.app) | Image generation API | `apiKey` | Yes | Yes |
 | [Google Docs](https://developers.google.com/docs/api/reference/rest) | API to read, write, and format Google Docs documents | `OAuth` | Yes | Unknown |
 | [Google Firebase](https://firebase.google.com/docs) | Google's mobile application development platform that helps build, improve, and grow app | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Fixed the broken Gitter API link in README.md.
Updated from https://developer.gitter.im/docs/welcome → https://gitter.im/docs/api/.
Also corrected the authentication type to OAuth for accuracy.