### PR TITLE
Add Apiverket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Government
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Apiverket](https://apiverket.se/docs) | Unified API for Swedish public data — weather, transport, companies, and 30+ agencies | `apiKey` | Yes | Yes |
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |


### PR DESCRIPTION
Apiverket is a unified REST API for Swedish public/government data. It aggregates 30+ government agencies (SMHI, SCB, Bolagsverket, Riksbanken, Trafikverket, etc.) into a single REST interface with consistent JSON responses.

- **Docs:** https://apiverket.se/docs
- **OpenAPI spec:** https://apiverket.se/openapi.json
- **Auth:** API key (Bearer token)
- **HTTPS:** Yes
- **CORS:** Yes