### PR TITLE
Add Schelling Protocol API to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
+| [Schelling Protocol](https://www.schellingprotocol.com) | Universal coordination layer for AI agents — discovery, matching, negotiation, contracts, and reputation | No | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding [Schelling Protocol](https://www.schellingprotocol.com) — universal coordination layer for AI agents (discovery, matching, negotiation, contracts, reputation). Free, HTTPS, CORS enabled.

GitHub: https://github.com/codyz123/a2a-assistant-matchmaker