### PR TITLE
Add LinkMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
+| [LinkMeta](https://linkmeta.dev/docs) | Free URL metadata extraction for any webpage | No | Yes | Yes |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |


### PR DESCRIPTION
LinkMeta (linkmeta.dev) is a free URL metadata extraction API. No authentication required. Returns Open Graph, meta tags, and structured data from any URL. Free forever, no rate limits for reasonable use.