### PR TITLE
Add Domain WHOIS Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
+| [Domain WHOIS Lookup](https://apify.com/george.the.developer/domain-whois-lookup) | Look up WHOIS data for any domain including registrar and expiry | `apiKey` | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |
 | [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |


### PR DESCRIPTION
Added Domain WHOIS Lookup to the Development section.

- **API Link**: https://apify.com/george.the.developer/domain-whois-lookup
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: Look up WHOIS data for any domain including registrar and expiry

Free tier available. No device/service purchase required.