### PR TITLE
trae01-v1

### DIFF
--- a/contrib/api_browser/README.md
+++ b/contrib/api_browser/README.md
@@ -1,0 +1,99 @@
+# API Browser
+
+A small Python CLI tool for browsing and filtering the public APIs list from the repository.
+
+## Features
+
+- **Parse APIs**: Read and parse APIs from the repository's README.md file
+- **Filter APIs**: Filter APIs by keyword in name or description
+- **Category Filter**: Filter APIs by category
+- **Output Formats**: Support JSON and table output formats
+- **Local Cache**: Cache parsed APIs locally for faster access (default 24 hours)
+- **Cache Refresh**: Force refresh the local cache
+
+## Installation
+
+1. Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Make the CLI script executable (optional):
+```bash
+chmod +x cli.py
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+python cli.py
+```
+
+This will display all APIs in a table format.
+
+### Filter by Keyword
+
+```bash
+python cli.py -q "weather"
+```
+
+This will display all APIs related to weather.
+
+### Filter by Category
+
+```bash
+python cli.py -c "development"
+```
+
+This will display all APIs in the Development category.
+
+### Combine Filters
+
+```bash
+python cli.py -q "oauth" -c "social"
+```
+
+This will display all APIs in the Social category that use OAuth authentication.
+
+### JSON Output
+
+```bash
+python cli.py -q "weather" -o json
+```
+
+This will display the filtered APIs in JSON format.
+
+### Force Cache Refresh
+
+```bash
+python cli.py --cache-refresh
+```
+
+This will force refresh the local cache by re-parsing the README.md file.
+
+## Testing
+
+Run the unit tests using pytest:
+
+```bash
+pytest test_api_browser.py
+```
+
+## Project Structure
+
+```
+api_browser/
+├── cli.py              # Main CLI entry point
+├── parser.py           # API parsing logic
+├── filter.py           # API filtering logic
+├── cache.py            # Cache management
+├── test_api_browser.py # Unit tests
+├── requirements.txt    # Dependencies
+└── README.md           # This file
+```
+
+## License
+
+MIT

--- a/contrib/api_browser/cache.py
+++ b/contrib/api_browser/cache.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+API Cache
+
+This module handles caching of the parsed APIs list to a local file.
+"""
+
+import json
+import os
+import time
+from typing import List, Dict
+
+CACHE_FILE = "apis_cache.json"
+CACHE_DURATION = 24 * 60 * 60  # 24 hours in seconds
+
+class CacheManager:
+    """Manages the local cache of APIs data."""
+    
+    def __init__(self, cache_file: str = CACHE_FILE, cache_duration: int = CACHE_DURATION):
+        """Initialize the CacheManager.
+        
+        Args:
+            cache_file: Path to the cache file
+            cache_duration: Cache duration in seconds
+        """
+        self.cache_file = cache_file
+        self.cache_duration = cache_duration
+    
+    def is_valid(self) -> bool:
+        """Check if the cache is valid (exists and not expired).
+        
+        Returns:
+            True if cache is valid, False otherwise
+        """
+        if not os.path.exists(self.cache_file):
+            return False
+        
+        # Check if cache is expired
+        file_mod_time = os.path.getmtime(self.cache_file)
+        current_time = time.time()
+        
+        return (current_time - file_mod_time) < self.cache_duration
+    
+    def load(self) -> List[Dict]:
+        """Load APIs from the cache file.
+        
+        Returns:
+            List of APIs loaded from cache
+        """
+        with open(self.cache_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        return data['apis']
+    
+    def save(self, apis: List[Dict]) -> None:
+        """Save APIs to the cache file.
+        
+        Args:
+            apis: List of APIs to save to cache
+        """
+        data = {
+            'timestamp': time.time(),
+            'apis': apis
+        }
+        
+        with open(self.cache_file, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+    
+    def clear(self) -> None:
+        """Clear the cache by deleting the cache file."""
+        if os.path.exists(self.cache_file):
+            os.remove(self.cache_file)
+
+if __name__ == "__main__":
+    # Test the CacheManager
+    cache_manager = CacheManager()
+    
+    # Test save and load
+    test_apis = [
+        {
+            'name': 'Test API',
+            'description': 'Test API description',
+            'auth': 'No',
+            'https': 'Yes',
+            'cors': 'Yes',
+            'link': 'https://example.com',
+            'category': 'Test'
+        }
+    ]
+    
+    print("Saving test APIs to cache...")
+    cache_manager.save(test_apis)
+    
+    print(f"Cache is valid: {cache_manager.is_valid()}")
+    
+    print("Loading APIs from cache...")
+    loaded_apis = cache_manager.load()
+    print(f"Loaded {len(loaded_apis)} APIs")
+    
+    # Test clear
+    print("Clearing cache...")
+    cache_manager.clear()
+    print(f"Cache is valid: {cache_manager.is_valid()}")

--- a/contrib/api_browser/cli.py
+++ b/contrib/api_browser/cli.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+API Browser CLI Tool
+
+This tool allows users to browse and filter the public APIs list from the repository.
+"""
+
+import argparse
+import json
+from typing import List, Dict
+
+import parser
+import filter
+import cache
+
+def main():
+    """Main entry point for the API Browser CLI tool."""
+    # Parse command line arguments
+    args = parse_args()
+    
+    # Initialize cache
+    cache_manager = cache.CacheManager()
+    
+    # Load APIs data
+    if args.cache_refresh or not cache_manager.is_valid():
+        # Parse from README.md if cache is invalid or refresh is requested
+        apis = parser.parse_apis_from_readme("../../README.md")
+        # Save to cache
+        cache_manager.save(apis)
+    else:
+        # Load from cache
+        apis = cache_manager.load()
+    
+    # Filter APIs
+    filtered_apis = filter.filter_apis(apis, args.query, args.category)
+    
+    # Output results
+    output_results(filtered_apis, args.output)
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Browse and filter public APIs")
+    
+    # Filter options
+    parser.add_argument(
+        "-q", "--query", 
+        type=str, 
+        help="Filter APIs by keyword in name or description"
+    )
+    parser.add_argument(
+        "-c", "--category", 
+        type=str, 
+        help="Filter APIs by category"
+    )
+    
+    # Output options
+    parser.add_argument(
+        "-o", "--output", 
+        type=str, 
+        choices=["json", "table"], 
+        default="table", 
+        help="Output format (default: table)"
+    )
+    
+    # Cache options
+    parser.add_argument(
+        "--cache-refresh", 
+        action="store_true", 
+        help="Force refresh the local cache"
+    )
+    
+    return parser.parse_args()
+
+def output_results(apis: List[Dict], format: str) -> None:
+    """Output the filtered APIs in the specified format."""
+    if format == "json":
+        print(json.dumps(apis, indent=2))
+    else:
+        # Output as table
+        print("{:<50} {:<100} {:<20} {:<10} {:<10}".format(
+            "Name", "Description", "Auth", "HTTPS", "CORS"
+        ))
+        print("=" * 200)
+        for api in apis:
+            print("{:<50} {:<100} {:<20} {:<10} {:<10}".format(
+                api["name"],
+                api["description"][:97] + "..." if len(api["description"]) > 100 else api["description"],
+                api["auth"],
+                api["https"],
+                api["cors"]
+            ))
+
+if __name__ == "__main__":
+    main()

--- a/contrib/api_browser/filter.py
+++ b/contrib/api_browser/filter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+API Filter
+
+This module filters the list of APIs based on keyword and category.
+"""
+
+from typing import List, Dict
+
+def filter_apis(apis: List[Dict], query: str = None, category: str = None) -> List[Dict]:
+    """Filter APIs based on keyword and category.
+    
+    Args:
+        apis: List of APIs to filter
+        query: Keyword to search in API name or description
+        category: Category to filter by
+        
+    Returns:
+        Filtered list of APIs
+    """
+    filtered = apis.copy()
+    
+    # Filter by category
+    if category:
+        filtered = [api for api in filtered if api['category'].lower() == category.lower()]
+    
+    # Filter by query
+    if query:
+        query_lower = query.lower()
+        filtered = [
+            api for api in filtered 
+            if query_lower in api['name'].lower() or query_lower in api['description'].lower()
+        ]
+    
+    return filtered
+
+if __name__ == "__main__":
+    # Test the filter
+    test_apis = [
+        {
+            'name': 'GitHub API',
+            'description': 'GitHub API for accessing repositories, users, etc.',
+            'auth': 'OAuth',
+            'https': 'Yes',
+            'cors': 'Yes',
+            'link': 'https://api.github.com',
+            'category': 'Development'
+        },
+        {
+            'name': 'OpenWeatherMap API',
+            'description': 'Weather data API',
+            'auth': 'apiKey',
+            'https': 'Yes',
+            'cors': 'Yes',
+            'link': 'https://api.openweathermap.org',
+            'category': 'Weather'
+        },
+        {
+            'name': 'Twitter API',
+            'description': 'Twitter API for accessing tweets and users',
+            'auth': 'OAuth',
+            'https': 'Yes',
+            'cors': 'No',
+            'link': 'https://api.twitter.com',
+            'category': 'Social'
+        }
+    ]
+    
+    # Test category filter
+    dev_apis = filter_apis(test_apis, category='Development')
+    print(f"Development APIs: {[api['name'] for api in dev_apis]}")
+    
+    # Test query filter
+    weather_apis = filter_apis(test_apis, query='weather')
+    print(f"Weather APIs: {[api['name'] for api in weather_apis]}")
+    
+    # Test combined filter
+    oauth_apis = filter_apis(test_apis, query='OAuth', category='Social')
+    print(f"Social OAuth APIs: {[api['name'] for api in oauth_apis]}")

--- a/contrib/api_browser/parser.py
+++ b/contrib/api_browser/parser.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+API Parser
+
+This module parses the public APIs list from the README.md file.
+"""
+
+import re
+from typing import List, Dict
+
+def parse_apis_from_readme(file_path: str) -> List[Dict]:
+    """Parse APIs from the README.md file and return a list of dictionaries.
+    
+    Args:
+        file_path: Path to the README.md file
+        
+    Returns:
+        List of APIs, each represented as a dictionary with keys: 
+        'name', 'description', 'auth', 'https', 'cors', 'link', 'category'
+    """
+    apis = []
+    current_category = None
+    
+    with open(file_path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    
+    # Regular expressions to match different parts of the README
+    category_re = re.compile(r'###\s+(.+)')
+    table_header_re = re.compile(r'\| API \| Description \| Auth \| HTTPS \| CORS \|')
+    table_row_re = re.compile(r'\|\s*\[(.+)\]\((https?://[^)]+)\)\s*\|\s*(.+)\s*\|\s*([^|]+)\s*\|\s*([^|]+)\s*\|\s*([^|]+)\s*\|')
+    
+    in_table = False
+    
+    for line in lines:
+        line = line.strip()
+        
+        # Check if this is a category header
+        category_match = category_re.match(line)
+        if category_match:
+            current_category = category_match.group(1)
+            in_table = False
+            continue
+        
+        # Check if this is the start of a table
+        if table_header_re.match(line):
+            in_table = True
+            continue
+        
+        # Check if this is a table row
+        if in_table and line.startswith('|'):
+            row_match = table_row_re.match(line)
+            if row_match:
+                name = row_match.group(1)
+                link = row_match.group(2)
+                description = row_match.group(3)
+                auth = row_match.group(4)
+                https = row_match.group(5)
+                cors = row_match.group(6)
+                
+                # Clean up the fields
+                auth = auth.strip() if auth.strip() != '' else 'No'
+                https = https.strip() if https.strip() != '' else 'No'
+                cors = cors.strip() if cors.strip() != '' else 'Unknown'
+                
+                api = {
+                    'name': name,
+                    'description': description,
+                    'auth': auth,
+                    'https': https,
+                    'cors': cors,
+                    'link': link,
+                    'category': current_category
+                }
+                
+                apis.append(api)
+    
+    return apis
+
+if __name__ == "__main__":
+    # Test the parser
+    apis = parse_apis_from_readme("../../README.md")
+    print(f"Parsed {len(apis)} APIs")
+    for api in apis[:5]:
+        print(f"- {api['name']} ({api['category']})")

--- a/contrib/api_browser/requirements.txt
+++ b/contrib/api_browser/requirements.txt
@@ -1,0 +1,6 @@
+argparse
+json
+os
+time
+re
+unittest

--- a/contrib/api_browser/test_api_browser.py
+++ b/contrib/api_browser/test_api_browser.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+API Browser Tests
+
+Unit tests for the API Browser tool.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open
+from typing import List, Dict
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+import parser
+import filter
+import cache
+import cli
+
+class TestParser(unittest.TestCase):
+    """Tests for the parser module."""
+    
+    def test_parse_apis_from_readme(self):
+        """Test parsing APIs from a sample README content."""
+        sample_readme = """### Development
+
+| API | Description | Auth | HTTPS | CORS |
+| --- | --- | --- | --- | --- |
+| [GitHub API](https://api.github.com) | GitHub API for accessing repositories, users, etc. | OAuth | Yes | Yes |
+| [OpenWeatherMap API](https://api.openweathermap.org) | Weather data API | apiKey | Yes | Yes |
+
+### Social
+
+| API | Description | Auth | HTTPS | CORS |
+| --- | --- | --- | --- | --- |
+| [Twitter API](https://api.twitter.com) | Twitter API for accessing tweets and users | OAuth | Yes | No |
+"""
+        
+        with patch("builtins.open", mock_open(read_data=sample_readme)):
+            apis = parser.parse_apis_from_readme("../../README.md")
+        
+        self.assertEqual(len(apis), 3)
+        
+        # Check first API
+        self.assertEqual(apis[0]['name'], 'GitHub API')
+        self.assertEqual(apis[0]['description'], 'GitHub API for accessing repositories, users, etc. ')
+        self.assertEqual(apis[0]['auth'], 'OAuth')
+        self.assertEqual(apis[0]['https'], 'Yes')
+        self.assertEqual(apis[0]['cors'], 'Yes')
+        self.assertEqual(apis[0]['link'], 'https://api.github.com')
+        self.assertEqual(apis[0]['category'], 'Development')
+        
+        # Check second API
+        self.assertEqual(apis[1]['name'], 'OpenWeatherMap API')
+        self.assertEqual(apis[1]['category'], 'Development')
+        
+        # Check third API
+        self.assertEqual(apis[2]['name'], 'Twitter API')
+        self.assertEqual(apis[2]['category'], 'Social')
+
+class TestFilter(unittest.TestCase):
+    """Tests for the filter module."""
+    
+    def setUp(self):
+        """Set up test data."""
+        self.test_apis = [
+            {
+                'name': 'GitHub API',
+                'description': 'GitHub API for accessing repositories, users, etc.',
+                'auth': 'OAuth',
+                'https': 'Yes',
+                'cors': 'Yes',
+                'link': 'https://api.github.com',
+                'category': 'Development'
+            },
+            {
+                'name': 'OpenWeatherMap API',
+                'description': 'Weather data API',
+                'auth': 'apiKey',
+                'https': 'Yes',
+                'cors': 'Yes',
+                'link': 'https://api.openweathermap.org',
+                'category': 'Weather'
+            },
+            {
+                'name': 'Twitter API',
+                'description': 'Twitter API for accessing tweets and users',
+                'auth': 'OAuth',
+                'https': 'Yes',
+                'cors': 'Yes',
+                'link': 'https://api.twitter.com',
+                'category': 'Social'
+            }
+        ]
+    
+    def test_filter_by_category(self):
+        """Test filtering APIs by category."""
+        filtered = filter.filter_apis(self.test_apis, category='Development')
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['name'], 'GitHub API')
+        
+        # Test case insensitivity
+        filtered = filter.filter_apis(self.test_apis, category='development')
+        self.assertEqual(len(filtered), 1)
+        
+        # Test non-existent category
+        filtered = filter.filter_apis(self.test_apis, category='NonExistent')
+        self.assertEqual(len(filtered), 0)
+    
+    def test_filter_by_query(self):
+        """Test filtering APIs by query."""
+        filtered = filter.filter_apis(self.test_apis, query='Weather')
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['name'], 'OpenWeatherMap API')
+        
+        # Test query in description
+        filtered = filter.filter_apis(self.test_apis, query='repositories')
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['name'], 'GitHub API')
+        
+        # Test case insensitivity
+        filtered = filter.filter_apis(self.test_apis, query='twitter')
+        self.assertEqual(len(filtered), 1)
+        
+        # Test non-existent query
+        filtered = filter.filter_apis(self.test_apis, query='NonExistent')
+        self.assertEqual(len(filtered), 0)
+    
+    def test_filter_by_category_and_query(self):
+        """Test filtering APIs by both category and query."""
+        filtered = filter.filter_apis(self.test_apis, query='OAuth', category='Social')
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['name'], 'Twitter API')
+        
+        # Test no matches
+        filtered = filter.filter_apis(self.test_apis, query='OAuth', category='Weather')
+        self.assertEqual(len(filtered), 0)
+
+class TestCache(unittest.TestCase):
+    """Tests for the cache module."""
+    
+    def setUp(self):
+        """Set up test data."""
+        self.test_apis = [
+            {
+                'name': 'Test API',
+                'description': 'Test API description',
+                'auth': 'No',
+                'https': 'Yes',
+                'cors': 'Yes',
+                'link': 'https://example.com',
+                'category': 'Test'
+            }
+        ]
+        
+        # Create a temporary directory for cache files
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_file = os.path.join(self.temp_dir.name, 'test_cache.json')
+    
+    def tearDown(self):
+        """Clean up test data."""
+        self.temp_dir.cleanup()
+    
+    def test_cache_save_load(self):
+        """Test saving and loading from cache."""
+        cache_manager = cache.CacheManager(self.cache_file, cache_duration=60)
+        
+        # Save to cache
+        cache_manager.save(self.test_apis)
+        
+        # Load from cache
+        loaded_apis = cache_manager.load()
+        
+        self.assertEqual(len(loaded_apis), 1)
+        self.assertEqual(loaded_apis[0]['name'], 'Test API')
+    
+    def test_cache_validity(self):
+        """Test cache validity check."""
+        cache_manager = cache.CacheManager(self.cache_file, cache_duration=1)  # 1 second
+        
+        # Cache is initially invalid
+        self.assertFalse(cache_manager.is_valid())
+        
+        # Save to cache
+        cache_manager.save(self.test_apis)
+        
+        # Cache is now valid
+        self.assertTrue(cache_manager.is_valid())
+        
+        # Wait for cache to expire
+        import time
+        time.sleep(2)
+        
+        # Cache is now invalid
+        self.assertFalse(cache_manager.is_valid())
+    
+    def test_cache_clear(self):
+        """Test clearing the cache."""
+        cache_manager = cache.CacheManager(self.cache_file)
+        
+        # Save to cache
+        cache_manager.save(self.test_apis)
+        self.assertTrue(os.path.exists(self.cache_file))
+        
+        # Clear cache
+        cache_manager.clear()
+        self.assertFalse(os.path.exists(self.cache_file))
+
+class TestCLI(unittest.TestCase):
+    """Tests for the CLI module."""
+    
+    @patch('sys.argv', ['cli.py', '-q', 'weather'])
+    def test_parse_args_query(self):
+        """Test parsing command line arguments with query."""
+        args = cli.parse_args()
+        self.assertEqual(args.query, 'weather')
+        self.assertIsNone(args.category)
+        self.assertEqual(args.output, 'table')
+        self.assertFalse(args.cache_refresh)
+    
+    @patch('sys.argv', ['cli.py', '-c', 'development'])
+    def test_parse_args_category(self):
+        """Test parsing command line arguments with category."""
+        args = cli.parse_args()
+        self.assertIsNone(args.query)
+        self.assertEqual(args.category, 'development')
+        self.assertEqual(args.output, 'table')
+        self.assertFalse(args.cache_refresh)
+    
+    @patch('sys.argv', ['cli.py', '-o', 'json'])
+    def test_parse_args_output_json(self):
+        """Test parsing command line arguments with JSON output."""
+        args = cli.parse_args()
+        self.assertEqual(args.output, 'json')
+    
+    @patch('sys.argv', ['cli.py', '--cache-refresh'])
+    def test_parse_args_cache_refresh(self):
+        """Test parsing command line arguments with cache refresh."""
+        args = cli.parse_args()
+        self.assertTrue(args.cache_refresh)
+    
+    @patch('sys.argv', ['cli.py', '-q', 'weather', '-c', 'development', '-o', 'json', '--cache-refresh'])
+    def test_parse_args_combined(self):
+        """Test parsing command line arguments with all options."""
+        args = cli.parse_args()
+        self.assertEqual(args.query, 'weather')
+        self.assertEqual(args.category, 'development')
+        self.assertEqual(args.output, 'json')
+        self.assertTrue(args.cache_refresh)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
请实现一个名为 api-browser 的小型 Python CLI 工具，放在仓库的 contrib/api_browser 目录下。工具应从仓库内的 API 列表（使用提供的 fixtures/sample README 或 JSON）读取并解析为结构化数据，支持按关键字（--query/-q）和按类别（--category/-c）过滤，支持 --output json 或 table 输出，支持本地文件缓存（默认 24小时）和 --cache-refresh 强制刷新。写单元测试覆盖解析、过滤、缓存和 CLI 参数。用 pytest 运行测试并在 README 或 docs 中给出两行使用示例。实现风格应尽量简单、易读并附带适当 docstring。