### PR TITLE
Remove duplicate Numbers API entry added in previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1440,7 +1440,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Newton](https://newton.vercel.app) | Symbolic and Arithmetic Math Calculator | No | Yes | No |
 | [Noctua](https://api.noctuasky.com/api/v1/swaggerdoc/) | REST API used to access NoctuaSky features | No | Yes | Unknown |
 | [Numbers](https://math.tools/api/numbers/) | Number of the day, random number, number facts and anything else you want to do with numbers | `apiKey` | Yes | No |
-| [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
 | [Numbers](http://numbersapi.com/) | Facts about numbers (math, trivia, date, year) | No | No | Unknown |
 | [Ocean Facts](https://oceanfacts.herokuapp.com/) | Facts pertaining to the physical science of Oceanography | No | Yes | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |

--- a/README.md
+++ b/README.md
@@ -1441,6 +1441,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Noctua](https://api.noctuasky.com/api/v1/swaggerdoc/) | REST API used to access NoctuaSky features | No | Yes | Unknown |
 | [Numbers](https://math.tools/api/numbers/) | Number of the day, random number, number facts and anything else you want to do with numbers | `apiKey` | Yes | No |
 | [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
+| [Numbers](http://numbersapi.com/) | Facts about numbers (math, trivia, date, year) | No | No | Unknown |
 | [Ocean Facts](https://oceanfacts.herokuapp.com/) | Facts pertaining to the physical science of Oceanography | No | Yes | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |


### PR DESCRIPTION
While adding the Numbers API I noticed an existing entry already referenced `numbersapi.com`.
This PR removes the duplicate entry introduced in my earlier commit to keep the list clean.
