### PR TITLE
Add Valix - Spanish fiscal identifier validation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |
+| [Valix](https://getvalix.io) | Validate Spanish fiscal identifiers: NIF, NIE, CIF, IBAN | `apiKey` | Yes | Yes | |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## API added
- **Name**: Valix
- **URL**: https://getvalix.io
- **Description**: Validate Spanish fiscal identifiers: NIF, NIE, CIF, IBAN
- **Category**: Finance
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
