### PR TITLE
Add DummyJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
+| [DummyJSON](https://dummyjson.com/) | Free fake REST API for placeholder JSON data including products, users, posts and more | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |


### PR DESCRIPTION
Adds [DummyJSON](https://dummyjson.com/) to the Test Data section. It's a free fake REST API for placeholder JSON data including products, users, posts, and more. It does not require authentication and supports CORS and HTTPS.