### PR TITLE
Add BSBFinder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
+| [BSBFinder](https://bsbfinder.com/api/v1/) | Australian BSB number lookup with bank details, branch addresses, and SWIFT codes | No | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |


### PR DESCRIPTION
Adding BSBFinder API

- URL: https://bsbfinder.com/api/v1/
- Description: Free Australian BSB number lookup API
- Auth: None
- HTTPS: Yes
- CORS: Yes

Example: https://bsbfinder.com/api/v1/bsb/062-000

Returns bank name, branch address, SWIFT code, and payment 
capabilities for 16,750+ Australian BSB codes.