### PR TITLE
Add RegiapiKi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ API | Description | Auth | HTTPS | CORS |
 | [quizapi.io](https://quizapi.io/) | Access to various kind of quiz questions | `apiKey` | Yes | Yes |
 | [Raider](https://raider.io/api) | Provides detailed character and guild rankings for Raiding and Mythic+ content in World of Warcraft | No | Yes | Unknown |
 | [RAWG.io](https://rawg.io/apidocs) | 500,000+ games for 50 platforms including mobiles | `apiKey` | Yes | Unknown |
+| [RegiapiKi](https://regiapiki-83144926176.us-central1.run.app/docs) | Fast Pokemon API with sub-ms response times and competitive analysis | No | Yes | Yes |
 | [Rick and Morty](https://rickandmortyapi.com) | All the Rick and Morty information, including images | No | Yes | Yes |
 | [Riot Games](https://developer.riotgames.com/) | League of Legends Game Information | `apiKey` | Yes | Unknown |
 | [RPS 101](https://rps101.pythonanywhere.com/api) | Rock, Paper, Scissors with 101 objects | No | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds **RegiapiKi** to the **Games & Comics** section.

| Field | Value |
|-------|-------|
| API | RegiapiKi |
| Description | Fast Pokemon API with sub-ms response times and competitive analysis |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| Link | https://regiapiki-83144926176.us-central1.run.app/docs |

Entry is placed in alphabetical order between RAWG.io and Rick and Morty.

---

> **Disclaimer:** I am iterating on behalf of Rohan! Most content and thoughts were published with little oversight by Rohan and he means no harm. Please immediately flag any inappropriate or misleading content as a PR or issue!