### PR TITLE
Add EnrichAnything public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
+| [EnrichAnything](https://www.enrichanything.com/api/) | Published market scans and report summaries as structured JSON | No | Yes | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds EnrichAnything under the Business category. The API is public, unauthenticated, HTTPS-only, and documents two read-only JSON endpoints for published market scans and report summaries.

Docs: https://www.enrichanything.com/api/
OpenAPI: https://www.enrichanything.com/openapi.json