### PR TITLE
Add Chaprola API

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |
+| [Chaprola](https://chaprola.org) | Agent-first data platform with 35 REST endpoints for AI agents | `apiKey` | Yes | Yes |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |


### PR DESCRIPTION
Chaprola is an agent-first data platform. 35 REST endpoints for AI agents to store, query, transform, and compute on structured data through plain HTTP calls. HIPAA-compliant. Free to register and use.

- **URL:** https://chaprola.org
- **API Docs:** https://chaprola.org/openapi.yaml
- **Auth:** API key
- **HTTPS:** Yes
- **CORS:** Yes