### PR TITLE
Add LinkShrink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1775,6 +1775,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Git.io](https://github.blog/2011-11-10-git-io-github-url-shortener/) | Git.io URL shortener | No | Yes | Unknown |
 | [GoTiny](https://github.com/robvanbakel/gotiny-api) | A lightweight URL shortener, focused on ease-of-use for the developer and end-user | No | Yes | Yes |
 | [Kutt](https://docs.kutt.it/) | Free Modern URL Shortener | `apiKey` | Yes | Yes |
+| [LinkShrink](https://linkshrink.dev/docs) | Free privacy-first URL shortener with analytics | No | Yes | Yes |
 | [Mgnet.me](http://mgnet.me/api.html) | Torrent URL shorten API | No | Yes | No |
 | [owo](https://owo.vc/api) | A simple link obfuscator/shortener | No | Yes | Unknown |
 | [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add LinkShrink to URL Shorteners

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [LinkShrink](https://linkshrink.dev/docs) | Free privacy-first URL shortener with analytics | No | Yes | Yes |

- **Link:** https://linkshrink.dev
- **Documentation:** https://linkshrink.dev/docs
- **Category:** URL Shorteners
- **Auth:** No (completely free, no API key required)
- **HTTPS:** Yes
- **CORS:** Yes

LinkShrink is a free, privacy-first URL shortener REST API. No authentication required, free forever.