### PR TITLE
Add Human Pages API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | Jobs with GraphQL | No | Yes | Yes |
 | [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Yes | Unknown |
 | [GraphQL Jobs](https://graphql.jobs/docs/api/) | Jobs with GraphQL | No | Yes | Yes |
+| [Human Pages](https://humanpages.ai/dev) | The open directory AI agents use to hire humans for real-world tasks | `apiKey` | Yes | Yes |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds the Human Pages API — the open directory AI agents use to hire humans for real-world tasks.

- Website: https://humanpages.ai
- Docs: https://humanpages.ai/dev
- GitHub: https://github.com/human-pages-ai/humanpages