### PR TITLE
docs: fix incorrect anchor link for Anti-Malware in index

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Join our [Discord server](https://discord.com/invite/hgjA78638n/?utm_source=Gith
 
 * [Animals](#animals)
 * [Anime](#anime)
-* [Anti-Malware](#anti-malware)
+* [Anti-Malware](#anti-malware-1)
 * [Art & Design](#art--design)
 * [Authentication & Authorization](#authentication--authorization)
 * [Blockchain](#blockchain)


### PR DESCRIPTION
Fixed the anchor link for 'Anti-Malware' in the index to correctly point to '#anti-malware-1' (the actual ID for the Anti-Malware section header).