### PR TITLE
Add ProofBets API — Crypto casino data with on-chain verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [ProofBets](https://proofbets.com/developers/) | Crypto casino reviews, bonuses, prediction markets, and World Cup odds with on-chain verification | `apiKey` | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What I'm adding
ProofBets is a free REST API (16 endpoints) for crypto casino data, including reviews, verified bonus codes, prediction market fees, and World Cup 2026 odds. Data is verified with on-chain checks via Etherscan. OpenAPI 3.1 spec available at proofbets.com/openapi.yaml. Free tier: 20 req/min anonymous, 100 req/min with key.

**API URL:** https://proofbets.com/developers/

## Checklist
- [x] Alphabetical order
- [x] Follows contribution guidelines
- [x] Link is working
- [x] Description is concise
- [x] HTTPS supported
- [x] CORS enabled