### PR TITLE
Add Sirius Prediction Market API

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
+| [Sirius Prediction Market](https://rapidapi.com/louismichalot/api/sirius-prediction-market-api) | Real-time prediction market odds, signals and sentiment from 28+ sources | `apiKey` | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Added Sirius Prediction Market API to the Finance category.

- **Description:** Real-time prediction market odds, signals and sentiment from 28+ sources
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Link:** https://rapidapi.com/louismichalot/api/sirius-prediction-market-api

Free tier available (50 requests/day, no credit card required).