### PR TITLE
Add LobsterMail API to Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
+| [LobsterMail](https://api.lobstermail.ai/v1/docs/openapi) | Email infrastructure for AI agents — create inboxes, send/receive email, prompt injection scanning | `apiKey` | Yes | Yes |
 | [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |
 | [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |
 | [mail.tm](https://docs.mail.tm) | Temporary Email Service | No | Yes | Yes |


### PR DESCRIPTION
Added [LobsterMail](https://lobstermail.ai/) to the Email section.

**API Documentation:** https://api.lobstermail.ai/v1/docs/openapi

LobsterMail provides email infrastructure for AI agents. Agents create their own inboxes, send/receive email, with built-in prompt injection scanning. REST API with OpenAPI 3.1 spec.

- Auth: apiKey (Bearer token)
- HTTPS: Yes
- CORS: Yes