### PR TITLE
Add RateAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [RateAPI](https://api.rateapi.dev) | Real interest rates from 1,400+ US credit unions across 50 states | `apiKey` | Yes | Yes |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
Added RateAPI to the Finance section.

RateAPI provides real interest rate data from 1,400+ US credit unions covering mortgages, auto loans, HELOCs, personal loans, and credit cards across all 50 US states. Rates are ranked by APR with no affiliate bias.

- **Auth:** API key (free tier: 50 requests/month, no credit card required)
- **HTTPS:** Yes
- **CORS:** Yes
- **Docs:** https://api.rateapi.dev

The API is live, documented, and the free tier requires only an email signup.