### PR TITLE
Add CountryLayer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cep.la](http://cep.la/) | Brazil RESTful API to find information about streets, zip codes, neighborhoods, cities and states | No | No | Unknown |
 | [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | Open APIs for select European cities | No | Yes | Unknown |
 | [Country](http://country.is/) | Get your visitor's country from their IP | No | Yes | Yes |
+| [CountryLayer](https://countrylayer.com) | Detailed country data including population, borders, languages, currencies, and geography | API Key | Yes | Unknown |
 | [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
 | [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
 | [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |


### PR DESCRIPTION
Added the CountryLayer API under the Geocoding category.

CountryLayer provides detailed country information such as population, borders, capital city, languages, currencies, geographic coordinates, regions, and ISO codes. The API requires an API key and supports HTTPS.
