### PR TITLE
feat: add FonteData - Brazilian data intelligence API (CNPJ, CPF, KYC, compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
+| [FonteData](https://fontedata.com/docs) | Brazilian data intelligence API — CNPJ, CPF, KYC, compliance, judicial records and international sanctions (108+ endpoints) | `apiKey` | Yes | Yes |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding [FonteData](https://fontedata.com) to the **Business** category.

FonteData is a Brazilian data intelligence REST API aggregating 108+ public and private data sources for CNPJ (company registry), CPF (individual taxpayer), KYC, compliance, judicial records, and international sanctions.

## API Details

- **Auth**: API Key via `X-API-Key` header
- **HTTPS**: Yes
- **CORS**: Yes
- **Docs**: https://fontedata.com/docs
- **Pricing**: Pre-paid credits, no subscription, free account with R$50 credits
- **Coverage**: Receita Federal, CGU, PGFN, TST, TSE, Banco Central, TJs, TRFs, TRTs, OFAC, UN, EU, UK sanctions

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md) guide
- [x] Entry is in alphabetical order
- [x] All URLs are working
- [x] Auth type is correct (`apiKey`)
- [x] HTTPS is correct (`Yes`)
- [x] CORS is correct (`Yes`)
