### PR TITLE
Add PreReason

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [PreReason](https://www.prereason.com/docs) | Pre-analyzed Bitcoin and macro market briefings with trend signals and regime classification | `apiKey` | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PreReason to the Cryptocurrency section.

Pre-analyzed Bitcoin and macro market briefings for AI agents. 17 briefings covering BTC, Fed balance sheet, M2, Treasury yields, and cross-asset correlations. Returns markdown or JSON with trend signals, confidence scores, and regime classification.

- **Docs:** https://www.prereason.com/docs
- **Free tier:** Yes (60 requests/hr, 500/day)
- **Auth:** API key (X-API-Key header)
- **HTTPS:** Yes
- **CORS:** Yes