### PR TITLE
Add Fantasy Premier League to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,6 +1582,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes | Yes |
 | [CollegeFootballData.com](https://collegefootballdata.com) | Unofficial detailed American college football statistics, records, and results API | `apiKey` | Yes | Unknown |
 | [Ergast F1](http://ergast.com/mrd/) | F1 data from the beginning of the world championships in 1950 | No | Yes | Unknown |
+| [Fantasy Premier League](https://fantasy.premierleague.com/api/bootstrap-static/) | Official FPL API with player stats, fixtures, teams and gameweek data | No | Yes | No |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |


### PR DESCRIPTION
## Description
Adding Fantasy Premier League to the Sports & Fitness section.

## API Details
- **Name:** Fantasy Premier League
- **URL:** https://fantasy.premierleague.com/api/bootstrap-static/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** No

The official Fantasy Premier League API provides comprehensive data including player statistics, fixtures, teams, gameweek data, and more. Widely used by the FPL community for building tools and analytics.

## Checklist
- [x] API is free to use
- [x] Entry is in alphabetical order
- [x] Description is under 100 characters
- [x] API has proper documentation