### PR TITLE
Add SharpAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1599,6 +1599,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
+| [SharpAPI](https://sharpapi.io) | Real-time sports betting odds with EV detection and arbitrage alerts | `apiKey` | Yes | Yes |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |
 | [Sport Places](https://developers.decathlon.com/products/sport-places) | Crowd-source sports places around the world | No | Yes | No |


### PR DESCRIPTION
Added [SharpAPI](https://docs.sharpapi.io) to the Sports & Fitness category.

SharpAPI is a real-time sports betting odds API with a free tier (12 requests/minute, no credit card required). It aggregates odds from 20+ sportsbooks and provides built-in +EV detection and arbitrage alerts.

- **Documentation**: https://docs.sharpapi.io
- **Auth**: API key
- **HTTPS**: Yes
- **CORS**: Yes
- **Free tier**: 12 req/min, no credit card, no time limit