### PR TITLE
Add Markbase - USPTO Trademark Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
+| [Markbase](https://markbase.co) | Search 14M+ USPTO trademarks with fuzzy search and autocomplete | No | Yes | Yes |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |


### PR DESCRIPTION
## Add Markbase API

**API:** [Markbase](https://markbase.co)  
**Category:** Business  
**Auth:** No  
**HTTPS:** Yes  
**CORS:** Yes  

### Description
Markbase is a free REST API for searching, filtering, and retrieving data from 14M+ U.S. trademarks in the USPTO registry. Features include fuzzy search, real-time autocomplete, faceted results, and daily data syncs.

### Links
- Website: https://markbase.co
- API Docs: https://api.markbase.co/docs
- OpenAPI Spec: https://api.markbase.co/openapi.json