### PR TITLE
fix: update Cat Facts API URL to working endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ API | Description | Auth | HTTPS | CORS
 |:---|:---|:---|:---|:---|
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
-| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
+| [Cat Facts](https://catfact.ninja) | Daily cat facts | No | Yes | No | |
 | [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |


### PR DESCRIPTION
## Overview
This PR fixes issue #4948 by updating the Cat Facts API URL in README.md from the old, non-working endpoint to a working one at `https://catfact.ninja`.

## Checklist
- [x] Code changes have been made to README.md
- [x] No tests are needed for this documentation change
- [x] Documentation is updated to reflect the new API endpoint

## Proof
The change is a simple URL update in the API list table. The new endpoint `https://catfact.ninja` is functional and provides cat facts as described in the table entry. The old endpoint `https://alexwohlbruck.github.io/cat-facts/` was returning a 404 error.

## Closes
Closes #4948