### PR TITLE
Add Mistral AI API to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1183,6 +1183,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
+| [Mistral AI](https://docs.mistral.ai/api/) | Powerful open-weight language models API including Mistral and Mixtral models | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **[Mistral AI](https://docs.mistral.ai/api/)** — API for Mistral and Mixtral open-weight language models.

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order
- [x] I have verified the API is functional