### PR TITLE
Add Polymarket Scanner API to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [Polymarket Scanner](https://github.com/vesper-astrena/polymarket-scanner-api) | Real-time arbitrage detection across 12,000+ prediction markets | No | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [Polymarket Scanner API](https://github.com/vesper-astrena/polymarket-scanner-api) to the Cryptocurrency section.

- **Description:** Real-time arbitrage detection across 12,000+ prediction markets
- **Auth:** No (free tier, no API key needed)
- **HTTPS:** Yes
- **CORS:** Yes

The API scans Polymarket prediction markets for pricing anomalies (exclusive outcome mispricings, ladder contradictions, cross-market conflicts) and returns results as JSON.

Free tier: 3 requests/day, no authentication required.