### PR TITLE
Add Statistics of the World API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |
+| [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |
 | [Teleport](https://developers.teleport.org/) | Quality of Life Data | No | Yes | Unknown |
 | [Umeå Open Data](https://opendata.umea.se/api/) | Open data of the city Umeå in northen Sweden | No | Yes | Yes |
 | [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |


### PR DESCRIPTION
## Add Statistics of the World API

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |

### Details
- **Section:** Open Data
- **Documentation:** https://statisticsoftheworld.com/api-docs
- **Auth:** No authentication required (up to 100 req/day, free API key for 1,000/day)
- **HTTPS:** Yes
- **CORS:** Yes
- Returns JSON for all 218 countries and 440+ indicators
- Data sourced from IMF, World Bank, WHO, FRED, UN