### PR TITLE
Add Registry Broker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Etherscan](https://etherscan.io/apis) | Ethereum explorer API | `apiKey` | Yes | Yes |
 | [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No | Yes | Unknown |
 | [Nownodes](https://nownodes.io/) | Blockchain-as-a-service solution that provides high-quality connection via API | `apiKey` | Yes | Unknown |
-| [Registry Broker](https://hol.org/docs/api/registry-broker) | Universal index for AI agents across web2 and web3 registries | No | Yes | Yes |
+| [Registry Broker](https://hol.org/registry/docs) | Universal index for AI agents across web2 and web3 registries | No | Yes | Yes |
 | [Steem](https://developers.steem.io/) | Blockchain-based blogging and social media website | No | No | No |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

This PR adds Registry Broker to the Blockchain section.

**Registry Broker** is a universal index and routing layer for AI agents. It provides a REST API that aggregates agent metadata from multiple registries across web2 and web3.

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| Registry Broker | Universal index for AI agents across web2 and web3 registries | No | Yes | Yes |

**Links:**
- API Docs: https://hol.org/registry/docs
- License: Apache 2.0