### PR TITLE
Add Event Listing Normalization API to Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Eventbrite](https://www.eventbrite.com/platform/api/) | Find events | `OAuth` | Yes | Unknown |
+| [Event Listing Normalization API](https://github.com/precisionsolutionstech-netizen/event-listing-normalization-api) | Normalize event data from multiple platforms into a canonical JSON schema | `apiKey` | Yes | Unknown |
 | [SeatGeek](https://platform.seatgeek.com/) | Search events, venues and performers | `apiKey` | Yes | Unknown |
 | [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | Search events, attractions, or venues | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
Adds the Event Listing Normalization API under the Events category.

The API normalizes event payloads from multiple platforms into a canonical schema.
