### PR TITLE
Add OfficialJoke API

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ API | Description | Auth | HTTPS | CORS |
 | [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey` | Yes | Unknown |
 | [Mojang](https://wiki.vg/Mojang_API) | Mojang / Minecraft API | `apiKey` | Yes | Unknown |
 | [Monster Hunter World](https://docs.mhw-db.com/) | Monster Hunter World data | No | Yes | Yes |
+| [OfficialJoke](https://official-joke-api.appspot.com/) | Generates random jokes | No | Yes | Yes |
 | [Open Trivia](https://opentdb.com/api_config.php) | Trivia Questions | No | Yes | Unknown |
 | [PandaScore](https://developers.pandascore.co/) | E-sports games and results | `apiKey` | Yes | Unknown |
 | [Path of Exile](https://www.pathofexile.com/developer/docs) | Path of Exile Game Information | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Added [OfficialJokes](https://official-joke-api.appspot.com/) to the Entertainment category.

    Description: Creates random jokes
    Auth: No
    HTTPS: Yes
    CORS: Yes
    Link: https://official-joke-api.appspot.com/
