### PR TITLE
Add API Status Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ API | Description | Auth | HTTPS | CORS |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 270+ third-party APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
-| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 270+ third-party APIs | No | Yes | Unknown |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 285 third-party APIs | No | Yes | Yes |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
-| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 285 third-party APIs | No | Yes | No |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 285 third-party APIs | No | Yes | Yes |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 270+ third-party APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
-| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 285 third-party APIs | No | Yes | Yes |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status monitoring for 285 third-party APIs | No | Yes | No |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |


### PR DESCRIPTION
API Status Check provides a free, public JSON API for real-time status monitoring of 270+ third-party APIs including OpenAI, AWS, Stripe, GitHub, Vercel, Cloudflare, and more.

**API endpoint:** `GET https://apistatuscheck.com/api/status`

Returns JSON with current operational status for all monitored APIs. No authentication required, HTTPS supported.

Example response:
```json
{
  "count": 272,
  "lastUpdated": "2026-03-20T18:36:05Z",
  "apis": [
    {
      "slug": "chatgpt",
      "name": "ChatGPT",
      "category": "ai",
      "status": "operational"
    }
  ]
}
```

Individual API status: `GET /api/badge/{slug}` (returns SVG badge)

Placed in Development section alphabetically between API Grátis and ApicAgent.