### PR TITLE
Add Pokemon Price Tracker to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PlayerDB](https://playerdb.co/) | Query Minecraft, Steam and XBox Accounts | No | Yes | Unknown |
 | [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
 | [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi) | The Unofficial GraphQL for PokeAPI | No | Yes | Yes |
+| [Pokemon Price Tracker](https://www.pokemonpricetracker.com/pokemon-card-price-api) | Real-time and historical Pokemon card pricing from TCGPlayer and eBay graded sales | `apiKey` | Yes | Yes |
 | [Pokémon TCG](https://pokemontcg.io) | Pokémon TCG Information | No | Yes | Unknown |
 | [Psychonauts](https://psychonauts-api.netlify.app/) | Psychonauts World Characters Information and PSI Powers | No | Yes | Yes |
 | [PUBG](https://developer.pubg.com/) | Access in-game PUBG data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added Pokemon Price Tracker API to the Games & Comics section.

API provides real-time and historical pricing for Pokemon cards from TCGPlayer and eBay graded sales (PSA, CGC, BGS, SGC). Placed alphabetically between PokéAPI (GraphQL) and Pokémon TCG.