### PR TITLE
Fix broken Cat Facts API link in Animals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ API | Description | Auth | HTTPS | CORS
 |:---|:---|:---|:---|:---|
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
-| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
-| [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
+| [Cat Facts](https://catfact.ninja/) | Daily cat facts | No | Yes | No || [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |
 | [Dog Facts](https://kinduff.github.io/dog-api/) | Random facts of Dogs | No | Yes | Yes |


### PR DESCRIPTION
## Description
This PR fixes the broken Cat Facts API link in the Animals section of the README.md file.

## Problem
The current Cat Facts API entry links to `https://alexwohlbruck.github.io/cat-facts/` which returns 404/503 errors and is no longer active.

## Solution
Replaced the broken URL with `https://catfact.ninja/` which:
- ✅ Is an active, reliable API endpoint
- ✅ Supports HTTPS
- ✅ Provides cat facts via a JSON API
- ✅ Has no authentication required

## Changes
- Modified line 104 in README.md
- Replaced broken URL with working alternative