### PR TITLE
Add LinkMeta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
+| [LinkMeta](https://linkmeta.dev) | Free URL metadata extraction API — titles, descriptions, Open Graph, favicons | No | Yes | Yes |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add LinkMeta API

[LinkMeta](https://linkmeta.dev) is a free URL metadata extraction API by SoftVoyagers.

**What it does:** Extract titles, descriptions, Open Graph tags, Twitter Cards, favicons, and other metadata from any URL with a single API call.

- **Auth:** No authentication required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free:** 100% free, no API keys needed

**API Documentation:** https://linkmeta.dev/docs