### PR TITLE
Add Hunter Education API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
+| [Hunter Education](https://www.onlinehuntereducation.com/developers) | Hunter education requirements for all 50 US states | No | Yes | Yes |
 | [INEI](http://iinei.inei.gob.pe/microdatos/) | Peruvian Statistical Government Open Data | No | No | Unknown |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
 | [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |


### PR DESCRIPTION
Free public JSON API providing hunter education requirements for all 50 U.S. states. Returns minimum age, online-only eligibility, field day requirements, course costs, and certifying agency for each state. 

No authentication required. CORS enabled. Documentation at https://www.onlinehuntereducation.com/developers

**Example:** `GET https://www.onlinehuntereducation.com/api/requirements/texas`