### PR TITLE
Add FlashAlpha API

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
+| [FlashAlpha](https://flashalpha.com/docs/lab-api-overview) | Options flow, gamma exposure, and derivatives analytics data | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
## Summary
- Adds [FlashAlpha](https://flashalpha.com/docs) to the Finance category
- FlashAlpha provides options flow, gamma exposure (GEX), and derivatives analytics data
- Auth: apiKey, HTTPS: Yes, CORS: Unknown

## Checklist
- [x] Alphabetical ordering maintained (between Finnhub and FRED)
- [x] Description under 100 characters
- [x] HTTPS supported
- [x] API has proper documentation
- [x] One link per PR