### PR TITLE
Add ZipCheckup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
 | [Website Carbon](https://api.websitecarbon.com/) | API to estimate the carbon footprint of loading web pages | No | Yes | Unknown |
+| [ZipCheckup](https://api.zipcheckup.com/v1/) | EPA water quality, contaminants, and home safety scores by US ZIP code | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary

Adds ZipCheckup API to the Environment section.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [ZipCheckup](https://api.zipcheckup.com/v1/) | EPA water quality, contaminants, and home safety scores by US ZIP code | No | Yes | Yes |

- Free, no auth required
- Placed alphabetically after "Website Carbon" in the Environment section
- Description is under 100 characters