### PR TITLE
Add QRCGen API

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |
 | [QR code](https://www.qrtag.net/api/) | Create an easy to read QR code and URL shortener | No | Yes | Yes |
 | [QR code](http://goqr.me/api/) | Generate and decode / read QR code graphics | No | Yes | Unknown |
+| [QRCGen](https://qrcgen.com/) | Ultra-lightweight SVG QR codes with edge caching, ~5 KB output | No | Yes | Unknown |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Add [QRCGen](https://qrcgen.com/) to the **Development** section (QR code APIs).

Free, open QR code API that generates ultra-lightweight SVG output (~5 KB vs 60–80 KB from other generators). No auth, no rate limits, edge-cached on Cloudflare.

- **API endpoint**: `https://qr.qrcgen.com/qr.inline?data=https://example.com`
- **Source**: https://github.com/investblog/qr-generator
- **Auth**: No
- **HTTPS**: Yes