### PR TITLE
Add LanguageTool API to Text Analysis section - Grammar checking service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1655,6 +1655,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
 | [Hirak OCR](https://ocr.hirak.site/) | Image to text -text recognition- from image more than 100 language, accurate, unlimited requests | `apiKey` | Yes | Unknown |
 | [Hirak Translation](https://translate.hirak.site/) | Translate between 21 of most used languages, accurate, unlimited requests | `apiKey` | Yes | Unknown |
+| [LanguageTool](https://languagetool.org/) | Grammar and spell checking API supporting multiple languages | No | Yes | Yes |
 | [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/) | Translation API with free tier and reasonable prices | `apiKey` | Yes | Yes |
 | [LibreTranslate](https://libretranslate.com/docs) | Translation tool with 17 available languages | No | Yes | Unknown |
 | [Semantria](https://semantria.readme.io/docs) | Text Analytics with sentiment analysis, categorization & named entity extraction | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Summary
This pull request adds LanguageTool API to the Text Analysis section of the README, addressing issue #5001.

## What was changed
- Added LanguageTool entry to the Text Analysis table in README.md
- Positioned alphabetically between "Hirak Translation" and "Lecto Translation"
- Entry includes: API name with link to https://languagetool.org/, description, authentication requirements, HTTPS support, and CORS information

## Details about LanguageTool API
**Description:** Grammar and spell checking API supporting multiple languages
**Website:** https://languagetool.org/
**Authentication:** No authentication required
**HTTPS:** Yes - Fully supported
**CORS:** Yes - CORS enabled

## Why this addition is valuable
- LanguageTool is a free, open-source grammar and spell checking service
- Supports 20+ languages including English, Spanish, French, German, and more
- Provides comprehensive grammar, style, and spell checking capabilities
- No API key required for basic usage, making it accessible for developers
- Actively maintained project with regular updates

## Checklist
- [x] Entry is formatted according to contributing guidelines in CONTRIBUTING.md
- [x] API is added in alphabetical order within the Text Analysis category
- [x] Entry includes all required fields: API name, description, Auth, HTTPS, CORS
- [x] Links are functional and point to the correct resources
- [x] Description is clear and under 100 characters

Fixes #5001