### PR TITLE
Add DummyJSON to Test Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1616,6 +1616,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
+| [DummyJSON](https://dummyjson.com/) | Fake REST API with products, carts, users, posts, and more | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |


### PR DESCRIPTION
## Description
Adding DummyJSON to the Test Data section.

## API Details
- **Name:** DummyJSON
- **URL:** https://dummyjson.com/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

DummyJSON is a free fake REST API for testing and prototyping. It provides realistic placeholder data including products, carts, users, posts, comments, and more.

## Checklist
- [x] API is free to use
- [x] Entry is in alphabetical order
- [x] Description is under 100 characters
- [x] API has proper documentation