### PR TITLE
Add RevAddress API

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown | |
+| [RevAddress](https://revaddress.com/docs) | USPS address validation, batch verification, and shipping rates | `apiKey` | Yes | Yes | |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
 | [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes | |
 | [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
## Summary
- Adds RevAddress to the **Data Validation** category
- USPS v3 address validation, batch verification (50 addresses/call), and shipping rates
- Free tier: 1,000 requests/month, no credit card required
- Auth: API key, HTTPS: Yes, CORS: Yes

## Link
https://revaddress.com/docs