### PR TITLE
Add CodeCosts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
+| [CodeCosts](https://codecosts-api.pingbase-api.workers.dev) | Free pricing data for AI coding tools (Copilot, Cursor, Claude Code, Windsurf) | No | Yes | Yes |
 | [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey` | Yes | Yes |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |


### PR DESCRIPTION
Added [CodeCosts](https://codecosts-api.pingbase-api.workers.dev) to the **Development** section.

**CodeCosts** provides free, real-time pricing data for AI coding tools including GitHub Copilot, Cursor, Claude Code, Windsurf, and more. No authentication required.

- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes
- **Link:** https://codecosts-api.pingbase-api.workers.dev
- **GitHub:** https://github.com/lunacompsia-oss/codecosts-api