### PR TITLE
Add Email Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |
 | [Email Validation](https://www.abstractapi.com/email-verification-validation-api) | Validate email addresses for deliverability and spam | `apiKey` | Yes | Yes |
+| [Email Validator](https://apify.com/george.the.developer/email-validator-api) | Validate email addresses with syntax, DNS, and mailbox checks | `apiKey` | Yes | Yes |
 | [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added Email Validator to the Email section.

- **API Link**: https://apify.com/george.the.developer/email-validator-api
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: Validate email addresses with syntax, DNS, and mailbox checks

Free tier available. No device/service purchase required.