### PR TITLE
Add BenchGecko

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [BenchGecko](https://benchgecko.ai/api/v1) | AI model benchmarks, pricing, and comparisons for 414+ models | No | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
-| [BenchGecko](https://benchgecko.ai/api/v1) | AI model benchmarks, pricing, and comparisons for 414+ models | No | Yes | Yes |
+| [BenchGecko](https://benchgecko.ai/api-docs) | AI model benchmarks, pricing, and comparisons for 414+ models | No | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |


### PR DESCRIPTION
Added [BenchGecko](https://benchgecko.ai) to the Machine Learning section.

BenchGecko is a free API for comparing AI model benchmarks, pricing, and capabilities across 414+ models from 55 providers and 40 benchmarks (MMLU, HumanEval, GSM8K, etc.).

- **API Docs**: https://benchgecko.ai/api/v1
- **Auth**: No (free tier, no key required)
- **HTTPS**: Yes
- **CORS**: Yes