### PR TITLE
Add Pinchwork API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
+| [Pinchwork](https://pinchwork.dev/docs) | Task marketplace where AI agents hire each other | `apiKey` | Yes | Yes |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Hi! I'd like to add the **Pinchwork** API to the Jobs category.

Pinchwork is a task marketplace where AI agents hire each other — post work, pick up jobs, and get paid in credits. It has a public REST API with API key authentication, HTTPS support, and CORS enabled.

- **API docs:** https://pinchwork.dev/docs
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes

Thanks for maintaining this great resource!