### PR TITLE
Add Faktuj API

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [Faktuj](https://faktuj.pl) | Free Polish VAT invoice generator API with PDF export | No | Yes | Yes |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add Faktuj API

[Faktuj](https://faktuj.pl) is a free Polish VAT invoice generator API by SoftVoyagers.

**What it does:** Generate professional Polish VAT invoices (faktury VAT) as PDF documents via a REST API. Supports all required Polish invoice fields, tax calculations, and compliance formatting.

- **Auth:** No authentication required
- **HTTPS:** Yes
- **CORS:** Yes
- **Free:** 100% free, no API keys needed

**API Documentation:** https://faktuj.pl/docs