### PR TITLE
Add Statistics of the World API

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
+| [Statistics of the World](https://statisticsoftheworld.com/api-docs) | 440+ economic indicators for 218 countries (GDP, population, inflation, etc.) from IMF, World Bank, WHO | No | Yes | Yes | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |
 | [Tax Data API](https://apilayer.com/marketplace/tax_data-api) | Instant VAT number and tax validation across the globe | `apiKey` | Yes | Unkown | |


### PR DESCRIPTION
## Description

Adding Statistics of the World — a free REST API for global economic data.

- **440+ indicators**: GDP, inflation, population, health, education, trade, environment, governance
- **218 countries** with historical data
- **No authentication required**
- **Sources**: IMF World Economic Outlook, World Bank WDI, WHO
- **HTTPS**: Yes
- **CORS**: Yes

API docs: https://statisticsoftheworld.com/api-docs

Added to the Finance section (between SmartAPI and StockData, alphabetically).