### PR TITLE
Add ShopSavvy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1520,6 +1520,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
+| [ShopSavvy](https://shopsavvy.com/data/documentation) | Real-time product pricing and price history across thousands of retailers | `apiKey` | Yes | Yes |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |
 | [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |
 


### PR DESCRIPTION
We've been running ShopSavvy (price comparison since 2008) and recently opened up our product data API. Covers real-time pricing and price history across thousands of retailers, free tier included.

Docs: https://shopsavvy.com/data/documentation

Seemed like a natural fit for the Shopping section.