### PR TITLE
Add DexPaprika API

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
+| [DexPaprika](https://api.dexpaprika.com) | Free DEX and DeFi data across all chains, pools, tokens, and trades | No | Yes | Yes |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
+| [DexPaprika](https://docs.dexpaprika.com) | DEX and DeFi market data covering tokens, pools, prices and OHLCV across 36 blockchains | No | Yes | No |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [DexPaprika](https://docs.dexpaprika.com) to the Cryptocurrency section, between Cryptonator and dYdX.

DexPaprika is a free, keyless API for DEX and DeFi market data: tokens, pools, prices and OHLCV across 36 blockchains.

Before asking for review I re-tested every column against the live API and corrected two things in the row:

- CORS is now `No`. A GET to `https://api.dexpaprika.com/networks` with a third-party `Origin` header returns no `access-control-allow-origin`, so the API is server-side only for now.
- The title now links to the documentation (`https://docs.dexpaprika.com`) instead of the bare API host, and the description states the actual coverage (36 blockchains, confirmed via the `/networks` endpoint) instead of "all chains".

Auth stays `No` (no key or registration) and HTTPS stays `Yes`. I also ran `scripts/validate/format.py` and `scripts/validate/links.py` locally against the change; the row adds no new errors.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (not creating a category)
- [x] All changes have been [squashed](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) into a single commit
