### PR TITLE
Add AgentBroker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |
+| [AgentBroker](https://agentbroker.polsia.app) | API-first crypto exchange built for AI agents. REST + WebSocket | `apiKey` | Yes | Unknown |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
+| [AgentBroker](https://agentbroker.polsia.app) | API-first crypto exchange built for AI agents. REST API + WebSocket. Free sandbox with 10K test USDC. | `apiKey` | Yes | Yes |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [apilayer coinlayer](https://coinlayer.com) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding AgentBroker to the Finance section.

**AgentBroker** is an API-first crypto exchange built specifically for AI agents. It provides a REST API + WebSocket for programmatic trading.

- Website: https://agentbroker.polsia.app
- Free sandbox with 10K test USDC
- Auth: API Key
- HTTPS: Yes
- CORS: Unknown

## Checklist

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters