### PR TITLE
Add Slot Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ API | Description | Auth | HTTPS | CORS |
 | [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
 | [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
 | [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
+| [Slot Data](https://slot.report/api/) | Free slot machine data — 5,600+ games with RTP, volatility, max win, features | No | Yes | Yes |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey` | Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |


### PR DESCRIPTION
## Summary
- Adds **Slot Data** API to the **Games & Comics** category
- Free REST API with data on 5,600+ online slot games including RTP, volatility, max win, and game features
- No authentication required, HTTPS, CORS enabled
- Documentation: https://slot.report/api/