### PR TITLE
Add SwapAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
+| [SwapAPI](https://swapapi.dev) | Free DEX aggregator returning executable swap calldata across 46 EVM chains | No | Yes | Yes |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary
- Add SwapAPI to the Cryptocurrency section
- SwapAPI is a free DEX aggregator API that returns executable swap calldata across 46 EVM chains
- No API key, no authentication, no account required

## Links
- Website: https://swapapi.dev
- API: https://api.swapapi.dev
- GitHub: https://github.com/swap-api/swap-api
- Docs: https://swapapi.dev/llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)