### PR TITLE
Add Codewars API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Codeforces](https://codeforces.com/apiHelp) | Get access to Codeforces data | `apiKey` | Yes | Unknown |
+| [Codewars](https://dev.codewars.com/) | Access Codewars user, kata, and leaderboard data | No | Yes | Unknown |
 | [Hackerearth](https://www.hackerearth.com/docs/wiki/developers/v4/) | For compiling and running code in several languages | `apiKey` | Yes | Unknown |
 | [Judge0 CE](https://ce.judge0.com/) | Online code execution system | `apiKey` | Yes | Unknown |
 | [KONTESTS](https://kontests.net/api) | For upcoming and ongoing competitive coding contests | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [Codewars](https://dev.codewars.com/) to the Programming section.

Codewars provides a public API to access kata (coding challenge) data, user profiles, leaderboards, and activity. No authentication is required for read-only access to public data.

Example: `https://www.codewars.com/api/v1/code-challenges/are-you-playing-banjo` returns kata details.

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Unknown

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`