### PR TITLE
Add DocForge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey` | Yes | Yes |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
+| [DocForge](https://docforge-api.vercel.app) | Convert between Markdown, HTML, CSV, JSON, and YAML formats | `apiKey` | Yes | Yes |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |


### PR DESCRIPTION
## Description

Adding [DocForge](https://docforge-api.vercel.app) to the **Development** category. DocForge is a free, stateless format conversion API that converts between Markdown/HTML, CSV/JSON, and YAML/JSON.

- **Base URL:** https://docforge-api.vercel.app
- **Auth:** `apiKey` (free tier available)
- **HTTPS:** Yes
- **CORS:** Yes
- **Docs:** https://docforge-api.vercel.app/api

### Endpoints

- `POST /api/md-to-html` -- Markdown to HTML
- `POST /api/csv-to-json` -- CSV to JSON
- `POST /api/json-to-csv` -- JSON to CSV
- `POST /api/yaml-json` -- YAML/JSON bidirectional

### Quick test

```bash
curl -s https://docforge-api.vercel.app/api | head -c 200
```

## Checklist

- [x] The API is free to use (has a free tier with 500 requests/day)
- [x] The API has proper documentation
- [x] The entry uses the correct format (`| [Name](url) | Description | Auth | HTTPS | CORS |`)
- [x] The entry is placed in alphabetical order within the Development category
- [x] The description does not exceed 100 characters
- [x] HTTPS is supported
- [x] CORS is supported
- [x] Only one API is added in this PR
- [x] The API name does not end with "API"
- [x] PR targets the `master` branch