### PR TITLE
Add BGPT MCP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
+| [BGPT MCP](https://bgpt.pro/mcp/) | Search scientific papers with structured experimental data from full-text studies | No | Yes | Yes |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1468,7 +1468,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
-| [BGPT MCP](https://bgpt.pro/mcp/) | Search scientific papers with structured experimental data from full-text studies | No | Yes | Yes |
+| [BGPT](https://bgpt.pro/mcp/) | Search scientific papers with structured full-text experimental data | No | Yes | Yes |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |


### PR DESCRIPTION
Adds [BGPT MCP](https://bgpt.pro/mcp/) to the **Science & Math** category.

- **Description:** Search scientific papers with structured experimental data from full-text studies
- **Auth:** No (50 free searches, no API key needed)
- **HTTPS:** Yes
- **CORS:** Yes
- **GitHub:** https://github.com/connerlambden/bgpt-mcp
- **Docs:** https://bgpt.pro/mcp/