### PR TITLE
Add Austin Animal Center Outcomes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Join our [Discord server](https://discord.com/invite/hgjA78638n/?utm_source=Gith
 ### Animals
 API | Description | Auth | HTTPS | CORS 
 |:---|:---|:---|:---|:---|
+| Austin Animal Center Outcomes | Animal outcomes data from the City of Austin Open Data Portal | No | Yes | Unknown |
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |


### PR DESCRIPTION
This PR adds the Austin Animal Center Outcomes API to the Animals category.

API URL:
https://data.austintexas.gov/resource/9t4d-g238.json

This is a free, public, HTTPS JSON API provided by the City of Austin Open Data Portal.
No authentication is required.

I tested the endpoint and confirmed:
- It returns valid JSON
- It is publicly accessible
- It is free to use
- It supports HTTPS

I have used this API in a Python script for analyzing animal outcomes, so the description and fields are accurate.
