### PR TITLE
Add newsmcp to News category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API) | Provides news from inshorts | No | Yes | Unknown |
 | [MarketAux](https://www.marketaux.com/) | Live stock market news with tagged tickers + sentiment and stats JSON API | `apiKey` | Yes | Yes |
 | [New York Times](https://developer.nytimes.com/) | The New York Times Developer Network | `apiKey` | Yes | Unknown |
+| [newsmcp](https://newsmcp.io/v1/news/) | Real-time world news events clustered from hundreds of sources, classified by topic and geography | No | Yes | Yes |
 | [News](https://newsapi.org/) | Headlines currently published on a range of news sources and blogs | `apiKey` | Yes | Unknown |
 | [NewsData](https://newsdata.io/docs) | News data API for live-breaking news and headlines from reputed  news sources | `apiKey` | Yes | Unknown |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖 | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [newsmcp](https://newsmcp.io) to the **News** category.

## About

Free REST API for real-time world news events. Articles are clustered from hundreds of sources using AI, classified by 12 topics and 30+ geographic regions, and ranked by importance.

- **Auth**: No (no API key required)
- **HTTPS**: Yes
- **CORS**: Yes
- **Base URL**: `https://newsmcp.io/v1/news/`
- **Website**: [newsmcp.io](https://newsmcp.io)

Thank you for maintaining this incredible list!