### PR TITLE
Add Crustdata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
+| [Crustdata](https://docs.crustdata.com/) | Real-time company and people data for enrichment and go-to-market workflows | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Add Crustdata to the Business category.

Crustdata provides real-time company and people data via API,
which is useful for enrichment and go-to-market workflows.

Entry follows the required table format and alphabetical ordering.