### PR TITLE
Remove deprecated Age of Empires II API (service no longer available)

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Games & Comics
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
-| [Age of Empires II](https://age-of-empires-2-api.herokuapp.com) | Get information about Age of Empires II resources | No | Yes | No |
+
 | [AmiiboAPI](https://amiiboapi.com/) | Nintendo Amiibo Information | No | Yes | Yes |
 | [Animal Crossing: New Horizons](http://acnhapi.com/) | API for critters, fossils, art, music, furniture and villagers | No | Yes | Unknown |
 | [Autochess VNG](https://github.com/didadadida93/autochess-vng-api) | Rest Api for Autochess VNG | No | Yes | Yes |


### PR DESCRIPTION
The Age of Empires II API is confirmed to be permanently shut down.

Evidence:
- The repository for the API states that it has been discontinued.
- The Public APIs issue tracker previously flagged this API as "permanently down".
- The API endpoints no longer return data.

This PR removes the entry from the Games & Comics section to ensure the list remains accurate and up to date.
