### PR TITLE
Add EditPDFree API to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [EditPDFree](https://api.editpdfree.com) | Convert HTML/URL to PDF, merge, compress, split, watermark, protect PDFs | `apiKey` | Yes | Yes |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adding **EditPDFree API** to the Documents & Productivity section.

- **API Name**: EditPDFree
- **Description**: Convert HTML/URL to PDF, merge, compress, split, watermark, protect PDFs
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Link**: https://api.editpdfree.com

Free tier available (50 requests/month, no credit card required). Paid plans from $9/month.

- [x] API is publicly accessible
- [x] HTTPS supported
- [x] CORS enabled
- [x] Alphabetical order maintained