### PR TITLE
Add LocalCoinSwap API; Remove LocalBitcoins (Defunct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ API | Description | Auth | HTTPS | CORS |
 | [INFURA Ethereum](https://infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes | Yes |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [LocalCoinSwap](https://github.com/LocalCoinSwap/api-examples) | Non-custodial P2P exchange to buy or sell bitcoin and other crypto | `apiKey` | Yes | Unknown |
+| [LocalCoinSwap](https://github.com/LocalCoinSwap/api-examples) | Non-custodial P2P crypto exchange to buy or sell bitcoin and other digital currencies  | `apiKey` | Yes | Unknown |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ API | Description | Auth | HTTPS | CORS |
 | [INFURA Ethereum](https://infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes | Yes |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [Localbitcoins](https://localbitcoins.com/api-docs/) | P2P platform to buy and sell Bitcoins | No | Yes | Unknown |
+| [LocalCoinSwap](https://github.com/LocalCoinSwap/api-examples) | Non-custodial P2P exchange to buy or sell bitcoin and other crypto | `apiKey` | Yes | Unknown |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |


### PR DESCRIPTION
### Description
Added LocalCoinSwap to the Cryptocurrency section. LocalCoinSwap is a non-custodial P2P crypto exchange to buy or sell bitcoin and other digital currencies. 

I have also removed LocalBitcoins from the list as the service is now defunct (dead), which helps keep the directory up to date.

### Checklist:
- [x] The API is a public/free API.
- [x] The entry is added to the correct category
- [x] The entry is in alphabetical order
- [x] The entry follows the format: `[Name](Link) | Description | Auth | HTTPS | CORS`