### PR TITLE
Add ReleaseRun Badge API to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey` | Yes | No |
+| [ReleaseRun Badge API](https://releaserun.com/badge-api/) | Generate SVG badges showing real-time health grades, EOL status, and CVE counts for 300+ technologies | No | Yes | Yes |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |
 | [SavePage.io](https://www.savepage.io) | A free, RESTful API used to screenshot any desktop, or mobile website | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description

Adds [ReleaseRun Badge API](https://releaserun.com/badge-api/) to the Development section.

**API endpoint:** `GET https://badge.releaserun.com/badge/{technology}/{type}`

Generates SVG badges showing real-time data for 300+ technologies (Node.js, Python, Go, Rust, Kubernetes, Docker, PostgreSQL, and more):
- `health` — Overall health grade A-F
- `version` — Current vs latest version
- `eol` — End-of-life countdown
- `cve` — Unfixed CVE count from OSV.dev

**Auth:** None required  
**HTTPS:** Yes  
**CORS:** Yes (all origins)  

Example: `https://badge.releaserun.com/badge/nodejs/health`  
Docs: https://releaserun.com/badge-api/

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] All URLs in this PR are accessible
- [x] Entry includes description, auth, HTTPS, and CORS fields
- [x] Entry added in alphabetical order in the correct section