### PR TITLE
Add EnrichAPI - B2B lead intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
+| [EnrichAPI](http://72.62.52.171:8000) | B2B lead intelligence: give a company URL, get tech stack, ICP fit score, pain hypothesis, and outreach angle | `apiKey` | No | Yes |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What is EnrichAPI?

EnrichAPI is a B2B lead intelligence API. Give it a company URL and it returns:
- Company profile (size, stage, industry, business model)
- Tech stack detection (CRM, hosting, analytics, payments)
- ICP fit scoring (0-100)
- Pain hypothesis — why they might need your product
- Personalized outreach angle

**Category:** Business  
**Auth:** apiKey  
**HTTPS:** No (HTTP)  
**CORS:** Yes

**Endpoint:** http://72.62.52.171:8000  
**Free trial:** `curl -X POST http://72.62.52.171:8000/keys/trial`  
**Docs:** http://72.62.52.171:8000/docs

Use cases: SDR automation, sales pipeline enrichment, agentic sales workflows, CRM enrichment.

The API is live and production-ready, with Stripe billing integration for paid tiers.