### PR TITLE
Fix broken Cat Facts API link in Animals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ API | Description | Auth | HTTPS | CORS
 |:---|:---|:---|:---|:---|
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
-| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
+| [Cat Facts](https://catfact.ninja) | Daily cat facts | No | Yes | No | |
 | [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |


### PR DESCRIPTION
## Description
This PR fixes the broken Cat Facts API link reported in issue #4948.

## Problem
The current Cat Facts API entry in the Animals section links to  which references a broken Heroku app () that returns 404/503 errors and is no longer active.

## Solution
- **Replaced broken URL** with the working API: 
- **Verified functionality**: The new API is active, supports HTTPS, and provides cat facts via JSON API
- **Maintained compatibility**: Same features (No auth required, HTTPS supported, No CORS restrictions)

## Testing
- ✅ Confirmed old URL is broken (503 Service Unavailable)
- ✅ Verified new URL works correctly
- ✅ Tested API endpoint returns valid JSON cat facts: `https://catfact.ninja/fact`
- ✅ Confirmed HTTPS support and CORS compatibility

## Changes Made
- Line 104: Updated Cat Facts URL from `https://alexwohlbruck.github.io/cat-facts/` to `https://catfact.ninja`

**Fixes #4948**