### PR TITLE
Add SEC Insider Trading API

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
+| [SEC Insider Trading](https://rapidapi.com/lulzasaur/api/sec-insider-trades) | Real-time SEC Form 4 insider trading data | `apiKey` | Yes | Unknown | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds the SEC Insider Trading API to the Finance category. Provides real-time SEC Form 4 insider trading data — track stock purchases, sales, and option exercises by corporate insiders for any public company. Free tier: 200 requests/month.