### PR TITLE
Add ClawdTalk API to Phone category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1361,6 +1361,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [apilayer numverify](https://numverify.com) | Phone number validation | `apiKey` | Yes | Unknown |
+| [ClawdTalk](https://clawdtalk.com) | Voice calling and SMS for OpenClaw AI agents. Powered by Telnyx. | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds ClawdTalk to the public-apis list under the Phone category.

**API Details:**
- Name: ClawdTalk
- Description: Voice calling and SMS for OpenClaw AI agents. Powered by Telnyx.
- URL: https://clawdtalk.com
- Auth: apiKey
- HTTPS: Yes
- CORS: Unknown

This PR follows the contribution guidelines for adding new APIs to the repository.