### PR TITLE
Add AI Engine OCR to Text Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Code Detection API](https://codedetectionapi.runtime.dev) | Detect, label, format and enrich the code in your app or in your data pipeline | `OAuth` | Yes | Unknown |
 | [apilayer languagelayer](https://languagelayer.com/) | Language Detection JSON API supporting 173 languages | `OAuth` | Yes | Unknown |
+| [AI Engine OCR](https://ai-engine.net/apis/ocr-wizard) | Extract text from images and PDFs with 200+ language and handwriting support | `apiKey` | Yes | Yes |
 | [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | A collection of information retrieval and natural language APIs | `apiKey` | Yes | Unknown |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [AI Engine OCR](https://ai-engine.net/apis/ocr-wizard) to the Text Analysis section.

- **API**: Extract text from images and PDFs with 200+ language and handwriting support
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Link**: https://ai-engine.net/apis/ocr-wizard

Entry placed in alphabetical order within the Text Analysis section.