### PR TITLE
Add WorldTimeAPI to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
+| [WorldTimeAPI](http://worldtimeapi.org/) | Get current time for various timezones | No | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
Added WorldTimeAPI - a free timezone API that provides current time for various timezones.

**API Details:**
- URL: http://worldtimeapi.org/
- Authentication: None required
- HTTPS: Supported
- CORS: Enabled

This is a simple, useful API for developers who need timezone information.