### PR TITLE
Add PaperClean

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PaperClean](https://paperclean.ip1.cc/api/docs) | Clean document photos for printing, remove shadows and fix lighting | `apiKey` | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add PaperClean to Documents & Productivity

**API:** [PaperClean](https://paperclean.ip1.cc/api/docs)

**Description:** Clean document photos for printing, remove shadows and fix lighting

**Auth:** apiKey (X-API-Key header)  
**HTTPS:** Yes  
**CORS:** Yes

PaperClean transforms photos of documents into clean, print-ready versions. It removes shadows, fixes uneven lighting, and produces a white background. The API has a free tier (50 images/month, no credit card required).

- [Full API documentation](https://paperclean.ip1.cc/api/docs)
- [OpenAPI 3.0.3 spec](https://paperclean.ip1.cc/api/openapi.json)
- [Interactive Swagger UI](https://paperclean.ip1.cc/api/swagger)
- [Self-service registration](https://paperclean.ip1.cc/developers) (free API key, no credit card)