### PR TITLE
Add HookTest to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Gorest](https://gorest.co.in/) | Online REST API for Testing and Prototyping | `OAuth` | Yes | Unknown |
 | [Hasura](https://hasura.io/opensource/) | GraphQL and REST API Engine with built in Authorization | `apiKey` | Yes | Yes |
 | [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/) | REST API to programmatically create apps, provision add-ons and perform other task on Heroku | `OAuth` | Yes | Yes |
+| [HookTest](https://hooktest.peakline-ops.workers.dev) | Capture, inspect, and replay webhook payloads in real-time | No | Yes | Yes |
 | [host-t.com](https://host-t.com) | Basic DNS query via HTTP GET request | No | Yes | No |
 | [Host.io](https://host.io) | Domains Data API for Developers | `apiKey` | Yes | Yes |
 | [HTTP2.Pro](https://http2.pro/doc/api) | Test endpoints for client and server HTTP/2 protocol support | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding [HookTest](https://hooktest.peakline-ops.workers.dev) to the Development section.

| Field | Value |
|-------|-------|
| **API** | HookTest |
| **URL** | https://hooktest.peakline-ops.workers.dev |
| **Description** | Capture, inspect, and replay webhook payloads in real-time |
| **Auth** | No |
| **HTTPS** | Yes |
| **CORS** | Yes |

## Checklist

- [x] API URL is public and functional
- [x] Free tier available with no account required
- [x] HTTPS is supported
- [x] Entry is in alphabetical order within the Development section
- [x] Description is under 100 characters
- [x] Only one API per PR
- [x] No duplicate found