### PR TITLE
Add FreeKit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |
 | [Filestack](https://www.filestack.com) | Filestack File Uploader & File Upload API | `apiKey` | Yes | Unknown |    |
+| [FreeKit](https://freekit.dev) | Free instant HTML hosting API — deploy pages with one API call | No | Yes | Yes | |
 | [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown | |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [Gyazo](https://gyazo.com/api/docs) | Save & Share screen captures instantly | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Add FreeKit API

[FreeKit](https://freekit.dev) is a free instant HTML hosting API by SoftVoyagers.

**What it does:** Deploy static HTML pages instantly with a single API call. Upload HTML content and get a public URL back immediately — no account needed.

- **Auth:** No authentication required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free:** 100% free, no API keys needed

**API Documentation:** https://freekit.dev/docs