### PR TITLE
Add Trend Seeker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tenders in Romania](https://tenders.guru/ro/api) | Get data for procurements in Romania in JSON format | No | Yes | Unknown |
 | [Tenders in Spain](https://tenders.guru/es/api) | Get data for procurements in Spain in JSON format | No | Yes | Unknown |
 | [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
+| [Trend Seeker](https://trend-seeker.app/docs/api) | Validated business ideas extracted from online discussions | `apiKey` | Yes | No |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
 


### PR DESCRIPTION
Adds Trend Seeker to the Business category.

- **API docs**: https://trend-seeker.app/docs/api
- **Description**: Validated business ideas extracted from online discussions
- **Auth**: `apiKey` (optional - works without auth at lower rate limits)
- **HTTPS**: Yes
- **CORS**: No

The API provides free access to a database of business ideas scored by evidence strength, market metrics, and validation confidence. Each idea is extracted from real online discussions (Reddit, forums). No auth required for basic access (10 req/min, 20 results/page).