### PR TITLE
Add Professional License Verify API to Health section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Disease](https://disease.sh/) | API for Current cases and more stuff about COVID-19 and Influenza | No | Yes | Yes |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |
 | [Orion Health](https://developer.orionhealth.io/) | Medical platform which allows the development of applications for different healthcare scenarios | `OAuth` | Yes | Unknown |
+| [Professional License Verify](https://rapidapi.com/lulzasaur9192/api/license-verify-api) | Verify professional licenses (nurses, doctors, contractors, real estate agents) across US states | `apiKey` | Yes | Unknown |
 | [Quarantine](https://quarantine.country/coronavirus/api/) | Coronavirus API with free COVID-19 live updates | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds the [Professional License Verify](https://rapidapi.com/lulzasaur9192/api/license-verify-api) API to the Health section.

**API Details:**
- Verify professional licenses (nurses, doctors, contractors, real estate agents) across US states
- 7 profession types, 50 states coverage
- Auth: API Key
- HTTPS: Yes
- CORS: Unknown

The entry is placed alphabetically between Orion Health and Quarantine.