### PR TITLE
Add Exercism API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Codeforces](https://codeforces.com/apiHelp) | Get access to Codeforces data | `apiKey` | Yes | Unknown |
+| [Exercism](https://exercism.org/docs/using/solving-exercises/working-locally) | Code practice and mentorship platform with tracks for 60+ languages | No | Yes | Unknown |
 | [Hackerearth](https://www.hackerearth.com/docs/wiki/developers/v4/) | For compiling and running code in several languages | `apiKey` | Yes | Unknown |
 | [Judge0 CE](https://ce.judge0.com/) | Online code execution system | `apiKey` | Yes | Unknown |
 | [KONTESTS](https://kontests.net/api) | For upcoming and ongoing competitive coding contests | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [Exercism](https://exercism.org/docs/using/solving-exercises/working-locally) to the Programming section.

Exercism is a free, open-source code practice and mentorship platform offering 60+ programming language tracks with hundreds of exercises each. The public API provides access to tracks, exercises, and user data without requiring authentication.

Example: `https://exercism.org/api/v2/tracks` returns all available programming language tracks.

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Unknown

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`