### PR TITLE
Add Satoshi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [Satoshi](https://bitcoinsapi.com/docs) | Self-hosted Bitcoin Core REST API with blockchain, mempool, and network data | `apiKey` | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Satoshi to the Cryptocurrency section. Self-hosted Bitcoin Core REST API providing blockchain, mempool, and network data endpoints.

- Link: https://bitcoinsapi.com/docs
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes