### PR TITLE
Add FreeKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |
 | [Filestack](https://www.filestack.com) | Filestack File Uploader & File Upload API | `apiKey` | Yes | Unknown |    |
+| [FreeKit](https://freekit.dev/docs) | Free instant HTML hosting, upload HTML and get a public URL | No | Yes | Yes |
 | [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown | |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [Gyazo](https://gyazo.com/api/docs) | Save & Share screen captures instantly | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Added [FreeKit](https://freekit.dev) to the Documents & Productivity section.

FreeKit is a free instant HTML hosting API. Upload HTML content and get a hosted URL back immediately. No authentication required.

- Auth: No
- HTTPS: Yes
- CORS: Yes