### PR TITLE
Add crypto sentiment and AI trading signal APIs to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Marketstack](https://marketstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-Time, Intraday & Historical Market Data API | `apiKey` | Yes | Unknown | |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
+| [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes |
+| [AI Trading Signal Bundle](https://bundle-api-production.up.railway.app) | All 10 trading signals in one API call — sentiment, macro, whale, momentum | `apiKey` | Yes | Yes |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data API](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
@@ -745,6 +747,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
+| [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown |
+| [Crypto Sentiment Score](https://crypto-sentiment-api-production.up.railway.app) | Real-time AI sentiment scoring for BTC, ETH, SOL and 10+ crypto assets | `apiKey` | Yes | Yes |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adding 2 real-time financial data APIs built for AI agent workflows.

- Crypto Sentiment Score: Real-time 0-100 sentiment for BTC, ETH, SOL and 10+ tickers
- AI Trading Signal Bundle: All 10 signals in one API call (sentiment, macro, whale, momentum)

Both have free tiers and support x402 micropayments on Base chain.
GitHub: https://github.com/roblambert9/crypto-sentiment-api

---

**Built with imperial-a2a** ([PyPI](https://pypi.org/project/imperial-a2a/)) — x402 payment rails for any API.

Products powered by this protocol: [Content Brief ($9)](https://buy.stripe.com/fZudR98zZgkI5EK3lg1Nu01) · [Starter Kit ($97)](https://buy.stripe.com/5kQ3cv8zZgkIebg4pk1Nu05) · [Full catalog →](https://neuralempireai.com)