### PR TITLE
Add Japan Neighborhoods API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ API | Description | Auth | HTTPS | CORS |
 | [INEI](http://iinei.inei.gob.pe/microdatos/) | Peruvian Statistical Government Open Data | No | No | Unknown |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
 | [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |
+| [Japan Neighborhoods](https://japanneighborhoods.com/developers) | Tokyo neighborhood crime statistics, safety scores, and station data | No | Yes | Yes |
 | [National Park Service, US](https://www.nps.gov/subjects/developer/) | Data from the US National Park Service | `apiKey` | Yes | Yes |
 | [Open Government, ACT](https://www.data.act.gov.au/) | Australian Capital Territory Open Data | No | Yes | Unknown |
 | [Open Government, Argentina](https://datos.gob.ar/) | Argentina Government Open Data | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Japan Neighborhoods API** to the Government category.

Free, read-only REST API for Tokyo neighborhood-level crime statistics from the Tokyo Metropolitan Police Department.

- **API docs**: https://japanneighborhoods.com/developers
- **Auth**: No (open access)
- **HTTPS**: Yes
- **CORS**: Yes
- **Endpoints**: 5 (wards, neighborhoods, safety rankings, crime trends, neighborhood detail)
- **Coverage**: 5,078 neighborhoods, 7 years (2018-2024), 37 crime categories
- **Data source**: Tokyo Metropolitan Police Department (official government data, CC BY 4.0)