### PR TITLE
Add PageShot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
+| [PageShot](https://pageshot.site/docs) | Free webpage screenshot and capture API powered by Playwright | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add PageShot to Development

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [PageShot](https://pageshot.site/docs) | Free webpage screenshot and capture API powered by Playwright | No | Yes | Yes |

- **Link:** https://pageshot.site
- **Documentation:** https://pageshot.site/docs
- **Category:** Development
- **Auth:** No (completely free, no API key required)
- **HTTPS:** Yes
- **CORS:** Yes

PageShot is a free REST API for taking screenshots and capturing webpages using Playwright. No authentication required, free forever.