### PR TITLE
Add BMO Cron API

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/The biggest FR jokes API | `apiKey` | Yes | Yes |
 | [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey` | Yes | Unknown |
 | [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey` | No | Unknown |
+| [BMO Cron](https://cron.bmobot.ai) | Parse cron expressions into human-readable descriptions with next run times | No | Yes | Yes |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Free, no-auth API for parsing cron expressions — converts to human-readable descriptions, calculates next N run times, validates syntax, and provides 20 common presets. Interactive playground at https://cron.bmobot.ai and OpenAPI spec at https://cron.bmobot.ai/openapi.json.

- Auth: No
- HTTPS: Yes
- CORS: Yes