### PR TITLE
Add ACLED API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [18F](http://18f.github.io/API-All-the-X/) | Unofficial US Federal Government API Development | No | No | Unknown |
+| [ACLED](https://acleddata.com/api-documentation/getting-started) | Global conflict, protest, and political violence event data | `OAuth` | Yes | Unknown |
 | [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds ACLED to the Open Data section.

Why this API:
- official public API documentation is available
- HTTPS is supported
- OAuth authentication is documented
- the API provides conflict, protest, and political violence event data