### PR TITLE
Add Bundlephobia API

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |
+| [Bundlephobia](https://bundlephobia.com/api) | Find the cost of adding a npm package to your bundle | No | Yes | Yes |
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |


### PR DESCRIPTION
## Description

Add [Bundlephobia](https://bundlephobia.com/api) to the Development section.

Bundlephobia provides an API to find the cost of adding any npm package to your JavaScript bundle. It returns minified size, gzipped size, and download time estimates. No authentication required.

Example: `https://bundlephobia.com/api/size?package=react` returns React's bundle size.

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`