### PR TITLE
Add OpenAlex API to Science & Math section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,6 +1444,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ocean Facts](https://oceanfacts.herokuapp.com/) | Facts pertaining to the physical science of Oceanography | No | Yes | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
+| [OpenAlex](https://docs.openalex.org/) | Fully open catalog of the world's scholarly research: papers, authors, institutions | No | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
Adds **[OpenAlex](https://docs.openalex.org/)** — fully open and free scholarly research API covering 200M+ works, authors, journals, and institutions.

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible and well-documented
- [x] The entry follows alphabetical order
- [x] I have verified the API is functional