### PR TITLE
Add HTML to PDF Generator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
+| [HTML to PDF Generator](https://rapidapi.com/bstratocast-bstratocast-default/api/html-to-pdf-generator4) | Convert HTML/URL to PDF with Chromium. Merge, split, watermark, form-fill | `apiKey` | Yes | Yes |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
 | [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth` | Yes | Unknown |
 | [Mattermost](https://api.mattermost.com/) | An open source platform for developer collaboration | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Summary
- Adds **HTML to PDF Generator** API to the **Documents & Productivity** section
- API provides Chromium-based HTML/URL to PDF conversion with merge, split, watermark, and form-fill capabilities
- Available via RapidAPI with API key authentication, HTTPS, and CORS support

## Entry details
| Field | Value |
|:---|:---|
| Name | HTML to PDF Generator |
| Link | https://rapidapi.com/bstratocast-bstratocast-default/api/html-to-pdf-generator4 |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |

Placed in alphabetical order within the Documents & Productivity section.