### PR TITLE
Add WalletIQ API to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
+| [WalletIQ](https://walletiq-zeta.vercel.app/docs) | EVM wallet intelligence: age, risk score, DeFi usage, labels | No | Yes | Yes |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |


### PR DESCRIPTION
## Add WalletIQ

**Category:** Cryptocurrency

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [WalletIQ](https://walletiq-zeta.vercel.app/docs) | EVM wallet intelligence: age, risk score, DeFi usage, labels | No | Yes | Yes |

### What it does
WalletIQ profiles any EVM wallet address across 5+ chains (Ethereum, Avalanche, Arbitrum, Base, Optimism). Returns wallet age, transaction stats, DeFi protocol usage (75+ protocols), risk scoring, and behavioral labels.

### Free access
The playground endpoint is free and requires no authentication (IP rate-limited to 5 requests/min):

```bash
curl https://walletiq-zeta.vercel.app/api/v1/playground/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
```

### Documentation
Full API docs: https://walletiq-zeta.vercel.app/docs

### CORS
CORS is fully supported for browser-based requests.