### PR TITLE
Add Himalayas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | Jobs with GraphQL | No | Yes | Yes |
 | [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Yes | Unknown |
 | [GraphQL Jobs](https://graphql.jobs/docs/api/) | Jobs with GraphQL | No | Yes | Yes |
+| [Himalayas](https://himalayas.app/api) | Remote job board and search engine | No | Yes | Yes |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds [Himalayas](https://himalayas.app/api) to the Jobs section.

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [Himalayas](https://himalayas.app/api) | Remote job board and search engine | No | Yes | Yes |

- Auth: No (fully public, no key required)
- HTTPS: Yes
- CORS: Yes
- Placed alphabetically between GraphQL Jobs and Jobs2Careers