### PR TITLE
Add SnapAPI to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping with a simple API | `apiKey` | Yes | Unknown |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
+| [SnapAPI](https://snapapi.pics) | Screenshot, video, PDF, and data extraction API | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding SnapAPI (https://snapapi.pics) - a screenshot, video recording, PDF generation, and web data extraction API with a free tier.