### PR TITLE
Add PredScope API

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data	 | `apiKey` | YES | |  |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [PredScope](https://predscope.com/api/markets.json) | Live prediction market odds, volumes, and resolved outcomes | No | Yes | Yes | |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
## Summary

- Adds [PredScope](https://predscope.com) to the **Finance** section
- PredScope provides free, open JSON endpoints for live prediction market odds, trading volumes, and resolved market outcomes aggregated from Polymarket
- No authentication required, supports HTTPS and CORS

### API Endpoints

| Endpoint | Description |
|---|---|
| [markets.json](https://predscope.com/api/markets.json) | Live prediction market odds and volumes |
| [resolved.json](https://predscope.com/api/resolved.json) | Resolved market outcomes |

### Checklist

- [x] Free, public API with no authentication required
- [x] Follows alphabetical ordering in the Finance section
- [x] Matches the required table format
- [x] Description under 100 characters
- [x] API name does not end with "API"
- [x] Single link per PR