### PR TITLE
Add MoonMaker API — AI crypto signals via x402 (no API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Localbitcoins](https://localbitcoins.com/api-docs/) | P2P platform to buy and sell Bitcoins | No | Yes | Unknown |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
+| [MoonMaker](https://api.moonmaker.cc) | AI-native crypto signals, DeFi yields, institutional data & market regime — pay-per-call via x402 (no API key) | No | Yes | Yes |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## API Description

**[MoonMaker API](https://api.moonmaker.cc)** — AI-native crypto market intelligence API with pay-per-call pricing via x402 (no API key, no signup required).

### Endpoints
- `/signal/{coin}` — Multi-indicator trading signals (BTC/ETH/SOL)  
- `/context/{coin}` — 25 raw market indicators
- `/regime` — Market regime classification (BULL/BEAR/SIDEWAYS)
- `/institutions` — Institutional BTC holdings tracker
- `/market/etf` — Bitcoin ETF daily flow data
- `/yields` — Top DeFi yields across 18,000+ pools

### Format Compliance
- Auth: `No` (x402 pay-per-call — USDC on Base, no API key needed)
- HTTPS: `Yes`
- CORS: `Yes`
- Free tier: `/stats`, `/health` endpoints available at no cost