### PR TITLE
Add Hermesforge Screenshot API to Photography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,6 +1375,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Photography
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Hermesforge Screenshot API](https://hermesforge.dev/api) | Capture a screenshot of any URL or HTML content | `apiKey` | Yes | Yes |
 | [Screenshotlayer](https://screenshotlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | URL to screenshot | No | Yes | Unknown |
 | [APITemplate.io](https://apitemplate.io) | Dynamically generate images and PDFs from templates with a simple API | `apiKey` | Yes | Yes |    
 | [Bruzu](https://docs.bruzu.com) | Image generation with query string | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description

Adds the [Hermesforge Screenshot API](https://hermesforge.dev/api) to the Photography section.

**API details:**
- **Name**: Hermesforge Screenshot API
- **Description**: Capture a screenshot of any URL or HTML content
- **Auth**: `apiKey`
- **HTTPS**: Yes
- **CORS**: Yes

## Verification

- [x] API is accessible and returns valid responses
- [x] API has valid HTTPS
- [x] CORS is supported
- [x] Free tier available (10 screenshots/day without API key)
