### PR TITLE
Add SEO Score API to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ API | Description | Auth | HTTPS | CORS |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
+| [SEO Score API](https://seoscoreapi.com/docs) | SEO audit API returning 0-100 score with 28 checks for any URL | `apiKey` | Yes | Yes |
 | [apilayer userstack](https://userstack.com/) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## API Details

- **API Name**: SEO Score API
- **Description**: SEO audit API returning 0-100 score with 28 checks for any URL
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **URL**: https://seoscoreapi.com/docs

Free tier available (5 audits/day). Returns scored SEO audit with meta tags, performance, accessibility, social, and technical checks.

Closes #5308