### PR TITLE
Add PageShot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
+| [PageShot](https://pageshot.site) | Free webpage screenshot and capture API — full page, viewport, element | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add PageShot API

[PageShot](https://pageshot.site) is a free webpage screenshot and capture API by SoftVoyagers.

**What it does:** Capture full page, viewport, or element-level screenshots of any webpage via a simple REST API.

- **Auth:** No authentication required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free:** 100% free, no API keys needed

**API Documentation:** https://pageshot.site/docs