### PR TITLE
Add Moltpost API - Physical postcards via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
+| [Moltpost](https://moltpost.io) | Send real physical postcards via API, worldwide delivery | No | Yes | Unknown |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Join our [Discord server](https://discord.com/invite/hgjA78638n/?utm_source=Gith
 * [Dictionaries](#dictionaries)
 * [Documents & Productivity](#documents--productivity)
 * [Email](#email)
+* [Mail](#mail)
 * [Entertainment](#entertainment)
 * [Environment](#environment)
 * [Events](#events)
@@ -674,6 +675,14 @@ API | Description | Auth | HTTPS | CORS |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [Verifier](https://verifier.meetchopra.com/docs#/) | Verifies that a given email is real | `apiKey` | Yes | Yes |
+
+**[⬆ Back to Index](#index)**
+<br >
+<br >
+### Mail
+API | Description | Auth | HTTPS | CORS |
+|:---|:---|:---|:---|:---|
+| [Moltpost](https://moltpost.io) | Send physical postcards worldwide via API | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Description

Added Moltpost API to a new **Mail** category.

### What is Moltpost?
Moltpost is an API that lets developers and AI agents send real physical postcards worldwide with a single API call.

### Use Cases
- Thank-you cards after meetings
- Birthday postcards from AI assistants
- Customer appreciation at scale
- Event reminders with physical presence

### API Details
- **Auth:** API Key
- **HTTPS:** Yes
- **CORS:** Yes
- **Link:** https://moltpost.io
- **Docs:** https://moltpost.io/docs

### Checklist
- [x] API returns JSON
- [x] API is free to use (first postcard free tier)
- [x] API has documentation
- [x] Added to index

This PR adds a new `Mail` category since physical mail delivery APIs are distinct from email APIs currently listed.