### PR TITLE
Add Feriados API - Brazilian Holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Checkiday - National Holiday API](https://apilayer.com/marketplace/checkiday-api) | Industry-leading Holiday API. Over 5,000 holidays and thousands of descriptions. Trusted by the World’s leading companies | `apiKey` | Yes | Unknown |
 | [Church Calendar](http://calapi.inadiutorium.cz/) | Catholic liturgical calendar | No | No | Unknown |
 | [Czech Namedays Calendar](https://svatky.adresa.info) | Lookup for a name and returns nameday date | No | No | Unknown |
+| [Feriados API](https://feriadosapi.com) | Brazilian holidays API covering national, state, and municipal holidays for 5,570+ municipalities | `apiKey` | Yes | Yes |
 | [Festivo Public Holidays](https://docs.getfestivo.com/docs/products/public-holidays-api/intro) | Fastest and most advanced public holiday and observance service on the market | `apiKey` | Yes | Yes |
 | [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
 | [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |


### PR DESCRIPTION
## Add Feriados API to Calendar section

[Feriados API](https://feriadosapi.com) is a REST API for Brazilian holidays covering:

- **National holidays** (feriados nacionais)
- **State holidays** (feriados estaduais) for all 27 states
- **Municipal holidays** (feriados municipais) for all 5,570+ municipalities

### Details

| Field | Value |
|-------|-------|
| API | Feriados API |
| Description | Brazilian holidays API covering national, state, and municipal holidays for 5,570+ municipalities |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |

### Links
- Website: https://feriadosapi.com
- API Docs: https://feriadosapi.com/docs