### PR TITLE
Add Groq AI inference API to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
+| [Groq](https://console.groq.com/docs/openai) | Fast AI inference API supporting Llama, Mixtral, Gemma and other open models | `apiKey` | Yes | Yes |
 | [Hirak FaceAPI](https://faceapi.hirak.site/) | Face detection, face recognition with age estimation/gender estimation, accurate, no quota limits | `apiKey` | Yes | Unknown |    
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What does this PR add?

Adds **[Groq](https://console.groq.com/docs/openai)** — a fast AI inference API supporting open models like Llama 3, Mixtral, and Gemma.

## Checklist
- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order in the section
- [x] I have verified the API is functional and the link is valid
