### PR TITLE
Add ProofBets API to Cryptocurrency category

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [ProofBets](https://proofbets.com/developers/) | Crypto casino data: bonuses, EV calculator, P2P platforms, on-chain verification | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
ProofBets (https://proofbets.com) is a crypto casino and P2P prediction market data API with 16 REST endpoints covering 50+ casinos and 7 P2P platforms (Polymarket, Kalshi, Azuro, etc.).

Features:
- Casino data: bonuses, withdrawal speeds, provably fair verification
- EV calculator, bonus code checker, on-chain wallet verification
- P2P platform comparisons with live TVL from DeFi Llama
- Free tier: 20 req/min (no key), 100 req/min with API key
- OpenAPI 3.1 spec: https://proofbets.com/openapi.yaml

Added under Cryptocurrency section, alphabetically between Poloniex and Solana JSON RPC. All required table columns included: API name, description, auth (apiKey), HTTPS (Yes), CORS (Unknown).