### PR TITLE
Add Just Cancel API to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown | |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
+| [JustCancel](https://www.justcancel.io/api/cancel-data) | Subscription cancellation data for 135+ services with cancel URLs and difficulty ratings | No | Yes | Yes | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Just Cancel API

**URL:** https://www.justcancel.io/api/cancel-data
**Category:** Finance
**Auth:** None
**HTTPS:** Yes
**CORS:** Yes

Free, public JSON API providing subscription cancellation difficulty data for 135+ services. Returns cancel methods, difficulty scores (1-10), direct cancel URLs, dark pattern warnings, and pricing info.

Useful for building personal finance tools, subscription management apps, or consumer advocacy projects.