### PR TITLE
Add APIVES - Curated API  Directory with 160+ APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Améthyste](https://api.amethyste.moe/) | Generate images for Discord users | `apiKey` | Yes | Unknown |
-| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | 
-No | Yes | Unknown |
+| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | No | Yes | Unknown |
 | [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Améthyste](https://api.amethyste.moe/) | Generate images for Discord users | `apiKey` | Yes | Unknown |
+| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | 
+No | Yes | Unknown |
 | [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
@@ -369,6 +371,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
+| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | No | Yes | Unknown |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [apilayer coinlayer](https://coinlayer.com) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
@@ -478,6 +481,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
+| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | No | Yes | Unknown |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Améthyste](https://api.amethyste.moe/) | Generate images for Discord users | `apiKey` | Yes | Unknown |
-| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | No | Yes | Unknown |
 | [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
@@ -370,7 +369,6 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
-| [APIVES](https://apives.com) | 160+ manually curated APIs with pricing, endpoints & playground | No | Yes | Unknown |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [apilayer coinlayer](https://coinlayer.com) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |


### PR DESCRIPTION

## What is APIves?

APIves (apives.com) is a manually 
curated directory of 160+ APIs 
for developers.

### Why add it here?

✅ 160+ APIs in one place
✅ Every API manually reviewed
✅ Pricing clearly listed
✅ Endpoint examples included
✅ API Playground available
✅ 18+ categories covered

### Categories covered:

- AI & LLM (GPT-4.1, Claude, Mistral)
- Travel (Amadeus)
- Payments (Stripe, Razorpay)
- Gaming (Discord, Twitch, RAWG)
- Communication (Twilio, Resend)
- Weather, Sports, Crypto & more

### Link:
https://apives.com