### PR TITLE
Add AstraScout Crypto APIs (Multi-Source Price API & Market Insights API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ API | Description | Auth | HTTPS | CORS |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
+| [AstraScout Crypto API](https://rapidapi.com/AstraScout/api/astrascout-crypto-api) | Multi-source crypto price API with fallback, caching, and stable USD pricing. Supports 26 tokens + price-all + utility scoring. | No | Yes | Unknown |
+| [AstraScout Market Insights API](https://rapidapi.com/AstraScout/api/astrascout-market-insights-api) | Real-time market sentiment: Fear & Greed, volatility, momentum, trending coins, and combined analytics. | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
This pull request adds two new crypto-related APIs to the Cryptocurrency section:

1. AstraScout Crypto API
A multi-source crypto price API with fallback, caching, and reliable USD price aggregation.
Supports 26 tokens, price-per-token, price-all, and utility scoring.


2. AstraScout Market Insights API
Real-time crypto market insights including Fear & Greed Index, volatility scores, momentum, trending coins, and combined sentiment analytics.



Both APIs are publicly accessible via RapidAPI and offer free tiers.

If you need adjustments, I’m happy to update them. Thank you!