### PR TITLE
Add ContentAPI — Content Extraction API for AI/RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
+| [ContentAPI](https://getcontentapi.com) | Extract content from YouTube, web, Twitter, Reddit for AI/RAG | `apiKey` | Yes | Yes |
 | [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey` | Yes | Yes |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |


### PR DESCRIPTION
## ContentAPI

**Website:** https://getcontentapi.com  
**API Docs:** https://getcontentapi.com/docs  
**OpenAPI Spec:** https://api.getcontentapi.com/api/v1/openapi.json

### Description

ContentAPI is a universal content extraction API designed for AI agents, RAG pipelines, and developers. It extracts clean, structured content from any URL — YouTube transcripts, web pages, Twitter/X threads, Reddit posts, search results, and more.

### Features
- YouTube transcripts (with AI fallback via Whisper for videos without captions)
- Web page extraction (handles JS-rendered pages)
- Twitter/X thread extraction
- Reddit post + comments extraction
- Structured data extraction with AI
- Website crawling (up to 100 pages)
- Batch processing (up to 10 URLs)

### Auth & Pricing
- **Auth:** API Key (X-API-Key header)
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** 5,000 requests/month, no credit card required

### Category
Added under **Development** (alphabetically between Contentful Images and CORS Proxy).

### SDKs
- Python: pip install contentapi
- MCP Server: npx contentapi-mcp-server