### PR TITLE
Add ScreenshotAPIs to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
+| [ScreenshotAPIs](https://screenshotapis.org) | Convert URLs or HTML to screenshots and PDFs | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary
- Adds [ScreenshotAPIs](https://screenshotapis.org) to the Development section
- API converts URLs or HTML to screenshots (PNG/JPEG/WEBP) and PDFs
- Uses API key authentication, supports HTTPS, CORS enabled
- Entry placed alphabetically after ScreenshotAPI.net

## Link
https://screenshotapis.org