### PR TITLE
Add Goat Screams API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ API | Description | Auth | HTTPS | CORS
 | [Dogs](https://dog.ceo/dog-api/) | Based on the Stanford Dogs Dataset | No | Yes | Yes |
 | [eBird](https://documenter.getpostman.com/view/664302/S1ENwy59) | Retrieve recent or notable birding observations within a region | `apiKey` | Yes | No |
 | [FishWatch](https://www.fishwatch.gov/developers) | Information and pictures about individual fish species | No | Yes | Yes |
+| [Goat Screams API](https://bleatbox.app/goat-scream-api) | 200+ curated goat scream sounds with musical analysis for apps & demos | No | Yes | Yes |
 | [HTTP Cat](https://http.cat/) | Cat for every HTTP Status | No | Yes | Yes |
 | [HTTP Dog](https://http.dog/) | Dogs for every HTTP response status code | No | Yes | Yes |
 | [IUCN](http://apiv3.iucnredlist.org/api/v3/docs) | IUCN Red List of Threatened Species | `apiKey` | No | No |


### PR DESCRIPTION
Adds **Goat Screams API** to the Animals section.

## API Details
- **URL**: https://bleatbox.app/goat-scream-api
- **Description**: 200+ curated goat scream sounds with musical analysis for apps & demos
- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

The API provides:
- Random goat scream audio files
- Search by intensity, duration, and tags
- Musical analysis (pitch, tempo, key detection)
- No authentication required

Perfect for apps, keyboards, demo projects, and internet mischief 🐐