### PR TITLE
Add Hugging Face Inference API to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [Hirak FaceAPI](https://faceapi.hirak.site/) | Face detection, face recognition with age estimation/gender estimation, accurate, no quota limits | `apiKey` | Yes | Unknown |    
+| [Hugging Face Inference](https://huggingface.co/docs/api-inference/index) | Run 200,000+ open-source ML models for NLP, vision, audio, and more | `apiKey` | Yes | Yes |
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
 | [IPS Online](https://docs.identity.ps/docs) | Face and License Plate Anonymization | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **[Hugging Face Inference API](https://huggingface.co/docs/api-inference/index)** — serverless inference on 200k+ open-source models.

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order
- [x] I have verified the API is functional