### PR TITLE
Add BMO Meta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/The biggest FR jokes API | `apiKey` | Yes | Yes |
 | [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey` | Yes | Unknown |
 | [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey` | No | Unknown |
+| [BMO Meta](https://meta.bmobot.ai) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | No | Yes | Yes |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Free, no-auth API for extracting metadata from URLs — Open Graph tags, Twitter Cards, favicons, canonical URLs, language, charset, and keywords. Includes LRU cache for fast repeated lookups. Interactive playground at https://meta.bmobot.ai and OpenAPI spec at https://meta.bmobot.ai/openapi.json.

- Auth: No
- HTTPS: Yes
- CORS: Yes