### PR TITLE
Add LinkShrink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1775,6 +1775,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Git.io](https://github.blog/2011-11-10-git-io-github-url-shortener/) | Git.io URL shortener | No | Yes | Unknown |
 | [GoTiny](https://github.com/robvanbakel/gotiny-api) | A lightweight URL shortener, focused on ease-of-use for the developer and end-user | No | Yes | Yes |
 | [Kutt](https://docs.kutt.it/) | Free Modern URL Shortener | `apiKey` | Yes | Yes |
+| [LinkShrink](https://linkshrink.dev/docs) | Free privacy-first URL shortener with no tracking | No | Yes | Yes |
 | [Mgnet.me](http://mgnet.me/api.html) | Torrent URL shorten API | No | Yes | No |
 | [owo](https://owo.vc/api) | A simple link obfuscator/shortener | No | Yes | Unknown |
 | [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [LinkShrink](https://linkshrink.dev) to the URL Shorteners section.

LinkShrink is a free, privacy-first URL shortener API that requires no authentication and supports CORS. It shortens and expands URLs without any tracking or analytics.

- Auth: No
- HTTPS: Yes
- CORS: Yes