### PR TITLE
Add GroanDeck dad jokes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Yes | Unknown |
 | [FOAAS](http://www.foaas.com/) | Fuck Off As A Service | No | No | Unknown |
 | [Forismatic](http://forismatic.com/en/api/) | Inspirational Quotes | No | No | Unknown |
+| [GroanDeck](https://groandeck.com/developers) | 2,000+ dad jokes with search, categories, and random joke endpoint | No | Yes | Yes |
 | [icanhazdadjoke](https://icanhazdadjoke.com/api) | The largest selection of dad jokes on the internet | No | Yes | Unknown |
 | [Inspiration](https://inspiration.goprogram.ai/docs/) | Motivational and Inspirational quotes | No | Yes | Yes |
 | [kanye.rest](https://kanye.rest) | REST API for random Kanye West quotes | No | Yes | Yes |


### PR DESCRIPTION
**API Name:** GroanDeck
**Description:** 2,000+ dad jokes with search, categories, and random joke endpoint
**Auth:** No
**HTTPS:** Yes
**CORS:** Yes
**Link:** https://groandeck.com/developers

GroanDeck serves 2,000+ curated dad jokes across 33 categories. Endpoints include random joke, search by keyword, and filter by category. No API key required.