### PR TITLE
Add Email Validator API and Domain WHOIS Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ API | Description | Auth | HTTPS | CORS |
 | [import.io](http://api.docs.import.io/) | Retrieve structured data from a website or RSS feed | `apiKey` | Yes | Unknown |
 | [ip-fast.com](https://ip-fast.com/docs/) | IP address, country and city | No | Yes | Yes |
 | [IP2WHOIS Information Lookup](https://www.ip2whois.com/) | WHOIS domain name lookup | `apiKey` | Yes | Unknown |
+| [George's Domain WHOIS Lookup](https://apify.com/george.the.developer/domain-whois-lookup) | Full WHOIS data for any domain including registrar, dates, and nameservers | `apiKey` | Yes | Yes |
 | [ipfind.io](https://ipfind.io) | Geographic location of an IP address or any domain name along with some other useful information | `apiKey` | Yes | Yes |
 | [IPify](https://www.ipify.org/) | A simple IP Address API | No | Yes | Unknown |
 | [IPinfo](https://ipinfo.io/developers) | Another simple IP Address API | No | Yes | Unknown |
@@ -666,6 +667,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |
 | [Email Validation](https://www.abstractapi.com/email-verification-validation-api) | Validate email addresses for deliverability and spam | `apiKey` | Yes | Yes |
 | [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
+| [George's Email Validator](https://apify.com/george.the.developer/email-validator-api) | Validate email addresses for deliverability, format, and MX records | `apiKey` | Yes | Yes |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
 | [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |


### PR DESCRIPTION
Two new hosted API entries from Apify actors:

**Email section:** [Email Validator API](https://apify.com/george.the.developer/email-validator-api) - validates email deliverability, format, and MX records. apiKey auth, HTTPS, free tier available.

**Development section:** [Domain WHOIS Lookup](https://apify.com/george.the.developer/domain-whois-lookup) - full WHOIS data including registrar, creation/expiry dates, nameservers. apiKey auth, HTTPS, free tier available.