### PR TITLE
Add LeadFinder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
+| [LeadFinder](https://leadscraper-coral.vercel.app/api/v1/leads) | Free local business leads from Google Maps | No | Yes | Yes |
 | [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |


### PR DESCRIPTION
## Add LeadFinder API to Business category

### API Details
- **Name:** LeadFinder
- **URL:** https://leadscraper-coral.vercel.app/api/v1/leads
- **Description:** Free local business leads from Google Maps
- **Auth:** No (completely free, no API key required)
- **HTTPS:** Yes
- **CORS:** Yes

### Example Request
```
GET https://leadscraper-coral.vercel.app/api/v1/leads?niche=dentists&city=miami
```

### What it does
LeadFinder is a free REST API that returns local business contact data (name, address, phone, website, rating) sourced from Google Maps. It requires no authentication, supports CORS for browser-based apps, and returns JSON responses.

### Checklist
- [x] API is free to use
- [x] API uses HTTPS
- [x] CORS is enabled
- [x] No authentication required
- [x] Entry added in alphabetical order within the Business category
- [x] Follows the existing table format