### PR TITLE
 Add OpenAlex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1442,6 +1442,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Numbers](https://math.tools/api/numbers/) | Number of the day, random number, number facts and anything else you want to do with numbers | `apiKey` | Yes | No |
 | [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
 | [Ocean Facts](https://oceanfacts.herokuapp.com/) | Facts pertaining to the physical science of Oceanography | No | Yes | Unknown |
+| [OpenAlex](https://docs.openalex.org/) | Open index of scholarly works, authors, venues, institutions and concepts | `apiKey` | Yes | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |


### PR DESCRIPTION
 ## Summary
  - Added OpenAlex to the Science & Math section.

  ## Why
  OpenAlex provides a free, open index of scholarly works, authors, venues, institutions, and concepts, which is useful for research and data applications.

  ## References
  - https://docs.openalex.org/
