### PR TITLE
Add StackData SaaS Pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Yes | Unknown |
+| [StackData SaaS Pricing](https://greg-rg-git.github.io/stackdata-store/api/) | Verified pricing data for 797 SaaS tools across 13 categories | No | Yes | Yes |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes | Unknown |
 | [Tenders in Hungary](https://tenders.guru/hu/api) | Get data for procurements in Hungary in JSON format | No | Yes | Unknown |
 | [Tenders in Poland](https://tenders.guru/pl/api) | Get data for procurements in Poland in JSON format | No | Yes | Unknown |


### PR DESCRIPTION
## What this adds

A free, public API serving verified SaaS pricing data — no auth required, HTTPS, CORS enabled.

- **Endpoint:** https://hubauzvpxuparrvqjytt.supabase.co/functions/v1/pricing-api
- **Docs:** https://greg-rg-git.github.io/stackdata-store/api/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes
- **Data:** 797 SaaS tools across 13 categories (productivity, CRM, devtools, analytics, etc.)
- **Access:** Fully free, no rate limits, no registration

Placed alphabetically in the Business section between Square and SwiftKanban.