### PR TITLE
docs: remove dead 'Quotes on Design' API from Personality category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1346,7 +1346,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Quotable Quotes](https://github.com/lukePeavey/quotable) | Quotable is a free, open source quotations API | No | Yes | Unknown |
 | [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | REST API for more than 5000 famous quotes | No | Yes | Unknown |
 | [quoteclear](https://quoteclear.web.app/) | Ever-growing list of James Clear quotes from the 3-2-1 Newsletter | No | Yes | Yes |
-| [Quotes on Design](https://quotesondesign.com/api/) | Inspirational Quotes | No | Yes | Unknown |
 | [Stoicism Quote](https://github.com/tlcheah2/stoic-quote-lambda-public-api) | Quotes about Stoicism | No | Yes | Unknown |
 | [They Said So Quotes](https://theysaidso.com/api/) | Quotes Trusted by many fortune brands around the world | No | Yes | Unknown |
 | [Traitify](https://app.traitify.com/developer) | Assess, collect and analyze Personality | No | Yes | Unknown |


### PR DESCRIPTION
### Summary
Removed the entry for **Quotes on Design API** under the Personality category.

### Reason
The URL `https://quotesondesign.com/api/` is no longer available and returns an error. 
Dead or inactive APIs should be removed to keep the Public APIs list accurate and useful.

### Checks
- [x] Verified the API is no longer working
- [x] Updated README only
- [x] Followed alphabetical table format and contribution guidelines
