### PR TITLE
Add PreReason API

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [PreReason](https://www.prereason.com/docs) | Pre-analyzed financial market briefings with trend signals and regime classification | `apiKey` | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PreReason API to the Cryptocurrency section.

PreReason provides pre-analyzed financial market briefings via REST API. Free tier available (6 briefings, 60 requests per hour, no credit card required). Returns trend signals, regime classification, and confidence scores in JSON or Markdown format.

- API docs: [prereason.com/docs](https://www.prereason.com/docs)
- Auth: API key (free tier available)
- HTTPS: Yes
- CORS: Yes