### PR TITLE
Add Flagcdn to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | Open APIs for select European cities | No | Yes | Unknown |
 | [Country](http://country.is/) | Get your visitor's country from their IP | No | Yes | Yes |
 | [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
+| [Flagcdn](https://flagcdn.com) | Free country flags in SVG and PNG format | No | Yes | Yes |
 | [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
 | [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
 | [Geoapify](https://www.geoapify.com/api/geocoding-api/) | Forward and reverse geocoding, address autocomplete | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description
Adding Flagcdn to the Geocoding section.

## API Details
- **Name:** Flagcdn
- **URL:** https://flagcdn.com
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

Flagcdn provides free country flag images in SVG and PNG formats. Supports all countries with multiple size options.

## Checklist
- [x] API is free to use
- [x] Entry is in alphabetical order
- [x] Description is under 100 characters
- [x] API has proper documentation