### PR TITLE
Add SEC EDGAR Insider Alerts API to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
+| [SEC EDGAR Insider Alerts](https://rapidapi.com/lulzasaur9192/api/sec-edgar-insider-alerts) | Real-time SEC Form 4 insider trading data with alerts for any stock ticker | `apiKey` | Yes | Unknown | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds the [SEC EDGAR Insider Alerts](https://rapidapi.com/lulzasaur9192/api/sec-edgar-insider-alerts) API to the Finance section.

**API Details:**
- Real-time SEC Form 4 insider trading data with alerts for any stock ticker
- Auth: API Key
- HTTPS: Yes
- CORS: Unknown

The entry is placed alphabetically after the existing SEC EDGAR Data entry.