### PR TITLE
Add ArkForge Trust Layer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1498,6 +1498,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
+| [Trust Layer](https://arkforge.fr/trust/docs) | Certifying proxy with cryptographic proof for any API call | `apiKey` | Yes | Yes |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [Virushee](https://api.virushee.com/) | Virushee file/data scanning | No | Yes | Yes |
 | [VulDB](https://vuldb.com/?doc.api) | VulDB API allows to initiate queries for one or more items along with transactional bots | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds **ArkForge Trust Layer** to the Security section.

| Field | Value |
|-------|-------|
| API | [ArkForge Trust Layer](https://arkforge.fr/trust) |
| Description | Cryptographic proof API for HTTP exchanges — Ed25519, RFC 3161, and Sigstore Rekor attestation |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |

## Checklist

- [x] API has a free tier (500 proofs/month, no credit card required)
- [x] Description is under 100 characters (95 chars)
- [x] Entry is alphabetically ordered within the Security section (after "Application Environment Verification", before "BinaryEdge")
- [x] HTTPS supported
- [x] CORS supported
- [x] PR title follows format "Add Api-name API"