### PR TITLE
Add MetaPeek API to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
-| [MetaPeek](https://rapidapi.com/alexeisliusarev/api/metapeek) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | \ | Yes | Yes |
+| [MetaPeek](https://rapidapi.com/search/metapeek) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | \ | Yes | Yes |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
+| [MetaPeek](https://rapidapi.com/alexeisliusarev/api/metapeek) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | \ | Yes | Yes |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
-| [MetaPeek](https://rapidapi.com/search/metapeek) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | \ | Yes | Yes |
+| [MetaPeek](https://devpeek.dev) | Extract Open Graph, Twitter Card, and favicon metadata from any URL | \ | Yes | Yes |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |


### PR DESCRIPTION
## MetaPeek API

URL metadata extraction API — extracts Open Graph tags, Twitter Cards, favicons, and link preview data from any URL in milliseconds.

- **RapidAPI:** https://rapidapi.com/search/metapeek
- **Auth:** API Key (via RapidAPI)
- **HTTPS:** Yes
- **CORS:** Yes
- **OpenAPI spec:** Included

Built on Cloudflare Workers (300+ edge locations, zero cold starts). Free tier: 100 requests/day.