### PR TITLE
Add CatchDoms API

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
+| [CatchDoms](https://catchdoms.com/api/docs) | Expired domain auctions and SEO metrics from 12 registrars | `apiKey` | Yes | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds CatchDoms to the Business category.

- **API docs:** https://catchdoms.com/api/docs
- **Description:** Expired domain auctions and SEO metrics from 12 registrars
- **Auth:** apiKey (free signup)
- **HTTPS:** Yes
- **CORS:** Unknown

CatchDoms aggregates expired and auction domains from 12 platforms (GoDaddy, Dynadot, DropCatch, Catched, Gname, SnapNames, etc.) with SEO metrics (DA, backlinks, Trust Flow, domain age, quality score).