### PR TITLE
Add SnapAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |
+| [SnapAPI](https://github.com/Epedroza999/snapapi) | Capture webpage screenshots and generate PDFs with a single API call | `apiKey` | Yes | Yes |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
 | [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Add SnapAPI to the Documents & Productivity section.

SnapAPI provides webpage screenshot capture (PNG, JPEG, WebP) and PDF generation via a simple REST API, powered by Playwright. It supports full-page capture, element selection, retina rendering, ad blocking, and customizable PDF options.

- Homepage: https://github.com/Epedroza999/snapapi
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes