### PR TITLE
Add OpenRouter to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
+| [OpenRouter](https://openrouter.ai/openrouter/free/api) | Unified API gateway with free access to 25+ AI models and paid access to 300+ more from multiple providers | `apiKey` | Yes | Unknown |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary
- Add OpenRouter, a unified AI API gateway, to the Machine Learning section.
- OpenRouter provides a free tier (25+ models, ~50 requests/day) and access to 300+ models via a single API.

## Test Plan
- Verified README.md formatting and table row placement under the Machine Learning category.