### PR TITLE
Add Remotive remote jobs API to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1157,6 +1157,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [Remotive](https://remotive.com/api) | Live remote jobs API filtering over 100k remote jobs by category and keyword | No | Yes | Yes |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |
 | [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Added [Remotive](https://remotive.com/api) to the **Jobs** section.

**API details:**
- **URL:** https://remotive.com/api/remote-jobs
- **Auth:** No (completely free, no API key needed)
- **HTTPS:** Yes
- **CORS:** Yes (`access-control-allow-origin: *`)
- **Description:** Live remote jobs API filtering over 100k remote jobs by category and keyword

**Verification:**
```bash
curl https://remotive.com/api/remote-jobs?limit=1
# Returns JSON with remote job listings
```

Placed alphabetically between Reed and The Muse in the Jobs section.