### PR TITLE
Add Deckaura Horoscope API

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
+| [Deckaura Horoscope](https://horoscope.deckaura.com/api/daily/aries) | Daily horoscope readings for all 12 zodiac signs (overview, love, career, lucky number) updated daily at 00:00 UTC | No | Yes | Yes |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |


### PR DESCRIPTION
Adding the Deckaura Horoscope API to the Entertainment category.

- **Endpoint:** https://horoscope.deckaura.com/api/daily/{sign}
- **Example:** https://horoscope.deckaura.com/api/daily/aries
- **Auth:** None
- **HTTPS:** Yes
- **CORS:** Yes
- **Cost:** Free, no registration

Returns daily horoscope JSON for all 12 zodiac signs (aries, taurus, gemini, cancer, leo, virgo, libra, scorpio, sagittarius, capricorn, aquarius, pisces). Each response includes overview, love, career, lucky number, and mood fields. Updated every 24 hours at 00:00 UTC via Cloudflare Cron Triggers.

The service is powered by Cloudflare Workers AI and runs entirely on the Cloudflare free tier — no API keys required from consumers.

Entry inserted alphabetically between `Corporate Buzz Words` and `Excuser`.