### PR TITLE
Add FunJokeAPI to Entertainment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
+| [FunJokeAPI](https://funjokeapi.com) | Free API to get random jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |


### PR DESCRIPTION
This PR adds FunJokeAPI to the Entertainment category in the public-apis list.

FunJokeAPI is a free public API that provides random jokes. It supports HTTPS and does not require authentication.

Changes included:
- Added a new row in the Entertainment table:
  | [FunJokeAPI](https://funjokeapi.com) | Free API to get random jokes | No | Yes | Unknown |
