### PR TITLE
Add LaserSell API

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ API | Description | Auth | HTTPS | CORS |
 | [INFURA Ethereum](https://infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes | Yes |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
+| [LaserSell](https://docs.lasersell.io/api/overview) | Automated sell transactions and exit intelligence for Solana DEXs | `apiKey` | Yes | Unknown |
 | [Localbitcoins](https://localbitcoins.com/api-docs/) | P2P platform to buy and sell Bitcoins | No | Yes | Unknown |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |


### PR DESCRIPTION
## Add LaserSell API

### Description

Adds [LaserSell](https://docs.lasersell.io/api/overview) to the Cryptocurrency category.

LaserSell is a REST and WebSocket API for building automated sell transactions and exit intelligence on Solana DEXs. It supports Raydium, Pump.fun, PumpSwap, and Meteora.

- **Free tier available** with no subscription required
- **API key authentication**
- **Documentation:** https://docs.lasersell.io/api/overview
- **SDKs:** TypeScript, Python, Rust, Go

### Checklist

- [x] Entry is placed in alphabetical order within the Cryptocurrency category
- [x] Description is under 100 characters
- [x] API has proper documentation
- [x] API offers a free tier
- [x] HTTPS is supported
- [x] Single API per pull request
