### PR TITLE
Add Epublys API

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [Epublys](https://epublys.com/v1) | Merge, split, compress, and convert EPUB/PDF ebook files | `apiKey` | Yes | Yes |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Add [Epublys](https://epublys.com) to the Documents & Productivity section.

Epublys is a free REST API for EPUB and PDF ebook manipulation — merge, split, compress, convert (EPUB↔PDF), edit metadata, and validate. Free tier available with API key authentication. HTTPS and CORS supported.

API docs: https://epublys.com/v1