### PR TITLE
Add TechDetect and SEC EDGAR Financial Data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ API | Description | Auth | HTTPS | CORS |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
 | [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
+| [TechDetect](https://rapidapi.com/dapdev-dapdev-default/api/technology-detection-api) | Detect 141+ technologies on any website — CMS, frameworks, CDN, analytics, hosting | `apiKey` | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
@@ -770,6 +771,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
+| [SEC EDGAR Financial Data](https://rapidapi.com/dapdev-dapdev-default/api/sec-edgar-financial-data-api) | 13F institutional holdings, insider transactions, and company search from SEC EDGAR | `apiKey` | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Added APIs

### Development section
- **TechDetect** — Detect 141+ technologies on any website (CMS, frameworks, CDN, analytics, hosting). 4-layer detection engine with sub-2-second response times. Free tier available.

### Finance section
- **SEC EDGAR Financial Data** — Query 13F institutional holdings, insider transactions, and search 10,000+ companies from SEC EDGAR. Data parsed from raw XBRL/XML into clean JSON, refreshed every 6 hours.

Both APIs have:
- HTTPS
- CORS support
- API key authentication
- Free tiers
- Python client libraries on GitHub
- Documentation and tutorials