### PR TITLE
Add Xquik API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1571,6 +1571,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
+| [Xquik](https://docs.xquik.com) | X (Twitter) automation — search, user lookup, extraction, engagement, draws & webhooks | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary

- Adds **Xquik** to the **Social** section
- X (Twitter) automation API - tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, trending topics, write actions & webhooks
- Auth: `apiKey`, HTTPS: Yes, CORS: Yes
- Docs: https://docs.xquik.com
