### PR TITLE
Fix broken Yelp API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,7 +1298,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
 | [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth` | Yes | Unknown |
 | [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
-| [Yelp](https://www.yelp.com/developers/documentation/v3) | Find Local Business | `OAuth` | Yes | Unknown |
+| [Yelp](https://docs.developer.yelp.com/docs/places-intro) | Find Local Business | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

## Description

The current Yelp API documentation link (`https://www.yelp.com/developers/documentation/v3`) returns a **404 — page not found**. Yelp has migrated their developer documentation to a new portal.

This PR updates the link to the current live Yelp Places API documentation at `https://docs.developer.yelp.com/docs/places-intro`.

### Change

| Before | After |
|---|---|
| `https://www.yelp.com/developers/documentation/v3` (broken, 404) | `https://docs.developer.yelp.com/docs/places-intro` (live) |
