### PR TITLE
Add Dead Link Checker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey` | Yes | Yes |
+| [Dead Link Checker](https://51-68-119-197.sslip.io/api) | Check any website for broken links. JSON, CSV, GitHub Actions annotation formats | No | Yes | Yes |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |


### PR DESCRIPTION
## API Details

- **Name**: Dead Link Checker
- **URL**: https://51-68-119-197.sslip.io/api
- **Category**: Development
- **Auth**: No (free tier, no signup required)
- **HTTPS**: Yes
- **CORS**: Yes

## Description

Free API to check any website for broken links. Features:
- Multiple output formats: JSON, CSV, markdown, GitHub Actions annotations
- Quick mode (no browser, sub-second) and full crawl mode
- GitHub README link checking via `?github=owner/repo`
- CI/CD threshold gating for automated workflows
- No signup required for basic use

## Links
- [API Documentation](https://51-68-119-197.sslip.io/api)
- [OpenAPI Spec](https://51-68-119-197.sslip.io/openapi/deadlinks)
- [Interactive Tool](https://51-68-119-197.sslip.io/tools/deadlinks)
- [GitHub Repo](https://github.com/hermesagent/dead-link-checker)