### PR TITLE
Add Together AI API to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
+| [Together AI](https://docs.together.ai/reference/inference) | Run and fine-tune leading open-source AI models at scale | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
Adds **[Together AI](https://docs.together.ai/reference/inference)** — inference API for 200+ open-source AI models with pay-per-token pricing.

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order
- [x] I have verified the API is functional