### PR TITLE
Add TCGApi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey` | Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |
 | [SuperHeroes](https://superheroapi.com) | All SuperHeroes and Villains data from all universes under a single API | `apiKey` | Yes | Unknown |
+| [TCGApi](https://tcgapi.dev/introduction/) | Trading card game prices and historical data across 89+ games | `apiKey` | Yes | No |
 | [TCGdex](https://www.tcgdex.net/docs) | Multi languages Pokémon TCG Information | No | Yes | Yes |
 | [Tebex](https://docs.tebex.io/plugin/) | Tebex API for information about game purchases | `X-Mashape-Key` | Yes | No |
 | [TETR.IO](https://tetr.io/about/api/) | TETR.IO Tetra Channel API | No | Yes | Unknown |


### PR DESCRIPTION
Adds TCGApi to the Games & Comics section.

TCGApi provides trading card game pricing data sourced from TCGPlayer for 89+ games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, One Piece, Flesh and Blood, and many others). It offers a free tier with 100 requests/day, real-time and historical price data, set/card metadata, and a documented OpenAPI 3.1 spec.

- Free tier: yes (100 req/day, no card required)
- Auth: API key via `X-API-Key` header
- HTTPS: yes
- CORS: no (origin restricted to tcgapi.dev)
- Documentation: https://tcgapi.dev/introduction/

Entry inserted alphabetically between SuperHeroes and TCGdex in the Games & Comics section.