### PR TITLE
Add MetaLens, SnapForge, DocForge and PageForge APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
+| [MetaLens](https://meta-extractor-iota.vercel.app) | Extract Open Graph, Twitter Cards, JSON-LD and meta tags from any URL | `apiKey` | Yes | Unknown |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |
@@ -588,6 +589,7 @@ API | Description | Auth | HTTPS | CORS |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
+| [SnapForge](https://screenshot-api-two-omega.vercel.app) | Capture screenshots of any URL as PNG, JPEG or PDF with dark mode support | `apiKey` | Yes | Unknown |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |
 | [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
@@ -635,6 +637,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [DocForge](https://docforge-vercel.vercel.app) | Convert PDF documents to clean Markdown with table and heading preservation | `apiKey` | Yes | Unknown |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
@@ -644,6 +647,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PageForge](https://html-to-pdf-jet.vercel.app) | Convert HTML or URLs to PDF with custom headers, footers and print-quality output | `apiKey` | Yes | Unknown |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding four developer tool APIs across two categories:

**Development:**
- **MetaLens** — Extracts Open Graph, Twitter Cards, JSON-LD and meta tags from any URL. Useful for building link previews, SEO tools, or content scrapers. Free tier available.
- **SnapForge** — Takes screenshots of any URL as PNG, JPEG or PDF. Supports dark mode, full page capture, and custom viewports. Free tier available.

**Documents & Productivity:**
- **DocForge** — Converts PDF documents to clean Markdown. Preserves tables and headings. Built for RAG pipelines and content ingestion. Free tier available.
- **PageForge** — Converts HTML content or URLs to PDF with support for custom headers, footers, and print-quality rendering. Free tier available.

All four use API key auth, serve over HTTPS, and are actively maintained.