### PR TITLE
Add Virlo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
+| [Virlo](https://dev.virlo.ai) | Real-time viral content trends and hashtag analytics across YouTube, TikTok, and Instagram | `apiKey` | Yes | Unknown |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Summary
- Adds the [Virlo API](https://dev.virlo.ai) to the **Social** category
- Virlo provides real-time viral content trends and hashtag analytics across YouTube, TikTok, and Instagram
- Auth: `apiKey`, HTTPS: Yes, CORS: Unknown

## Details
- Entry placed alphabetically between Twitter and vk
- Virlo offers a free tier with API key authentication
- Documentation available at https://dev.virlo.ai