### PR TITLE
Add MailCheck - Email Validation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ API | Description | Auth | HTTPS | CORS |
 | [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |
 | [mail.tm](https://docs.mail.tm) | Temporary Email Service | No | Yes | Yes |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
+| [MailCheck](https://rapidapi.com/soutone/api/mailcheck-email-validation-api) | Email validation with syntax, domain, MX, and disposable detection | `apiKey` | Yes | Yes |
 | [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
 | [Mailtrap](https://mailtrap.docs.apiary.io/#) | A service for the safe testing of emails sent from the development and staging environments | `apiKey` | Yes | Unknown |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description
Adding **MailCheck**, an email validation API available on RapidAPI.

## Features
- Syntax validation (RFC 5322 compliant)
- Domain verification
- MX record lookup
- Disposable email detection (10,000+ domains)
- Role-based email detection (info@, support@, etc.)

## Pricing
- Free tier: 100 requests/month
- Paid plans available for higher volumes

## Links
- API: https://rapidapi.com/soutone/api/mailcheck-email-validation-api
- Live endpoint: https://mailcheck-api.fly.dev

## Checklist
- [x] API has a free tier
- [x] API uses HTTPS
- [x] API returns JSON
- [x] Entry is alphabetically ordered