### PR TITLE
Add Absurdity Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Government
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Absurdity Index](https://absurdityindex.org/api/bills.json) | Congressional bill data scored on an Absurdity Index (1-10) | No | Yes | Unknown |
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |


### PR DESCRIPTION
## Add Absurdity Index API to Government

**API**: [Absurdity Index](https://absurdityindex.org/api/bills.json)
**Description**: Congressional bill data scored on an Absurdity Index (1-10)
**Auth**: No
**HTTPS**: Yes
**CORS**: Unknown

### About

Absurdity Index is a free, public JSON API that provides data on real U.S. congressional legislation, each scored on an absurdity scale from 1-10. Every bill entry includes proof links to congress.gov. No authentication required.

**API endpoint**: `https://absurdityindex.org/api/bills.json`

The entry has been placed in alphabetical order within the Government section.