### PR TITLE
Add Chakras to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BitWarden](https://bitwarden.com/help/api/) | Best open-source password manager | `OAuth` | Yes | Unknown |
 | [Botd](https://github.com/fingerprintjs/botd) | Botd is a browser library for JavaScript bot detection | `apiKey` | Yes | Yes |
 | [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | Bugcrowd API for interacting and tracking the reported issues programmatically | `apiKey` | Yes | Unknown |
+| [Chakras](https://api.chakras.dev/api/docs) | Website security scanning — headers, SSL, tech stack and vulnerability checks | No | Yes | Yes |
 | [Censys](https://search.censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [Chakras](https://api.chakras.dev/api/docs) to the Security section.

**What it does:** Free API for website security scanning — check security headers, SSL certificates, technology stack detection, and HTTP status/redirect tracing.

**Endpoints (no auth required):**
- `POST /api/v1/public/tools/headers-check`
- `POST /api/v1/public/tools/ssl-check`
- `POST /api/v1/public/tools/tech-detect`
- `POST /api/v1/public/tools/http-status`
- `POST /api/v1/public/tools/scan-all`

**Auth:** No (fully free, no signup needed)
**HTTPS:** Yes
**CORS:** Yes
**Docs:** https://api.chakras.dev/api/docs (Swagger UI)