### PR TITLE
Add CallStack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [CallStack](https://callstack-api.vercel.app/docs) | Unified LLM API gateway for OpenAI, Anthropic, Gemini, DeepSeek with failover | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |


### PR DESCRIPTION
**CallStack** is a unified LLM API gateway that provides OpenAI-compatible access to OpenAI, Anthropic, Google Gemini, and DeepSeek through a single endpoint.

- **API URL**: https://callstack-api.vercel.app
- **Documentation**: https://callstack-api.vercel.app/docs
- **Auth**: API key (BYOK — users pass their own provider keys)
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **Free**: Yes — zero markup, users only pay their LLM providers

Features: automatic failover across 4 providers, cost tracking, SSE streaming, 18 models supported.