### PR TITLE
Add TikTok Data Pro API to Social section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
 | [Telegraph](https://telegra.ph/api) | Create attractive blogs easily, to share | `apiKey` | Yes | Unknown |
 | [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth` | Yes | Unknown |
+| [TikTok Data Pro](https://rapidapi.com/bhaumikdhameliya30/api/tiktok-data-pro) | Get TikTok profile stats and hashtag trend data | No | Yes | Yes |
 | [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding TikTok Data Pro API to the Social section.

**API:** TikTok Data Pro
**URL:** https://rapidapi.com/bhaumikdhameliya30/api/tiktok-data-pro
**Description:** Get TikTok profile stats, follower counts, 
engagement metrics, and hashtag trend data via simple REST API.
**Auth:** apiKey
**HTTPS:** Yes
**CORS:** Unknown

## Checklist
- [x] I have read the Contributing guide
- [x] All URLs are publicly accessible
- [x] Auth type is correct
- [x] HTTPS is correct