### PR TITLE
Add wttr.in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1881,6 +1881,7 @@ API | Description | Auth | HTTPS | CORS |
 | [US Weather](https://www.weather.gov/documentation/services-web-api) | US National Weather Service | No | Yes | Yes |
 | [Visual Crossing](https://www.visualcrossing.com/weather-api) | Global historical and weather forecast data | `apiKey` | Yes | Yes |
 | [weather-api](https://github.com/robertoduessmann/weather-api) | A RESTful free API to check the weather | No | Yes | No |
+| [wttr.in](https://wttr.in/) | Console-oriented weather service that supports various output formats (text, PNG, JSON) | No | Yes | Yes |
 | [WeatherAPI](https://www.weatherapi.com/) | Weather API with other stuff like Astronomy and Geolocation API | `apiKey` | Yes | Yes |
 | [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
 | [Yandex.Weather](https://yandex.com/dev/weather/) | Assesses weather condition in specific locations | `apiKey` | Yes | No |


### PR DESCRIPTION
## Description

Add [wttr.in](https://wttr.in/) to the Weather section.

wttr.in is a console-oriented weather service that also provides JSON output, PNG images, and one-line weather summaries. It requires no authentication and supports locations by city name, GPS coordinates, airport codes, domain names, and area codes.

Example: `curl wttr.in/London?format=j1` returns structured JSON weather data.

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`