### PR TITLE
Add plynx Music Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Napster](https://developer.napster.com/api/v2.2) | Music | `apiKey` | Yes | Yes |
 | [Openwhyd](https://openwhyd.github.io/openwhyd/API) | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...) | No | Yes | No |
 | [Phishin](https://phish.in/api-docs) | A web-based archive of legal live audio recordings of the improvisational rock band Phish | `apiKey` | Yes | No |
+| [plynx Music Intelligence](https://dashboard-ruddy-beta.vercel.app/docs) | AI-interpreted song metadata, 15 structured attributes, and 768-dim embeddings for 63,000+ songs | `apiKey` | Yes | Yes |
 | [Radio Browser](https://api.radio-browser.info/) | List of internet radio stations | No | Yes | Yes |
 | [Songkick](https://www.songkick.com/developer/) | Music Events | `apiKey` | Yes | Unknown |
 | [Songlink / Odesli](https://www.notion.so/API-d0ebe08a5e304a55928405eb682f6741) | Get all the services on which a song is available | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds **plynx Music Intelligence** to the **Music** category.

**plynx Music Intelligence** is a Data-as-a-Service API that provides:
- AI-interpreted song metadata for 63,000+ songs
- 15 structured musical attributes (genre, mood, energy, tempo, danceability, valence, vocal style, production, texture, acousticness, era, cultural origin, listening context, emotional arc, subgenre)
- 768-dimensional embeddings (OpenAI text-embedding-3-small) for vector similarity search
- Structured text representations for each song

### Why this API matters

Spotify deprecated its Audio Features / Audio Analysis API in November 2024, leaving a gap in the ecosystem for developers who need structured musical attributes and embeddings. plynx Music Intelligence fills that gap with richer, AI-interpreted attributes and pre-computed embeddings.

### Details

| Field | Value |
|-------|-------|
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |
| Free tier | Yes |
| Docs | https://dashboard-ruddy-beta.vercel.app/docs |