### PR TITLE
Add Nory x402 API to Blockchain category

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Etherscan](https://etherscan.io/apis) | Ethereum explorer API | `apiKey` | Yes | Yes |
 | [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No | Yes | Unknown |
 | [Nownodes](https://nownodes.io/) | Blockchain-as-a-service solution that provides high-quality connection via API | `apiKey` | Yes | Unknown |
+| [Nory x402](https://noryx402.com) | x402 payment processor for AI agents with USDC micropayments on Solana | No | Yes | Yes |
 | [Steem](https://developers.steem.io/) | Blockchain-based blogging and social media website | No | No | No |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |


### PR DESCRIPTION
## Summary
Adding Nory x402 to the Blockchain category.

## API Details
- **Name**: Nory x402
- **URL**: https://noryx402.com
- **Description**: x402 payment processor for AI agents with USDC micropayments on Solana
- **Auth**: No (public endpoints)
- **HTTPS**: Yes
- **CORS**: Yes

## What is Nory x402?
Nory is a payment processor implementing the x402 protocol (HTTP 402 Payment Required). It enables AI agents to autonomously pay for APIs and services using USDC on Solana with ~400ms settlement.

Features:
- Verify and settle payments via REST API
- Live paid APIs (crypto prices, weather, QR codes, translation)
- SDKs for both payers and payees
- MCP server for Claude integration

## Documentation
- OpenAPI spec: https://noryx402.com/openapi.yaml
- Docs: https://noryx402.com/docs