### PR TITLE
Add MobileAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Numverify](https://numverify.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Phone number validation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
+| [MobileAPI](https://mobileapi.dev/docs/) | Smartphone, tablet, and wearable device specifications | `apiKey` | Yes | Yes |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [MobileAPI](https://mobileapi.dev/docs/) to the Phone category.

MobileAPI is a REST API providing device specifications, images, and pricing data for 27,000+ smartphones, tablets, smartwatches, and laptops from 200+ brands. It offers a free tier (200 requests/month) with API key authentication.

- [x] One API per pull request
- [x] Alphabetical ordering maintained
- [x] Placed in most relevant category (Phone)
- [x] Commit message format followed
- [x] Searched for duplicates — not currently listed
- [x] API has proper documentation
- [x] Single commit
- [x] Targeting master branch