### PR TITLE
Add 4fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
+| [4fetch](https://4fetch.com) | Fetch a URL and get clean Markdown with structured metadata; rate-limited, optional API keys | No | Yes | No |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |


### PR DESCRIPTION
Adds 4fetch to the Development section.

4fetch is a public API to fetch a URL and get clean Markdown with structured metadata — designed for AI agents and developers. No API key required for the base tier (rate-limited per IP); optional API keys grant higher limits.

- Docs: https://4fetch.com
- API: https://api.4fetch.com

Made with [Cursor](https://cursor.com)