### PR TITLE
Remove dead link: PlaceKitten (placekitten.com) returns error 521

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ API | Description | Auth | HTTPS | CORS
 | [Petfinder](https://www.petfinder.com/developers/) | Petfinder is dedicated to helping pets find homes, another resource to get pets adopted | `apiKey` | Yes | Yes |
 | [PlaceBear](https://placebear.com/) | Placeholder bear pictures | No | Yes | Yes |
 | [PlaceDog](https://place.dog) | Placeholder Dog pictures | No | Yes | Yes |
-| [PlaceKitten](https://placekitten.com/) | Placeholder Kitten pictures | No | Yes | Yes |
 | [RandomDog](https://random.dog/woof.json) | Random pictures of dogs | No | Yes | Yes |
 | [RandomDuck](https://random-d.uk/api) | Random pictures of ducks | No | Yes | No |
 | [RandomFox](https://randomfox.ca/floof/) | Random pictures of foxes | No | Yes | No |


### PR DESCRIPTION
placekitten.com is currently returning a **521 "Web server is down"** error (verified on 2026-03-05). Removing the dead entry from the Animals section.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] - [x] My addition is ordered alphabetically
- [ ] - [x] My submission has a useful description
- [ ] - [x] The description does not have more than 100 characters
- [ ] - [x] The description does not end with punctuation
- [ ] - [x] Each table column is padded with one space on either side
- [ ] - [x] I have searched the repository for any relevant issues or pull requests
- [ ] - [x] Any category I am creating has the minimum requirement of 3 items
- [ ] - [x] All changes have been [squashed][squash-link] into a single commit
[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>