### PR TITLE
Add Gawrshdarn API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |
+| [Gawrshdarn](https://api.gawrshdarn.com) | Profanity detection, filtering, and playful word replacement | No | Yes | Yes |
 | [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
 | [Hirak OCR](https://ocr.hirak.site/) | Image to text -text recognition- from image more than 100 language, accurate, unlimited requests | `apiKey` | Yes | Unknown |
 | [Hirak Translation](https://translate.hirak.site/) | Translate between 21 of most used languages, accurate, unlimited requests | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Gawrshdarn**, a free profanity filter API that detects, censors, and replaces profanity with playful family-friendly alternatives.

## API Details

- **URL:** https://api.gawrshdarn.com
- **Auth:** None required
- **HTTPS:** Yes
- **CORS:** Yes

## Endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /api/detect` | Check if text contains profanity |
| `POST /api/filter` | Censor or remove profanity |
| `POST /api/replace` | Replace with playful alternatives (hell → heck, damn → darn) |
| `GET /api/health` | Health check |

## Example

```bash
curl -X POST https://api.gawrshdarn.com/api/replace \
  -H 'Content-Type: application/json' \
  -d '{"text": "What the hell is this damn thing?"}'
# → {"replaced":"What in tarnation is this dadgummit thing?","substitutions":2}
```

## Category

Text Analysis (inserted alphabetically between ELI and Google Cloud Natural)