### PR TITLE
Add Meridian smart money signals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
+| [Meridian](https://meridianfin.io/developers) | Smart money signals API — Congress trades, dark pool, insider trading, 13F, crypto on-chain | `apiKey` | Yes | Yes | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## What
Add [Meridian](https://meridianfin.io) to the Finance section — a smart money intelligence API providing Congress trading (STOCK Act), dark pool anomalies (FINRA), SEC insider trading (Form 4), institutional 13F filings, ARK Invest trades, crypto on-chain analytics, and more.

## Details
| Field | Value |
|-------|-------|
| URL | https://meridianfin.io/developers |
| Auth | apiKey (also supports x402 crypto micropayments) |
| HTTPS | Yes |
| CORS | Yes |
| Free tier | Yes (market regime + crypto Fear & Greed are free) |
| Docs | [OpenAPI spec](https://meridianfin.io/api/openapi.json), [llms.txt](https://meridianfin.io/llms.txt) |
| MCP Server | https://meridianfin.io/mcp (for AI agents) |

34 API tools covering smart money signals, crypto derivatives, on-chain data, and macro intelligence.