### PR TITLE
Add Webcite API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1664,6 +1664,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Semantria](https://semantria.readme.io/docs) | Text Analytics with sentiment analysis, categorization & named entity extraction | `OAuth` | Yes | Unknown |
 | [Sentiment Analysis](https://www.meaningcloud.com/developer/sentiment-analysis) | Multilingual sentiment analysis of texts from different sources | `apiKey` | Yes | Yes |
 | [Tisane](https://tisane.ai/) | Text Analytics with focus on detection of abusive content and law enforcement applications | `OAuth` | Yes | Yes |
+| [Webcite](https://webcite.co/) | Fact-checking and citation verification API for AI outputs | `apiKey` | Yes | Yes |
 | [Watson Natural Language Understanding](https://cloud.ibm.com/apidocs/natural-language-understanding/natural-language-understanding) | Natural language processing for advanced text analysis | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Add Webcite API to Text Analysis

**API Name:** Webcite
**Category:** Text Analysis
**Link:** https://webcite.co/
**Description:** Fact-checking and citation verification API for AI outputs
**Auth:** apiKey
**HTTPS:** Yes
**CORS:** Yes

Webcite provides a REST API for fact-checking, citation verification, and hallucination detection in LLM outputs. It offers a free tier (100 verifications/month) and returns structured verification results with source citations.