### PR TITLE
Add DhanHQ API to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
+| [DhanHQ](https://dhanhq.co/docs/v2/) | Real-time stock trading, order management, and market data API for Indian markets | `apiKey` | Yes | Unknown |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION

## API Name
DhanHQ

## API Documentation URL
https://dhanhq.co/docs/v2/

## Category
Finance

## Description
DhanHQ is a free REST API by Dhan (Indian stock broker) for real-time 
order management, portfolio tracking, live market data, historical 
candle data, and algo trading across NSE, BSE, and MCX exchanges.

## Checklist
- [x] The API has free access
- [x] The API is publicly documented
- [x] HTTPS is supported
- [x] Entry is added in alphabetical order (between Citi and Econdb)
- [x] Description is under 100 characters
- [x] One API per PR
- [x] No duplicate