### PR TITLE
Add PDFSpark

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PDFSpark](https://pdfspark.dev/docs) | Free HTML and URL to PDF conversion service | No | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [PDFSpark](https://pdfspark.dev) to the Documents & Productivity section.

PDFSpark is a free HTML/URL to PDF conversion API. Convert any webpage or HTML content to PDF via a simple REST call. No authentication required.

- Auth: No
- HTTPS: Yes
- CORS: Yes