### PR TITLE
Add Moltbook Sentiment API to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CoinDCX](https://docs.coindcx.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [CoinDesk](https://old.coindesk.com/coindesk-api/) | CoinDesk's Bitcoin Price Index (BPI) in multiple currencies | No | Yes | Unknown |
 | [CoinGecko](http://www.coingecko.com/api) | Cryptocurrency Price, Market, and Developer/Social Data | No | Yes | Yes |
+| [Moltbook Sentiment](http://187.124.93.57:8080) | AI agent crypto market sentiment + Polymarket + DEX signals | `apiKey` | Yes | Yes |
 | [Coinigy](https://coinigy.docs.apiary.io) | Interacting with Coinigy Accounts and Exchange Directly | `apiKey` | Yes | Unknown |
 | [Coinlib](https://coinlib.io/apidocs) | Crypto Currency Prices | `apiKey` | Yes | Unknown |
 | [Coinlore](https://www.coinlore.com/cryptocurrency-data-api) | Cryptocurrencies prices, volume and more | No | Yes | Unknown |


### PR DESCRIPTION
Adding Moltbook Sentiment API.

- Real-time crypto sentiment from 2M+ AI agent discussions
- Free tier available with demo key
- Also includes Polymarket + DEX Screener data
- MCP server compatible
- GitHub: https://github.com/julybrian-art/moltbook-sentiment-mcp