### PR TITLE
Add ContextWire search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
+| [ContextWire](https://contextwire.dev/docs.html) | Free search API for AI agents with 105 engines, MCP server | `apiKey` | Yes | Yes | |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [ContextWire](https://contextwire.dev) to the Development section.

- **Free tier**: 1,000 queries/month, no credit card required
- **Auth**: API key
- **HTTPS**: Yes
- **CORS**: Yes
- **What it does**: Web search API for developers and AI agents. Searches 105 engines, returns structured results. Also has MCP server integration.
- **Docs**: https://contextwire.dev/docs.html