### PR TITLE
Add LinkMeta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
+| [LinkMeta](https://linkmeta.dev/docs) | Extract metadata, Open Graph tags, and favicons from any URL | No | Yes | Yes |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add LinkMeta to Development

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [LinkMeta](https://linkmeta.dev/docs) | Extract metadata, Open Graph tags, and favicons from any URL | No | Yes | Yes |

- **Link:** https://linkmeta.dev
- **Documentation:** https://linkmeta.dev/docs
- **Category:** Development
- **Auth:** No (completely free, no API key required)
- **HTTPS:** Yes
- **CORS:** Yes

LinkMeta is a free REST API for extracting metadata, Open Graph tags, Twitter Card data, and favicons from any URL. No authentication required, free forever.