### PR TITLE
Add Bright Sky API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1860,6 +1860,7 @@ API | Description | Auth | HTTPS | CORS |
 | [APIXU](https://www.apixu.com/doc/request.aspx) | Weather | `apiKey` | Yes | Unknown |
 | [AQICN](https://aqicn.org/api/) | Air Quality Index Data for over 1000 cities | `apiKey` | Yes | Unknown |
 | [AviationWeather](https://www.aviationweather.gov/dataserver) | NOAA aviation weather forecasts and observations | No | Yes | Unknown |
+| [Bright Sky](https://brightsky.dev/) | Free, open-source JSON API for DWD (German Weather Service) weather data | No | Yes | Yes |
 | [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | Weather | `apiKey` | Yes | Yes |
 | [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
 | [Foreca](https://developer.foreca.com) | Weather | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [Bright Sky](https://brightsky.dev/) to the Weather section.

Bright Sky is a free, open-source JSON API that provides easy access to DWD (Deutscher Wetterdienst / German Weather Service) weather data. It offers current weather conditions and forecasts with no authentication required.

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`