### PR TITLE
Add CardAPI - Credit card data API for US & Canada

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
+| [CardAPI](https://cardapi.dev) | Credit card rewards, fees, benefits, and application criteria for US & Canada | `apiKey` | Yes | Yes | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## API Details

- **Name:** CardAPI
- **URL:** https://cardapi.dev
- **Description:** Credit card rewards, fees, benefits, and application criteria for US & Canada
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes

### About

CardAPI provides structured credit card data via REST API. 440+ cards across 39 issuers (Chase, Amex, Citi, Capital One, etc.) with reward rates, signup bonuses, annual fees, benefits, transfer partners, and application rules.

- **Docs:** https://cardapi.dev/docs
- **OpenAPI Spec:** https://cardapi.dev/v1/openapi.json
- **SDKs:** [npm](https://www.npmjs.com/package/@cardapi/client) | [PyPI](https://pypi.org/project/cardapi/)
- **Free tier:** 100 calls/day