### PR TITLE
Add PageBolt — Screenshot, PDF, video recording, OG image, and page inspection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
+| [PageBolt](https://pagebolt.dev) | Screenshot, PDF, video recording, OG image, and page inspection via REST API | `apiKey` | Yes | Unknown |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [PageBolt](https://pagebolt.dev) to the Development section.

**Entry:**
| [PageBolt](https://pagebolt.dev) | Screenshot, PDF, video recording, OG image, and page inspection via REST API | `apiKey` | Yes | Unknown |

PageBolt is a hosted web capture API with 8 tools: screenshots (25+ device presets, ad blocking, cookie banner removal), PDFs, OG social images, multi-step browser sequences, page inspection, and video recording with AI voice narration. Requires an API key. HTTPS only.

Placed alphabetically between `oyyi` and `PageCDN`.