### PR TITLE
Add ZenQuotes API to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ API | Description | Auth | HTTPS | CORS |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
+| [ZenQuotes API](https://zenquotes.io/) | Free quotes API | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary
Added ZenQuotes API to the public APIs list.

## Why This Is Important
Provides a free API for quotes, useful for developers looking for inspirational data.

## Changes Made
- Added ZenQuotes row to README table
