### PR TITLE
Add is.gd API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1774,6 +1774,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Free Url Shortener](https://ulvis.net/developer.html) | Free URL Shortener offers a powerful API to interact with other sites | No | Yes | Unknown |
 | [Git.io](https://github.blog/2011-11-10-git-io-github-url-shortener/) | Git.io URL shortener | No | Yes | Unknown |
 | [GoTiny](https://github.com/robvanbakel/gotiny-api) | A lightweight URL shortener, focused on ease-of-use for the developer and end-user | No | Yes | Yes |
+| [is.gd](https://is.gd/developers.php) | Fast and simple URL shortener, free with no account required | No | Yes | Yes |
 | [Kutt](https://docs.kutt.it/) | Free Modern URL Shortener | `apiKey` | Yes | Yes |
 | [Mgnet.me](http://mgnet.me/api.html) | Torrent URL shorten API | No | Yes | No |
 | [owo](https://owo.vc/api) | A simple link obfuscator/shortener | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [is.gd](https://is.gd/developers.php) to the URL Shorteners section.

is.gd is a fast, free URL shortener that provides a simple REST API. No account or authentication is required. It also supports CORS and can optionally return statistics. Supports custom shortcodes and QR code generation.

Example: `https://is.gd/create.php?format=json&url=https://example.com`

- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist
- [x] API is publicly accessible
- [x] API has free tier / no authentication required
- [x] Entry is placed in alphabetical order within the section
- [x] Description does not exceed 100 characters
- [x] PR title is in format `Add Api-name API`