### PR TITLE
Add AI Engine Background Removal to Photography

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,6 +1375,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Photography
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [AI Engine Background Removal](https://ai-engine.net/apis/background-removal) | Remove image backgrounds and get transparent PNGs | `apiKey` | Yes | Yes |
 | [apilayer screenshotlayer](https://screenshotlayer.com) | URL 2 Image | No | Yes | Unknown |
 | [APITemplate.io](https://apitemplate.io) | Dynamically generate images and PDFs from templates with a simple API | `apiKey` | Yes | Yes |    
 | [Bruzu](https://docs.bruzu.com) | Image generation with query string | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds [AI Engine Background Removal](https://ai-engine.net/apis/background-removal) to the Photography section.

- **API**: Remove image backgrounds and get transparent PNGs
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Link**: https://ai-engine.net/apis/background-removal

Entry placed in alphabetical order within the Photography section.