### PR TITLE
Add DocForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [DocForge](https://docforge-api.vercel.app) | Convert between Markdown, HTML, CSV, JSON, and YAML formats | No | Yes | Yes |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description

Adding DocForge to the Documents & Productivity category. It is a free document and data format conversion API.

- **Base URL:** https://docforge-api.vercel.app
- **Auth:** No (free tier requires no auth)
- **HTTPS:** Yes
- **CORS:** Yes
- **Rate limit:** 500 requests/day (free tier)

## Endpoints

- `POST /api/md-to-html` — Markdown to HTML
- `POST /api/csv-to-json` — CSV to JSON
- `POST /api/json-to-csv` — JSON to CSV
- `POST /api/yaml-json` — YAML/JSON bidirectional

## Quick test

```bash
curl -X POST https://docforge-api.vercel.app/api/csv-to-json \
  -H "Content-Type: application/json" \
  -d '{"csv": "name,age\nAlice,30\nBob,25"}'
```

## Checklist

- [x] API has a free tier (500 requests/day, no signup required)
- [x] API documentation is available at https://docforge-api.vercel.app/docs
- [x] Entry uses the correct format
- [x] Entry is in alphabetical order within the category
- [x] Description does not exceed 100 characters
- [x] API name does not end with "API"