### PR TITLE
Add PDFSpark API

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PDFSpark](https://pdfspark.dev/docs) | Free HTML and URL to PDF conversion API | No | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add PDFSpark to Documents & Productivity

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [PDFSpark](https://pdfspark.dev/docs) | Free HTML and URL to PDF conversion API | No | Yes | Yes |

- **Link:** https://pdfspark.dev
- **Documentation:** https://pdfspark.dev/docs
- **Category:** Documents & Productivity
- **Auth:** No (completely free, no API key required)
- **HTTPS:** Yes
- **CORS:** Yes

PDFSpark is a free REST API for converting HTML content and URLs to PDF documents using Playwright. No authentication required, free forever.