### PR TITLE
Add PikaSim API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,6 +1363,7 @@ API | Description | Auth | HTTPS | CORS |
 | [apilayer numverify](https://numverify.com) | Phone number validation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
+| [PikaSim](https://pikasim.com/reseller/api-docs) | Purchase eSIMs programmatically for 190+ countries | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds [PikaSim](https://pikasim.com) to the Phone section.

**PikaSim** is a privacy-focused eSIM API that allows developers to purchase eSIMs programmatically for 190+ countries.

- **Documentation**: https://pikasim.com/reseller/api-docs
- **Auth**: API Key
- **HTTPS**: Yes
- **CORS**: Yes

Key features:
- No KYC required
- Accepts cryptocurrency (Bitcoin, Lightning, Monero)
- Webhooks for async provisioning
- Cancel unused eSIMs for refund
- No minimum orders