### PR TITLE
Add Property Comps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
+| [Property Comps](https://api.nwc-advisory.com/docs) | Comparable property sales data across 11 global markets from government open data | No | Yes | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |


### PR DESCRIPTION
Added [Property Comps](https://api.nwc-advisory.com/docs) to the **Open Data** section.

**API Details:**
- Comparable property sales data across 11 global markets (UK, France, Singapore, NYC, Chicago, Dubai, Miami, Philadelphia, Connecticut, Ireland, Taiwan)
- Data sourced from government open data registries (HM Land Registry, DVF, HDB, NYC DOF, etc.)
- 44M+ transactions
- Free access, no authentication required
- HTTPS and CORS supported
- Swagger/OpenAPI documentation at the linked URL

**Checklist:**
- [x] Added in alphabetical order (between PeakMetrics and Recreation Information Database)
- [x] Description under 100 characters (81 chars)
- [x] API name does not end with "API"
- [x] API has proper documentation (Swagger UI)
- [x] Free access, no auth required
- [x] HTTPS supported
- [x] Single link added
- [x] Squashed into single commit