### PR TITLE
Add Spiderhash to Development APIs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |
 | [Base](https://www.base-api.io/) | Building quick backends | `apiKey` | Yes | Yes |
 | [Beeceptor](https://beeceptor.com/) | Build a mock Rest API endpoint in seconds | No | Yes | Yes |
+| [Spiderhash](https://spiderhash.io/) | Webhook receiver and request inspection API for testing and debugging webhook integrations | No | Yes | Unknown |
 | [Bitbucket](https://developer.atlassian.com/bitbucket/api/2/reference/) | Bitbucket API | `OAuth` | Yes | Unknown |
 | [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/The biggest FR jokes API | `apiKey` | Yes | Yes |
 | [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary
Adds Spiderhash (https://spiderhash.io/) to the Development section as a webhook testing/inspection API for developers.

## Why
Spiderhash is relevant to webhook development workflows for receiving and debugging incoming webhook requests.
