### PR TITLE
Add BBC News API (fixes #3778)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [apilayer mediastack](https://mediastack.com/) | Free, Simple REST API for Live News & Blog Articles | `apiKey` | Yes | Unknown |
 | [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
+| [BBC News](https://www.bbc.co.uk/news) | News, articles, and headlines from BBC News. | No | Yes | Unknown |
 | [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
 | [Currents](https://currentsapi.services/) | Latest news published in various news sources, blogs and forums | `apiKey` | Yes | Yes |
 | [Feedbin](https://github.com/feedbin/feedbin-api) | RSS reader | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
### Added BBC News API

This PR adds the **BBC News** API entry under the “News” category in the public APIs list.  
The entry includes the following fields:
- API: BBC News  
- Description: News, articles, and headlines from BBC News.  
- Auth: No  
- HTTPS: Yes  
- CORS: Unknown  
- Link: https://www.bbc.co.uk/news  

This resolves issue #3778.  
Thanks to the maintainers for reviewing and merging!

