### PR TITLE
Add SnapForge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
+| [SnapForge](https://ni1ra.github.io/snapforge/) | Screenshot any webpage as PNG, JPEG, or PDF | `apiKey` | Yes | Yes |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |
 | [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Add SnapForge — a screenshot API for developers.

- **URL**: https://ni1ra.github.io/snapforge/
- **Auth**: API Key
- **HTTPS**: Yes
- **CORS**: Yes
- **Category**: Development
- **Description**: Screenshot any webpage as PNG, JPEG, or PDF
- **Free tier**: 100 screenshots/month

Follows alphabetical ordering within the Development section.