### PR TITLE
Add NanoStack to Cryptocurrency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
+| [NanoStack](https://api.nano-labs.io) | Cross-chain execution API, 86 chains, 8-15 bps | No | Yes | Yes |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Hello. Here is our NanoStack API with access to native token swaps across 80+ chains.

- api: https://api.nano-labs.io
- docs: https://api.nano-labs.io/.well-known/openapi.json

Thanks for maintaining this.