### PR TITLE
Add PostalDataPI API to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pinball Map](https://pinballmap.com/api/v1/docs) | A crowdsourced map of public pinball machines | No | Yes | Yes |
 | [positionstack](https://positionstack.com/) | Forward & Reverse Batch Geocoding REST API | `apiKey` | Yes | Unknown |
 | [Postali](https://postali.app/api) | Mexico Zip Codes API | No | Yes | Yes |
+| [PostalDataPI](https://postaldatapi.com) | Postal code lookup for 70+ countries | `apiKey` | Yes | Yes |
 | [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | Provide geolocation data based on postcode for Dutch addresses | No | No | Unknown |
 | [Postcodes.io](https://postcodes.io) | Postcode lookup & Geolocation for the UK | No | Yes | Yes |
 | [Queimadas INPE](https://queimadas.dgi.inpe.br/queimadas/dados-abertos/) | Access to heat focus data (probable wildfire) | No | Yes | Unknown |


### PR DESCRIPTION
Adds PostalDataPI to the Geocoding section.

PostalDataPI is a global postal code API serving 240+ countries with sub-10ms responses. Free tier (1,000 queries, no credit card), official Python and Node.js SDKs, and an MCP server for AI agents.

Site: https://postaldatapi.com
Docs: https://docs.postaldatapi.com