### PR TITLE
Add Cat Facts API to Animals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ API | Description | Auth | HTTPS | CORS
 | [The Dog](https://thedogapi.com/) | A public service all about Dogs, free to use when making your fancy new App, Website or Service | `apiKey` | Yes | No |
 | [xeno-canto](https://xeno-canto.org/explore/api) | Bird recordings | No | Yes | Unknown |
 | [Zoo Animals](https://zoo-animal-api.herokuapp.com/) | Facts and pictures of zoo animals | No | Yes | Yes |
-
+| [| Cat Facts | Daily cat facts | No | Yes | Unknown | https://catfact.ninja |]
 **[⬆ Back to Index](#index)**
 <br >
 <br >


### PR DESCRIPTION
This PR adds the Cat Facts API to the Animals section of the public APIs list.
The API provides daily cat facts and is publicly accessible without authentication.