### PR TITLE
Add TikTool Live API to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
 | [Telegraph](https://telegra.ph/api) | Create attractive blogs easily, to share | `apiKey` | Yes | Unknown |
 | [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth` | Yes | Unknown |
+| [TikTool Live](https://tik.tools/docs) | Real-time TikTok LIVE stream events via WebSocket | `apiKey` | Yes | Yes |
 | [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adding TikTool Live - a WebSocket API for real-time TikTok LIVE stream data.

- Category: Social
- Auth: apiKey (free tier available, 50 req/day, no credit card)
- HTTPS: Yes
- CORS: Yes
- Docs: https://tik.tools/docs

Provides real-time events (chat, gifts, likes, follows, viewer counts, battles) from any TikTok LIVE stream. SDKs for Node.js and Python.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
