### PR TITLE
Add DataVendor Crypto to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | Cryptocurrency data | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
+| [DataVendor Crypto](https://web-production-a2ec.up.railway.app) | M2M crypto prices, signals & predictions — pay per call in satoshis | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | Cryptocurrency data | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
-| [DataVendor Crypto](https://web-production-a2ec.up.railway.app) | M2M crypto prices, signals & predictions — pay per call in satoshis | `apiKey` | Yes | Yes |
+| [DataVendor Crypto](https://web-production-a2ec.up.railway.app) | M2M crypto prices, signals and predictions - pay per call in satoshis | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |


### PR DESCRIPTION

M2M cryptocurrency data marketplace. Prices, signals and predictions.
Pay per call in Bitcoin satoshis. Free key on registration (100k sats).
Supports BTC, ETH, SOL, DOGE, XRP, ADA, AVAX, DOT, MATIC, LINK.