### PR TITLE
Add ReceiptsAPI to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
+| [ReceiptsAPI](https://receiptsapi.com) | AI-powered receipt and invoice data extraction — extract structured JSON from any image (merchant, totals, line items, date) | apiKey | Yes | Yes |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding ReceiptsAPI — an AI-powered receipt and invoice parsing API.

• Extracts structured JSON (merchant, totals, line items, tax, date, payment method)
• Supports JPG, PNG, PDF, WebP via URL or base64
• Free tier available (50 docs/month)
• API docs: https://api.receiptsapi.com/docs