### PR TITLE
Add DummyJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1622,6 +1622,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
+| [DummyJSON](https://dummyjson.com) | Get fake JSON data including products, users, posts, todos and more | No | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
 | [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |
 | [GeneradorDNI](https://api.generadordni.es) | Data generator API. Profiles, vehicles, banks and cards, etc | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [DummyJSON](https://dummyjson.com) to the Test Data section.

DummyJSON is a free, no-auth required REST API that provides fake JSON data including products, users, posts, todos, comments, and more. It's widely used for prototyping, testing, and front-end development.

- **Auth**: No
- **HTTPS**: Yes  
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`