### PR TITLE
Add BMO JWT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bitbucket](https://developer.atlassian.com/bitbucket/api/2/reference/) | Bitbucket API | `OAuth` | Yes | Unknown |
 | [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/The biggest FR jokes API | `apiKey` | Yes | Yes |
 | [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey` | Yes | Unknown |
+| [BMO JWT](https://jwt.bmobot.ai) | Decode, verify, generate, inspect, and diff JSON Web Tokens | No | Yes | Yes |
 | [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey` | No | Unknown |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Free, no-auth API for working with JSON Web Tokens — decode headers/payload, verify signatures (HS256/384/512), generate tokens, inspect expiration, and diff two JWTs. Includes interactive playground at https://jwt.bmobot.ai and OpenAPI spec at https://jwt.bmobot.ai/openapi.json.

- Auth: No
- HTTPS: Yes
- CORS: Yes