### PR TITLE
Add Portal da Transparência Brazil API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, USA](https://www.data.gov/) | United States Government Open Data | No | Yes | Unknown |
 | [Open Government, Victoria State Government](https://www.data.vic.gov.au/) | Victoria State Government Open Data | No | Yes | Unknown |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
+| [Portal da Transparência, Brazil](https://api.portaldatransparencia.gov.br/) | Brazilian federal government spending, public employees, and transfers data | `apiKey` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds **[Portal da Transparência](https://api.portaldatransparencia.gov.br/)** — official Brazilian federal government open data API covering public spending, employees, and transfers.

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order
- [x] I have verified the API is functional