### PR TITLE
Add MusclesWorked API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
+| [MusclesWorked](https://musclesworked.com/redoc) | Exercise-to-muscle mapping with 320+ exercises, 65 muscles, and 14 muscle groups | `apiKey` | Yes | Yes |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [MusclesWorked](https://musclesworked.com) to the **Sports & Fitness** section.

MusclesWorked is a REST API for exercise-to-muscle mapping — it lets developers query which muscles an exercise works, find exercises targeting specific muscles, and analyze workout coverage.

## Entry

| [MusclesWorked](https://musclesworked.com/redoc) | Exercise-to-muscle mapping with 320+ exercises, 65 muscles, and 14 muscle groups | `apiKey` | Yes | Yes |

## Checklist

- [x] API has a free tier (free signup at musclesworked.com)
- [x] Entry follows the existing format (API | Description | Auth | HTTPS | CORS)
- [x] Description is under 100 characters
- [x] Alphabetically ordered within Sports & Fitness (between MLB Records and NBA Data)
- [x] API name does not end with "API"
- [x] HTTPS: Yes
- [x] CORS: Yes
- [x] Auth: `apiKey`
- [x] PR title is in the format "Add Api-name API"