### PR TITLE
Add svg.new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PHP-Noise](https://php-noise.com/) | Noise Background Image Generator | No | Yes | Yes |
 | [Pixel Encounter](https://pixelencounter.com/api) | SVG Icon Generator | No | Yes | No |
 | [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/) | RijksMuseum Data | `apiKey` | Yes | Unknown |
+| [svg.new](https://svg.new/docs/api) | AI-powered image to SVG vectorization | `apiKey` | Yes | Yes |
 | [Word Cloud](https://wordcloudapi.com/) | Easily create word clouds | `apiKey` | Yes | Unknown |
 | [xColors](https://x-colors.herokuapp.com/) | Generate & convert colors | No | Yes | Yes |
 


### PR DESCRIPTION
Adds [svg.new](https://svg.new) — AI-powered image to SVG vectorization API.

Features:
- Convert raster images (PNG, JPG, WebP) to clean SVG vectors
- Recolor, simplify, and edit SVGs
- Batch processing up to 50 images
- MCP server for AI agents

API documentation: https://svg.new/docs/api