### PR TITLE
Add MapAtlas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,7 @@ API | Description | Auth | HTTPS | CORS |
 | [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
 | [Longdo Map](https://map.longdo.com/docs/) | Interactive map with detailed places and information portal in Thailand | `apiKey` | Yes | Yes |
+| [MapAtlas](https://mapatlas.eu/docs) | Geocoding, routing, map tiles, directions and route optimization | `apiKey` | Yes | Yes |
 | [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
 | [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No | Yes
 | [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ API | Description | Auth | HTTPS | CORS |
 | [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
 | [Longdo Map](https://map.longdo.com/docs/) | Interactive map with detailed places and information portal in Thailand | `apiKey` | Yes | Yes |
-| [MapAtlas](https://mapatlas.eu/docs) | Geocoding, routing, map tiles, directions and route optimization | `apiKey` | Yes | Yes |
+| [MapAtlas](https://mapatlas.eu) | Geocoding, routing, map tiles, directions and route optimization | `apiKey` | Yes | Yes |
 | [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
 | [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No | Yes
 | [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |


### PR DESCRIPTION
MapAtlas is a European mapping API providing geocoding, routing, map tiles, and route optimization.

- EU-hosted, GDPR compliant, ISO 27001 certified
- Free tier: 10k map loads, 10k geocodes, 100k routes/month
- No user tracking
- Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V., the company behind MapAtlas.