### PR TITLE
Add DummyJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
+| [DummyJSON](https://dummyjson.com) | Fake REST API with placeholder JSON data for testing and prototyping | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |


### PR DESCRIPTION
## Summary
- Adds [DummyJSON](https://dummyjson.com) to the **Test Data** section
- DummyJSON is a free REST API that provides placeholder JSON data (products, carts, users, posts, comments, quotes, todos, etc.) for testing and prototyping
- No authentication required, supports HTTPS and CORS
- Entry placed in alphabetical order between Dicebear Avatars and English Random Words

## API Details
| Field | Value |
|---|---|
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

## Checklist
- [x] API is free to use with no authentication required
- [x] API has proper documentation at https://dummyjson.com/docs
- [x] Entry follows alphabetical ordering
- [x] Description does not exceed 100 characters
- [x] API name does not end with "API"
- [x] Verified API is not already in the list
- [x] Verified API is live and responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)