### PR TITLE
Add AgentDeals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
+| [AgentDeals](https://agentdeals.dev/api/docs) | Developer infrastructure free tiers, deals & pricing changes | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |


### PR DESCRIPTION
AgentDeals is a free REST API that aggregates developer infrastructure free tiers, startup credits, and pricing changes across 1,641 offers in 67 categories.

- **API Docs:** https://agentdeals.dev/api/docs (Swagger UI)
- **OpenAPI Spec:** https://agentdeals.dev/api/openapi.json
- **Auth:** None required
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **18 endpoints** including search, filtering, vendor comparison, stack planning, and pricing change tracking
- MIT licensed