### PR TITLE
Add Rotate Aviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
+| [Rotate Aviation](https://rotatepilot.com/developers) | ATPL Exam Questions, Airport Data, and Aviation Glossary | No | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add Rotate Aviation to Transportation

**API:** [Rotate Aviation](https://rotatepilot.com/developers)

**Description:** Free REST API providing 2,200+ ATPL pilot exam questions, 500+ airport data (ICAO/IATA lookup), and 500+ aviation glossary terms.

**Auth:** No (no API key required)
**HTTPS:** Yes
**CORS:** Yes

### Endpoints
- `GET /api/v1/question` — Random ATPL exam questions with explanations
- `GET /api/v1/airport/{code}` — Airport lookup by ICAO or IATA code
- `GET /api/v1/glossary/{term}` — Aviation terminology definitions
- `GET /api/v1/stats` — Platform statistics

### Quick test
```bash
curl https://rotatepilot.com/api/v1/question?subject=meteorology
curl https://rotatepilot.com/api/v1/airport/KJFK
curl https://rotatepilot.com/api/v1/glossary/tcas
```