### PR TITLE
docs: add Agent Gateway API to Development category

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
+| [Agent Gateway](https://agent-gateway-kappa.vercel.app) | 40+ services for AI agents including web scraping, screenshots, code execution, crypto data, agent memory, and file storage | apiKey | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |


### PR DESCRIPTION
This PR adds the Agent Gateway API to the Development category in the public APIs list.

Agent Gateway provides 40+ services for AI agents including web scraping, screenshots, code execution, crypto data, agent memory, and file storage.

API Details

API: Agent Gateway

Link: https://agent-gateway-kappa.vercel.app

Documentation: https://api-catalog-three.vercel.app/docs

Auth: apiKey

HTTPS: Yes

CORS: Yes

Related Issue

Closes #5367