### PR TITLE
Add ParseFlow to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [ParseFlow](https://parseflow-dashboard.vercel.app) | Extract structured data from invoices and documents (PDF/image to JSON) | `apiKey` | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## API Name
ParseFlow

## API Description
ParseFlow is a document parsing API that extracts structured JSON from invoices, receipts, and documents. Send a PDF or image, get back clean data: vendor, invoice number, dates, totals, line items, currency.

## API Homepage
https://parseflow-dashboard.vercel.app

## API Documentation
https://api-ebon-tau-30.vercel.app/health (OpenAPI spec available)

## Auth
`apiKey` — passed as `X-API-Key` header

## HTTPS
Yes

## CORS
Yes

## Category
Documents & Productivity

## Checklist
- [x] I have read the [contributing guide](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] The API is publicly accessible
- [x] The entry is alphabetically ordered within its category
- [x] Auth, HTTPS, and CORS values are accurate