### PR TITLE
Add Pravatar to Photography

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pexels](https://www.pexels.com/api/) | Free Stock Photos and Videos | `apiKey` | Yes | Yes |
 | [PhotoRoom](https://www.photoroom.com/api/) | Remove background from images | `apiKey` | Yes | Unknown |
 | [Pixabay](https://pixabay.com/sk/service/about/api/) | Photography | `apiKey` | Yes | Unknown |
+| [Pravatar](https://pravatar.cc) | Random avatar placeholder images for developers | No | Yes | Unknown |
 | [PlaceKeanu](https://placekeanu.com/) | Resizable Keanu Reeves placeholder images with grayscale and young Keanu options | No | Yes | Unknown |
 | [Readme typing SVG](https://github.com/DenverCoder1/readme-typing-svg) | Customizable typing and deleting text SVG | No | Yes | Unknown |
 | [Remove.bg](https://www.remove.bg/api) | Image Background removal | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description
Adding Pravatar to the Photography section.

## API Details
- **Name:** Pravatar
- **URL:** https://pravatar.cc
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Unknown

Pravatar provides random avatar placeholder images for developers. Great for prototyping user interfaces that require profile photos.

## Checklist
- [x] API is free to use
- [x] Entry is in alphabetical order
- [x] Description is under 100 characters
- [x] API has proper documentation