### PR TITLE
Add Mastodon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lanyard](https://github.com/Phineas/lanyard) | Retrieve your presence on Discord through an HTTP REST API or WebSocket | No | Yes | Yes |
 | [Line](https://developers.line.biz/) | Line Login, Share on Line, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | The foundation of all digital integrations with LinkedIn | `OAuth` | Yes | Unknown |
+| [Mastodon](https://docs.joinmastodon.org/api/) | Open-source self-hosted social networking and microblogging API | `OAuth` | Yes | Unknown |
 | [Meetup.com](https://www.meetup.com/api/guide) | Data about Meetups from Meetup.com | `apiKey` | Yes | Unknown |
 | [Microsoft Graph](https://docs.microsoft.com/en-us/graph/api/overview) | Access the data and intelligence in Microsoft 365, Windows 10, and Enterprise Mobility | `OAuth` | Yes | Unknown |
 | [NAVER](https://developers.naver.com/main/) | NAVER Login, Share on NAVER, Social Plugins and more | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [Mastodon](https://docs.joinmastodon.org/api/) to the Social section.

Mastodon is a major open-source, self-hosted social networking platform with millions of users across thousands of instances. Its REST API supports reading timelines, posting, account management, and much more. OAuth is required for write operations; many read endpoints are publicly accessible.

- **Auth**: OAuth
- **HTTPS**: Yes
- **CORS**: Unknown

## Checklist
- [x] API is publicly accessible
- [x] API has free tier (many endpoints work without auth)
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`