### PR TITLE
Add The Daily Lesson API

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OwlBot](https://owlbot.info/) | Definitions with example sentence and photo if available | `apiKey` | Yes | Yes |
 | [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data | `apiKey` | Yes | No |
 | [Synonyms](https://www.synonyms.com/synonyms_api.php) | Synonyms, thesaurus and antonyms information for any given word | `apiKey` | Yes | Unknown |
+| [The Daily Lesson](https://wordorb.ai/api) | 162K words across 47 languages with structured lessons, quizzes, and knowledge graph | `apiKey` | Yes | Yes |
 | [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
 | [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
 | [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add The Daily Lesson to Dictionaries

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [The Daily Lesson](https://wordorb.ai/api) | 162K words across 47 languages with structured lessons, quizzes, and knowledge graph | `apiKey` | Yes | Yes |

### Details
- **Category:** Dictionaries
- **Auth:** apiKey (Bearer token)
- **HTTPS:** Yes
- **CORS:** Yes
- **Documentation:** https://wordorb.ai/api
- **Website:** https://thedailylesson.com

The Daily Lesson (WordOrb) is a deterministic education API with 162,253 words, 601K+ translations across 47 languages, structured 5-phase lessons, quizzes, and a knowledge graph. All data is curated — zero hallucinations.

The API has a free tier and is publicly accessible with an API key.