### PR TITLE
Add VerifyEd API

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ API | Description | Auth | HTTPS | CORS |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
 | [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes | |
 | [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes | |
+| [VerifyEd](https://verifyed.org/docs) | Search 912K+ schools worldwide and detect diploma mills for credential verification | `apiKey` | Yes | Yes | |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Description

Adds [VerifyEd](https://verifyed.org/docs) to the **Data Validation** section.

VerifyEd is an academic credential verification API:
- Search 912,000+ schools worldwide (government-sourced data)
- Detect diploma mills (2,592 known fraudulent institutions flagged)
- Free tier available, no credit card required
- Supports CORS for browser-based use

**Entry added:**
| [VerifyEd](https://verifyed.org/docs) | Search 912K+ schools worldwide and detect diploma mills for credential verification | `apiKey` | Yes | Yes |

Fits Data Validation category — primary use case is validating whether a school/credential is legitimate.