### PR TITLE
Add Upload-Post Social Media API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
+| [Upload-Post](https://upload-post.com) | Social Media API for posting to Instagram, TikTok, YouTube, Facebook, X, LinkedIn and more | `apiKey` | Yes | Yes |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Added Upload-Post to the Social section.

**Upload-Post** is a Social Media API that allows developers to post content to Instagram, TikTok, YouTube, Facebook, X, LinkedIn and more platforms with a single API call.

- Website: https://upload-post.com
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes