### PR TITLE
Add Glio to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
+| [Glio](https://glio.io) | Unified API for 50+ AI models — Kling, Sora2, Veo3, Suno, ElevenLabs. Pay-per-use | `apiKey` | Yes | Yes |
 | [Hirak FaceAPI](https://faceapi.hirak.site/) | Face detection, face recognition with age estimation/gender estimation, accurate, no quota limits | `apiKey` | Yes | Unknown |    
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adding **Glio** to the Machine Learning section.

| Field | Value |
|-------|-------|
| API | [Glio](https://glio.io) |
| Description | Unified API for 50+ AI models — Kling, Sora2, Veo3, Suno, ElevenLabs. Pay-per-use |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |

### What is Glio?

Glio provides a single API endpoint for AI media generation across 50+ state-of-the-art models:
- **Video**: Kling, Sora2, Veo3, Runway, Luma, Hailuo
- **Image**: Midjourney, FLUX, Ideogram, Recraft, NanoBanana
- **Audio**: Suno, ElevenLabs (TTS/STT/SFX)

Pay-per-use pricing with no subscriptions required.

### Links
- Homepage: https://glio.io/
- API Docs: https://glio.io/docs/api/
- OpenAPI Spec: https://glio.io/openapi.json