### PR TITLE
Add Vedika API to Science & Math section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TLE](https://tle.ivanstanojevic.me/#/docs) | Satellite information | No | Yes | No |
 | [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | No |
 | [USGS Water Services](https://waterservices.usgs.gov/) | Water quality and level info for rivers and lakes | No | Yes | No |
+| [Vedika](https://vedika.io/docs) | Vedic & Western astrology calculations with AI analysis | `apiKey` | Yes | Yes |
 | [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | World Data | No | Yes | No |
 | [xMath](https://x-math.herokuapp.com/) | Random mathematical expressions | No | Yes | Yes |
 


### PR DESCRIPTION
Adds [Vedika API](https://vedika.io) to the Science & Math section.

**API Details:**
- URL: https://vedika.io
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes

**Features:**
- 108+ REST API endpoints for Vedic astrology
- AI-powered chatbot
- Birth charts, horoscopes, panchang
- 22 language support
- Free sandbox: https://vedika.io/sandbox