### PR TITLE
Add xpay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes | |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |
 | [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets Stock Comments Sentiment Analysis | No | Yes | Unknown | |
+| [xpay](https://docs.xpay.sh) | AI agent payments via x402 protocol with USDC micropayments on Base blockchain | No | Yes | Yes | |
 | [Yahoo Finance](https://www.yahoofinanceapi.com/) | Real time low latency Yahoo Finance API for stock market, crypto currencies, and currency exchange | `apiKey` | Yes | Yes | |
 | [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth` | Yes | Yes | |
 | [Zoho Books](https://www.zoho.com/books/api/v3/) | Online accounting software, built for your business | `OAuth` | Yes | Unknown | |


### PR DESCRIPTION
Adding xpay — an AI agent payment API using the x402 protocol (HTTP 402 Payment Required) with USDC micropayments on Base blockchain.

- **Auth**: No (x402 handles payment via HTTP 402 responses — no API keys needed)
- **HTTPS**: Yes
- **CORS**: Yes
- **Docs**: https://docs.xpay.sh
- **Website**: https://xpay.sh