### PR TITLE
Add Minecraft ServerHub API to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |
 | [Marvel](https://developer.marvel.com) | Marvel Comics | `apiKey` | Yes | Unknown |
+| Minecraft ServerHub | Minecraft server status, player counts, MOTD, and live status badges | No | Yes | Yes | [Link](https://minecraft-serverhub.com/developers) |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |    
 | [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |
 | [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
This PR adds the Minecraft ServerHub API to the Games & Comics section. It provides real-time Minecraft server status, player counts, and MOTD without requiring an API key.

The entry has been formatted according to the details provided by the maintainer (@DRAGINOXd) in issue #5270.

Metadata:

Auth: No

HTTPS: Yes

CORS: Yes
