### PR TITLE
Add SnapAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping with a simple API | `apiKey` | Yes | Unknown |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
+| [SnapAPI](https://bonskari.github.io/snapapi/) | Screenshot and PDF generation from any URL or HTML | `apiKey` | Yes | Yes |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add SnapAPI

SnapAPI is a screenshot and PDF generation API for developers. Send a URL or HTML, get back a PNG, JPEG, or PDF.

- **Website**: https://bonskari.github.io/snapapi/
- **API Docs**: https://api.unstableentity.com/docs
- **Auth**: API key (free tier: 500 captures/month)
- **HTTPS**: Yes
- **CORS**: Yes

Open source (MIT): https://github.com/bonskari/snapapi