### PR TITLE
Add Scene45 Nollywood API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,6 +1825,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Movie Database](http://www.omdbapi.com/) | Movie information | `apiKey` | Yes | Unknown |
 | [Owen Wilson Wow](https://owen-wilson-wow-api.herokuapp.com) | API for actor Owen Wilson's "wow" exclamations in movies | No | Yes | Yes |
 | [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
+| [Scene45 Nollywood](https://filmflux.app/scene45/embed) | Trending Nollywood movies with titles, thumbnails, and channels | No | Yes | Yes |
 | [Simkl](https://simkl.docs.apiary.io) | Movie, TV and Anime data | `apiKey` | Yes | Unknown |
 | [STAPI](http://stapi.co) | Information on all things Star Trek | No | No | No |
 | [Stranger Things Quotes](https://github.com/shadowoff09/strangerthings-quotes) | Returns Stranger Things quotes | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding **Scene45 Nollywood** — a free, public JSON API for trending Nollywood (Nigerian cinema) movie data.

- **API docs:** https://filmflux.app/scene45/embed
- **Endpoint:** `GET https://filmflux.app/api/public/trending?limit=10`
- **Auth:** None required
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)

### What it returns
Trending Nollywood movies with title, description, thumbnail, duration, channel name, YouTube ID, and direct URL. Updates hourly.

### Why it belongs in Video
Scene45 is a Nollywood movie database (1,700+ films). The API serves movie/video data similar to other entries in the Video section (TMDb, OMDb, IMDB-API).

### Checklist
- [x] Free, no authentication required
- [x] HTTPS supported
- [x] CORS enabled
- [x] Alphabetical placement (between Ron Swanson Quotes and Simkl)
- [x] Description under 100 characters
- [x] API name does not end with "API"
- [x] Single link per PR