### PR TITLE
Add PageGuard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
+| [PageGuard](https://pageguard.qiudeqiu.workers.dev/docs) | Scan websites for SEO, performance, accessibility and best practices | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
-| [PageGuard](https://pageguard.qiudeqiu.workers.dev/docs) | Scan websites for SEO, performance, accessibility and best practices | No | Yes | Yes |
+| [PageGuard](https://pageguard.org/docs) | Scan websites for SEO, performance, accessibility and best practices | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adding PageGuard to the **Development** section (alphabetical order, between PageCDN and Postman).

PageGuard is a free website health scanner API that lets developers programmatically scan websites for SEO, performance, accessibility, and best practices issues. Returns structured JSON results.

**API Details:**
- **Endpoint**: `POST https://pageguard.qiudeqiu.workers.dev/api/v1/scan`
- **Auth**: No (free, no signup required)
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **Docs**: https://pageguard.qiudeqiu.workers.dev/docs

**Use case**: Developers can integrate website health checks into their CI/CD pipelines, monitoring dashboards, or build tooling without any registration.

## Checklist

- [x] Follows alphabetical ordering within the Development section
- [x] Description is under 100 characters (68 chars)
- [x] API has free access (no signup, no credit card)
- [x] HTTPS supported
- [x] CORS supported (Access-Control-Allow-Origin: *)
- [x] API has proper documentation page
- [x] One link added
- [x] PR title format: `Add PageGuard API`
- [x] PR targets `master` branch