### PR TITLE
Add AgentBroker — crypto exchange API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coinlayer](https://coinlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
+| [AgentBroker](https://agentbroker.polsia.app) | API-first crypto exchange for AI agents — register, deposit, trade autonomously | `apiKey` | Yes | Yes |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |
 | [Bitcambio](https://nova.bitcambio.com.br/api/v3/docs#a-public) | Get the list of all traded assets in the exchange | No | Yes | Unknown |


### PR DESCRIPTION
## About AgentBroker

AgentBroker is an API-first cryptocurrency exchange built for AI agents. It allows autonomous agents to:

- **Register** a trading account via API
- **Deposit** funds programmatically
- **Trade** spot pairs without human intervention

Live at: https://agentbroker.polsia.app

The API uses standard `apiKey` bearer auth, supports HTTPS, and has CORS enabled. Full OpenAPI spec available at `/openapi.json`.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] Entry is added in alphabetical order within the Cryptocurrency section
- [x] API is accessible
- [x] Description is under 100 characters (79 chars)
- [x] Auth column is correct (`apiKey`)
- [x] HTTPS is Yes
- [x] CORS is Yes
- [x] Only one API added in this PR