### PR TITLE
Add Shotstack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Movie Database](http://www.omdbapi.com/) | Movie information | `apiKey` | Yes | Unknown |
 | [Owen Wilson Wow](https://owen-wilson-wow-api.herokuapp.com) | API for actor Owen Wilson's "wow" exclamations in movies | No | Yes | Yes |
 | [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
+| [Shotstack](https://shotstack.io) | Cloud-based video editing and rendering API | API Key | Yes | Unknown |
 | [Simkl](https://simkl.docs.apiary.io) | Movie, TV and Anime data | `apiKey` | Yes | Unknown |
 | [STAPI](http://stapi.co) | Information on all things Star Trek | No | No | No |
 | [Stranger Things Quotes](https://github.com/shadowoff09/strangerthings-quotes) | Returns Stranger Things quotes | No | Yes | Unknown |


### PR DESCRIPTION
Added the Shotstack API to the Video category.

Shotstack is a cloud-based video editing and rendering API that allows developers to create videos programmatically using JSON-based templates. The API supports features such as video composition, transitions, audio tracks, animations, and export rendering.

Requires API Key and supports HTTPS.
