### PR TITLE
Add pauth.me - phone call authentication API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,6 +1363,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Phone
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [pauth.me](https://pauth.me) | Phone call-based OTP authentication API. SMS-free, SIM-swap resistant, landline support | `apiKey` | Yes | Unknown |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [apilayer numverify](https://numverify.com) | Phone number validation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |


### PR DESCRIPTION
pauth.me is a phone call-based OTP authentication API from Japan. It offers SMS-free verification that is SIM-swap resistant and supports landlines. Official site: https://pauth.me