### PR TITLE
Add Agent Audit Log API to Business section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Business
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [Agent Audit Log](https://rapidapi.com/lulzasaur9192/api/agent-memory-api) | Tamper-evident HMAC-chain audit logging for AI agents with cryptographic verification | `apiKey` | Yes | Unknown |
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the [Agent Audit Log](https://rapidapi.com/lulzasaur9192/api/agent-memory-api) API to the Business section.

**API Details:**
- Tamper-evident HMAC-chain audit logging for AI agents with cryptographic verification
- Useful for compliance, debugging, and accountability in AI agent workflows
- Auth: API Key
- HTTPS: Yes
- CORS: Unknown

The entry is placed alphabetically before Apache Superset.