### PR TITLE
Add Karrito API — digital catalog with WhatsApp checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,6 +1514,7 @@ API | Description | Auth | HTTPS | CORS |
 | [eBay](https://developer.ebay.com/) | Sell and Buy on eBay | `OAuth` | Yes | Unknown |
 | [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | Manage shop and interact with listings | `OAuth` | Yes | Unknown |
 | [Flipkart Marketplace](https://seller.flipkart.com/api-docs/FMSAPI.html) | Product listing management, Order Fulfilment in the Flipkart Marketplace | `OAuth` | Yes | Yes |
+| [Karrito](https://karrito.shop/.well-known/openapi.json) | Digital catalog management with WhatsApp checkout — products, orders, discounts, reviews, customers, analytics | `apiKey` | Yes | Yes |
 | [Lazada](https://open.lazada.com/doc/doc.htm) | Retrieve product ratings and seller performance metrics | `apiKey` | Yes | Unknown |
 | [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**API**: [Karrito](https://karrito.shop)
**Category**: Shopping
**OpenAPI Spec**: https://karrito.shop/.well-known/openapi.json
**Auth**: apiKey
**HTTPS**: Yes
**CORS**: Yes

Karrito is a digital catalog builder for WhatsApp sellers in Latin America. The REST API provides endpoints for managing products, categories, orders, discounts, reviews, customers, shipping, and analytics.

MCP server also available: `npx karrito-mcp` (30 tools + 5 resources)