### PR TITLE
Add SnapAPI - Screenshot any URL via REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
+| [SnapAPI](https://snappapi.dev) | Screenshot any URL via REST API. PNG, JPG, WebP, PDF. Custom viewport, full-page, dark mode | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding SnapAPI (https://snappapi.dev) to the Screenshot category.

- Free tier available
- Supports PNG, JPG, WebP, PDF
- Custom viewport, full-page, dark mode
- CORS enabled
- Auth: apiKey