### PR TITLE
Add Screenshot PDF API

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
+| [Screenshot PDF](https://rapidapi.com/louismichalot/api/screenshot-pdf-api) | Screenshot URLs, generate PDFs, extract metadata, render HTML to images | `apiKey` | Yes | Yes |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |


### PR DESCRIPTION
Added Screenshot PDF API to the Documents & Productivity category.

- **Description:** Screenshot URLs, generate PDFs, extract metadata, render HTML to images
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Link:** https://rapidapi.com/louismichalot/api/screenshot-pdf-api

Free tier available (20 screenshots/day, no credit card required).