### PR TITLE
Add BOFH Excuses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Entertainment
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [BOFH Excuses](https://bofh.bombeck.io) | 453 classic Bastard Operator From Hell IT excuses as JSON | No | Yes | Yes |
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |


### PR DESCRIPTION
## Add BOFH Excuses API

Added to the **Entertainment** section (alphabetically before chucknorris.io).

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [BOFH Excuses](https://bofh.bombeck.io) | 453 classic Bastard Operator From Hell IT excuses as JSON | No | Yes | Yes |

### Details
- **URL**: https://bofh.bombeck.io
- **Docs**: https://bofh.bombeck.io/#api-docs
- **OpenAPI Spec**: https://bofh.bombeck.io/openapi.json
- **Auth**: None required
- **HTTPS**: Yes
- **CORS**: Yes
- **Rate Limit**: 1,000 req/15min per IP
- **License**: MIT

Free JSON API serving 453 classic Bastard Operator From Hell (BOFH) excuses. Supports JSON and plain text responses. No authentication required.