### PR TITLE
Add Frostbyte API to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Country](http://country.is/) | Get your visitor's country from their IP | No | Yes | Yes |
 | [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
 | [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
+| [Frostbyte](https://frostbyte-landing.vercel.app) | IP geolocation with country, city, timezone and coordinates | No | Yes | Yes |
 | [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
 | [Geoapify](https://www.geoapify.com/api/geocoding-api/) | Forward and reverse geocoding, address autocomplete | `apiKey` | Yes | Yes |
 | [Geocod.io](https://www.geocod.io/) | Address geocoding / reverse geocoding in bulk | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [Frostbyte](https://frostbyte-landing.vercel.app) to the Geocoding section.

- **Auth**: No authentication required
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: IP geolocation with country, city, timezone and coordinates

Returns geolocation data for any IP address including country, city, region, timezone, and lat/lon coordinates. No API key needed for basic lookups.

**Example**:
```bash
curl https://agent-gateway-kappa.vercel.app/ip
```