### PR TITLE
Fix CoinStats docs link and auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
 | [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
 | [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |
-| [CoinStats](https://documenter.getpostman.com/view/5734027/RzZ6Hzr3?version=latest) | Crypto Tracker | No | Yes | Unknown |
+| [CoinStats](https://coinstats.app/api-docs/) | Crypto Tracker | No | Yes | Unknown |
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | Cryptocurrency data | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
 | [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
 | [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |
-| [CoinStats](https://coinstats.app/api-docs/) | Crypto Tracker | No | Yes | Unknown |
+| [CoinStats](https://coinstats.app/api-docs/) | Crypto Tracker | `apiKey` | Yes | Unknown |
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | Cryptocurrency data | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |


### PR DESCRIPTION
## Summary
- replace the old CoinStats Postman docs URL with the current CoinStats API docs URL
- update the CoinStats auth field from `No` to `apiKey`

## Why
- the existing Postman link points to the old CoinStats API documentation
- the current official documentation is published at `https://coinstats.app/api-docs/`
- the official auth docs show API key authentication via the `X-API-KEY` header

## Verification
- validated the updated entry with `check_entry(...)` from `scripts/validate/format.py`
- validated the added link with `python scripts/validate/links.py` against the updated PR additions
- ran `python -m unittest discover tests/ --verbose` in `scripts/`