### PR TITLE
Add myip.casa IP intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FullHunt](https://api-docs.fullhunt.io/#introduction) | Searchable attack surface database of the entire internet | `apiKey` | Yes | Unknown |
 | [GitGuardian](https://api.gitguardian.com/doc) | Scan files for secrets (API Keys, database credentials) | `apiKey` | Yes | No |
 | [GreyNoise](https://docs.greynoise.io/reference/get_v3-community-ip) | Query IPs in the GreyNoise dataset and retrieve a subset of the full IP context data | `apiKey` | Yes | Unknown |
+| [myip.casa](https://myip.casa/developer) | Privacy-first IP intelligence API providing geolocation, ASN lookup and VPN / proxy detection | `apiKey` | Yes | Unknown |
 | [HackerOne](https://api.hackerone.com/) | The industry’s first hacker API that helps increase productivity towards creative bug bounty hunting | `apiKey` | Yes | Unknown |
 | [Hashable](https://hashable.space/pages/api/) | A REST API to access high level cryptographic functions and methods | No | Yes | Yes |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds myip.casa, a privacy-first IP intelligence API.

Documentation:
https://myip.casa/developer

Features:
- IP geolocation
- ASN / ISP lookup
- VPN / proxy detection
- IPv4 & IPv6 support
- Bulk IP lookup

No tracking, no analytics, and instant API key access.