### PR TITLE
docs: fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1500,7 +1500,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [Virushee](https://api.virushee.com/) | Virushee file/data scanning | No | Yes | Yes |
-| [VulDB](https://vuldb.com/?doc.api) | VulDB API allows to initiate queries for one or more items along with transactional bots | `apiKey` | Yes | Unknown |
+| [VulDB](https://vuldb.com/?doc.api) | VulDB API allows you to initiate queries for one or more items along with transactional bots | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Changed 'VulDB API allows to initiate' to 'VulDB API allows you to initiate' for better grammar.