### PR TITLE
Add Frostbyte API to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |
+| [Frostbyte](https://frostbyte-landing.vercel.app) | Real-time prices for 500+ cryptocurrencies, no signup required | No | Yes | Yes |
 | [FTX](https://docs.ftx.com/) | Complete REST, websocket, and FTX APIs to suit your algorithmic trading needs | `apiKey` | Yes | Yes |
 | [Gateio](https://www.gate.io/api2) | API provides spot, margin and futures trading operations | `apiKey` | Yes | Unknown |
 | [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |


### PR DESCRIPTION
Added [Frostbyte](https://frostbyte-landing.vercel.app) to the Cryptocurrency section.

- **Auth**: No authentication required
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: Real-time prices for 500+ cryptocurrencies, no signup required

The API returns live prices for 500+ tokens in a single request via a simple REST endpoint. No API key needed.

**Example**:
```bash
curl https://agent-gateway-kappa.vercel.app/prices
```