### PR TITLE
docs: add WHO Open GHO API to Health section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,6 +1132,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
 | [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
 | [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
+| [Open GHO](https://www.who.int/data/gho/info/gho-odata-api) | World Health Organization Global Health Observatory data including 2000+ health indicators across 194 countries | No | Yes | Unknown |
 | [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
 | [Open Data NHS Scotland](https://www.opendata.nhs.scot) | Medical reference data and statistics by Public Health Scotland | No | Yes | Unknown |
 | [Open Disease](https://disease.sh/) | API for Current cases and more stuff about COVID-19 and Influenza | No | Yes | Yes |


### PR DESCRIPTION
### What does this PR do?

Adds the WHO Global Health Observatory (GHO) OData API to the Health section.
It provides free access to 2000+ health indicators across 194 countries, 
published by the World Health Organization - no authentication required.

### Checklist
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit