### PR TITLE
Add OilPriceAPI to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
+| [OilPriceAPI](https://www.oilpriceapi.com) | Real-time and historical oil, gas, and energy commodity prices | `apiKey` | Yes | Yes | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
-| [OilPriceAPI](https://www.oilpriceapi.com) | Real-time and historical oil, gas, and energy commodity prices | `apiKey` | Yes | Yes | |
+| [OilPriceAPI](https://docs.oilpriceapi.com) | Crude oil, natural gas, refined product and marine fuel prices, each with its source timestamp | `apiKey` | Yes | Yes | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Add OilPriceAPI

Adds [OilPriceAPI](https://www.oilpriceapi.com) to the Finance section.

**Description:** Real-time and historical oil, gas, and energy commodity prices

- **Auth:** `apiKey`
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** Yes (free embeddable widgets, free API tier)
- **Documentation:** https://www.oilpriceapi.com/docs

The API provides Brent Crude, WTI, Natural Gas, diesel, and other energy commodity prices via REST endpoints.