### PR TITLE
Add FileShot API to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown | |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |
+| [FileShot](https://fileshot.io) | Zero-knowledge encrypted file uploads and shareable link generation | No | Yes | Unknown | |
 | [Filestack](https://www.filestack.com) | Filestack File Uploader & File Upload API | `apiKey` | Yes | Unknown |    |
 | [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown | |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |


### PR DESCRIPTION
Title: Add FileShot API to Cloud Storage & File Sharing
Body:
### Summary
This PR adds the [FileShot API](https://fileshot.io) to the "Cloud Storage & File Sharing" section of the README.
### Details
* **Description:** The FileShot API provides zero-knowledge encrypted file uploads and shareable link generation. Files are encrypted client-side before reaching the API endpoint.
* **Auth:** No
* **HTTPS:** Yes
* **CORS:** Unknown
Address : 5357
### Checks
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) 
- [x] API is added alphabetically
- [x] Description is less than 100 characters
- [x] TLD has been removed from the API's name (`FileShot.io` -> `FileShot`)
- [x] Commit message is descriptive
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
