### PR TITLE
Add CatFact Ninja API to Animals category

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ API | Description | Auth | HTTPS | CORS
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
+| [CatFact Ninja](https://catfact.ninja) | Random cat facts and information | No | Yes | Yes |
 | [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |


### PR DESCRIPTION
Add CatFact Ninja API to the Animals category. This API provides random cat facts and information for free, without authentication.

API Details:
- URL: https://catfact.ninja
- Auth: No
- HTTPS: Yes
- CORS: Yes

This API complements existing cat-related APIs like Cat Facts and MeowFacts.