### PR TITLE
Fix UnboundLocalError in format.py validation script

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -43,7 +43,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
 
     categories = {}
     category_line_num = {}
-
+    category = ''
     for line_num, line_content in enumerate(contents):
 
         if line_content.startswith(anchor):


### PR DESCRIPTION
This PR fixes an UnboundLocalError in the format validation script by initializing the `category` variable at the start of `get_categories_content()` function. This prevents errors when table entries appear before category headers in the README.md file.

The fix ensures the validation script can properly parse all API entries and check alphabetical order without crashing.