### PR TITLE
Add PDFSpark API

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
+| [PDFSpark](https://pdfspark.dev) | Free HTML and URL to PDF conversion API with customizable options | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add PDFSpark API

[PDFSpark](https://pdfspark.dev) is a free HTML and URL to PDF conversion API by SoftVoyagers.

**What it does:** Convert any HTML content or URL to a PDF document with customizable page size, margins, headers, footers, and more.

- **Auth:** No authentication required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free:** 100% free, no API keys needed

**API Documentation:** https://pdfspark.dev/docs