### PR TITLE
Add Payroll Tax API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
+| [Payroll Tax API](https://payrolltaxapi.com) | US payroll tax rates — federal, state, and 4,246 local jurisdictions | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |


### PR DESCRIPTION
## API name
Payroll Tax API

## API description
US payroll tax rates API — federal, state income/SUTA/SDI, and 4,246 local jurisdictions (cities, counties, school districts).

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] One link per pull request
- [x] Alphabetical ordering maintained (between OpenFIGI and Plaid in Finance section)
- [x] Description is under 100 characters
- [x] API has a free tier (1,000 req/month, no credit card)
- [x] HTTPS: Yes
- [x] CORS: Yes (Access-Control-Allow-Origin: *)
- [x] Auth: apiKey (Bearer token / X-API-Key header)