### PR TITLE
Add OGKit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lordicon](https://lordicon.com/) | Icons with predone Animations | No | Yes | Yes |
 | [Metropolitan Museum of Art](https://metmuseum.github.io/) | Met Museum of Art | No | Yes | No |
 | [Noun Project](http://api.thenounproject.com/index.html) | Icons | `OAuth` | No | Unknown |
+| [OGKit](https://ogkit.vercel.app/docs) | Generate dynamic Open Graph images via URL parameters | No | Yes | Unknown |
 | [PHP-Noise](https://php-noise.com/) | Noise Background Image Generator | No | Yes | Yes |
 | [Pixel Encounter](https://pixelencounter.com/api) | SVG Icon Generator | No | Yes | No |
 | [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/) | RijksMuseum Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add OGKit API

**Category**: Art & Design

**Description**: OGKit is a free API that generates dynamic Open Graph images via URL parameters. No signup or API key required.

**API URL**: https://ogkit.vercel.app/docs

**Example**:
```
GET https://ogkit.vercel.app/api/og?title=Hello+World&template=blog&theme=dark
```

Returns a 1200x630 PNG image.

**Features**:
- 6 templates (basic, blog, product, profile, gradient, minimal)
- 6 color themes (light, dark, blue, green, purple, orange)
- Edge-powered (<200ms response time)
- CDN cached for 24 hours
- 50 images/day free tier

**Auth**: No
**HTTPS**: Yes
**CORS**: Unknown