### PR TITLE
Add CSV2GEO to Geocoding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | Open APIs for select European cities | No | Yes | Unknown |
 | [Country](http://country.is/) | Get your visitor's country from their IP | No | Yes | Yes |
 | [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
+| [CSV2GEO](https://csv2geo.com/api/geocoding) | Forward & reverse geocoding, batch processing, places search, divisions, and autocomplete. 461M+ addresses, 200+ countries | `apiKey` | Yes | Yes |
 | [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
 | [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
 | [Geoapify](https://www.geoapify.com/api/geocoding-api/) | Forward and reverse geocoding, address autocomplete | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add CSV2GEO Geocoding API

**API:** [csv2geo.com/api/geocoding](https://csv2geo.com/api/geocoding)

CSV2GEO is a geocoding API with 18 endpoints covering forward & reverse geocoding, batch processing (up to 10,000 per request), places search (72M+ POIs), administrative divisions (4.6M+ boundaries), and address autocomplete.

**Key facts:**
- 461M+ addresses across 200+ countries
- Free tier: 1,000 requests/day, no credit card
- Python SDK: pip install csv2geo
- Node.js SDK: npm install csv2geo-sdk
- OpenAPI spec, Postman & Insomnia collections available
- GitHub: github.com/acenji/csv2geo-api

Auth: API key | HTTPS: Yes | CORS: Yes