### PR TITLE
Add Arch Tools API — 61 developer tools behind one key

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
+| [Arch Tools](https://archtools.dev/docs) | 58 developer tools API — AI generation, web scraping, crypto, voice, email | `X-Api-Key` | Yes | Yes | |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |


### PR DESCRIPTION
Arch Tools provides 58 API tools behind one key with a free tier (250 credits). https://archtools.dev