### PR TITLE
Add OilPriceAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
+| [OilPriceAPI](https://www.oilpriceapi.com) | Real-time and historical oil, gas, and commodity prices | `apiKey` | Yes | Yes |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |


### PR DESCRIPTION
## API Details

**Name:** OilPriceAPI  
**URL:** https://www.oilpriceapi.com  
**Category:** Finance  
**Auth:** apiKey  
**HTTPS:** Yes  
**CORS:** Yes

## Description

Real-time and historical oil, gas, and commodity prices including WTI, Brent, natural gas, marine fuels, and more. Used by 1000+ developers for energy market data.

## Documentation

- API Docs: https://docs.oilpriceapi.com
- Quick Start: https://www.oilpriceapi.com/quick-start

## Checklist

- [x] API has proper documentation
- [x] Follows alphabetical ordering in Finance section
- [x] Description under 100 characters
- [x] One API per PR