### PR TITLE
Add RunDida — Running calculators and marathon data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1599,6 +1599,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
+| [RunDida](https://rundida.com/api/) | Running calculators, marathon data, and race information | No | Yes | Yes |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |
 | [Sport Places](https://developers.decathlon.com/products/sport-places) | Crowd-source sports places around the world | No | Yes | No |


### PR DESCRIPTION
## Description

RunDida provides a free JSON API for running data — 87 calculator metadata, 29 marathon events with weather and course profiles, and full OpenAPI 3.0 documentation.

### Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/tools.json` | All 87 running tools with metadata, categories, keywords |
| `GET /api/tools/{slug}.json` | Tool detail with FAQs, related tools, and sources |
| `GET /api/marathons.json` | 23 active + 7 archived marathon events |
| `GET /api/marathons/{id}.json` | Marathon detail with weather, course, Schema.org data |

### Verification

```bash
# List all tools
curl -s https://rundida.com/api/tools.json | jq '.meta.total'
# Returns: 87

# Get a specific tool
curl -s https://rundida.com/api/tools/pace-calculator.json | jq '.tool.title'
# Returns: "Running Pace Calculator — Time, Distance & Speed"

# List marathons
curl -s https://rundida.com/api/marathons.json | jq '.meta.totalActive'
# Returns: 23
```

### Checklist

- [x] HTTPS
- [x] No authentication required
- [x] CORS enabled
- [x] Returns JSON
- [x] OpenAPI spec: https://rundida.com/api/openapi.json
- [x] Documentation: https://rundida.com/api/