### PR TITLE
Add BMO SemVer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/The biggest FR jokes API | `apiKey` | Yes | Yes |
 | [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey` | Yes | Unknown |
 | [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey` | No | Unknown |
+| [BMO SemVer](https://semver.bmobot.ai) | Parse, compare, sort, and validate semantic version strings with range matching | No | Yes | Yes |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Free, no-auth API for working with Semantic Versioning — parse versions, compare/sort, check range satisfaction (npm-style ^/~/>=), bump versions, and diff. Follows SemVer 2.0.0 spec. Interactive playground at https://semver.bmobot.ai and OpenAPI spec at https://semver.bmobot.ai/openapi.json.

- Auth: No
- HTTPS: Yes
- CORS: Yes