### PR TITLE
Add Late API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Instagram](https://www.instagram.com/developer/) | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [Kakao](https://developers.kakao.com/) | Kakao Login, Share on KakaoTalk, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [Lanyard](https://github.com/Phineas/lanyard) | Retrieve your presence on Discord through an HTTP REST API or WebSocket | No | Yes | Yes |
+| [Late](https://docs.getlate.dev) | Schedule posts and get analytics across 13 social media platforms | `apiKey` | Yes | Yes |
 | [Line](https://developers.line.biz/) | Line Login, Share on Line, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | The foundation of all digital integrations with LinkedIn | `OAuth` | Yes | Unknown |
 | [Meetup.com](https://www.meetup.com/api/guide) | Data about Meetups from Meetup.com | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [Late](https://getlate.dev) to the **Social** category.

Late is a unified REST API for scheduling posts and retrieving analytics across 13 social media platforms (Twitter/X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Reddit, Pinterest, Bluesky, Telegram, Google Business, Snapchat).

- **Documentation:** https://docs.getlate.dev
- **Auth:** API Key (Bearer token)
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** Yes (20 posts/month)