### PR TITLE
Add RxNorm API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
 | [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
 | [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
+| [RxNorm](https://rxnav.nlm.nih.gov/RxNormAPIREST.html) | Drug information and drug interaction data from the US National Library of Medicine | No | Yes | Yes |
 | [Open Data NHS Scotland](https://www.opendata.nhs.scot) | Medical reference data and statistics by Public Health Scotland | No | Yes | Unknown |
 | [Open Disease](https://disease.sh/) | API for Current cases and more stuff about COVID-19 and Influenza | No | Yes | Yes |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [RxNorm](https://rxnav.nlm.nih.gov/RxNormAPIREST.html) to the Health section.

RxNorm is a free REST API from the US National Library of Medicine that provides normalized drug names and drug information. It returns drug details, RxCUI identifiers, drug interactions, and related information. No API key is required.

Example: `https://rxnav.nlm.nih.gov/REST/drugs.json?name=aspirin`

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`