### PR TITLE
Add Stock Sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
+| [Stock Sentiment](https://api.adanos.org/docs) | Real-time stock sentiment from Reddit, X/Twitter and Polymarket | `apiKey` | Yes | Yes | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |
 | [Tax Data API](https://apilayer.com/marketplace/tax_data-api) | Instant VAT number and tax validation across the globe | `apiKey` | Yes | Unkown | |


### PR DESCRIPTION
Adding Stock Sentiment — a REST API for real-time social media sentiment analysis of stocks.

- Category: Finance
- Auth: apiKey (free tier: 250 req/month, no credit card required)
- HTTPS: Yes
- CORS: Yes
- Docs: https://api.adanos.org/docs

Aggregates sentiment from three platforms:
- **Reddit** — tracks mentions, buzz scores, and sentiment across communities like r/wallstreetbets, r/stocks, r/investing
- **X/Twitter** — trending stocks and social buzz from tweets
- **Polymarket** — prediction market activity and trade signals

Useful for building stock dashboards, alert systems, or feeding sentiment data into trading strategies. No other API in this list combines Reddit + X + prediction market data in a single endpoint.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>