### PR TITLE
Remove Yelp API from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,7 +1298,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
 | [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth` | Yes | Unknown |
 | [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
-| [Yelp](https://www.yelp.com/developers/documentation/v3) | Find Local Business | `OAuth` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary\n- remove the Yelp API entry from the README list\n\n## Why\nYelp API is no longer free and the listed link is broken.