### PR TITLE
Add DA Leads API to Open Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,6 +1271,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
+| [DA Leads](https://daleads.com.au/api/v1/docs) | Australian development application data across 330+ councils | `apiKey` | Yes | Yes |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding [DA Leads API](https://daleads.com.au/api/v1/docs) to the Open Data section.

DA Leads provides programmatic access to Australian development application (building permit) data across 330+ local councils covering all states and territories.

**API Features:**
- Search DAs by location, category, date range
- Nearby lookups (radius-based)
- 21 trade categories
- Council statistics
- Real-time webhooks

**Auth:** API key
**HTTPS:** Yes
**CORS:** Yes
**Docs:** https://daleads.com.au/api/v1/docs