### PR TITLE
Add Elden Ring API to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dota 2](https://docs.opendota.com/) | Provides information about Player stats , Match stats, Rankings for Dota 2 | `apiKey` | Yes | Unknown |
 | [Dungeons and Dragons](https://www.dnd5eapi.co/docs/) | Reference for 5th edition spells, classes, monsters, and more | No | No | No |
 | [Dungeons and Dragons (Alternate)](https://open5e.com/) | Includes all monsters and spells from the SRD (System Reference Document) as well as a search API | No | Yes | Yes |
+| [Elden Ring](https://eldenring.fanapis.com) | Elden Ring items, bosses, and more | No | Yes | Yes |
 | [Eve Online](https://esi.evetech.net/ui) | Third-Party Developer Documentation | `OAuth` | Yes | Unknown |
 | [FFXIV Collect](https://ffxivcollect.com/) | Final Fantasy XIV data on collectables | No | Yes | Yes |
 | [FIFA Ultimate Team](https://www.easports.com/fifa/ultimate-team/api/fut/item) | FIFA Ultimate Team items API | No | Yes | Unknown |


### PR DESCRIPTION
## Description
I have found and added the Elden Ring API to the `Games & Comics` category.
- **API**: Elden Ring API
- **Description**: Elden Ring items, bosses, and more
- **Auth**: No (It is open to everyone without an API key)
- **HTTPS**: Yes (Verified https://eldenring.fanapis.com works properly)
- **CORS**: Yes (Tested locally with `OPTIONS` yielding `access-control-allow-origin: *`)

Verified that it works smoothly and added alphabetically to the appropriate section as per the `CONTRIBUTING.md` guidelines.