### PR TITLE
Add Coinnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ API | Description | Auth | HTTPS | CORS |
 | [1Forge](https://1forge.com/forex-data-api/api-documentation) | Forex currency market data | `apiKey` | Yes | Unknown |
 | [Amdoren](https://www.amdoren.com/currency-api/) | Free currency API with over 150 currencies | `apiKey` | Yes | Unknown |
 | [Bank of Russia](https://www.cbr.ru/development/SXML/) | Exchange rates and currency conversion | No | Yes | Unknown |
+| [Coinnect](https://coinnect.bot/docs) | Open money transfer routing across fiat, crypto and P2P networks | `apiKey` | Yes | Yes |
 | [Currency-api](https://github.com/fawazahmed0/currency-api#readme) | Free Currency Exchange Rates API with 150+ Currencies & No Rate Limits | No | Yes | Yes |
 | [CurrencyFreaks](https://currencyfreaks.com/) | Provides current and historical currency exchange rates with free plan 1K requests/month | `apiKey` | Yes | Yes |
 | [CurrencyScoop](https://currencyscoop.com/api-documentation) | Real-time and historical currency rates JSON API | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add Coinnect to Currency Exchange

[Coinnect](https://coinnect.bot/docs) is an open money transfer routing API that finds the cheapest path across fiat, crypto, and P2P networks. It uses Dijkstra's algorithm over 29K+ live edges from 80+ adapters.

- **API**: Coinnect
- **Description**: Open money transfer routing across fiat, crypto and P2P networks
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Link**: https://coinnect.bot/docs
- **Category**: Currency Exchange