### PR TITLE
Add URL Metadata Extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |
+| [URL Metadata Extractor](https://apify.com/george.the.developer/url-metadata-extractor) | Extract Open Graph, meta tags, and structured data from any URL | `apiKey` | Yes | Yes |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
 | [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Added URL Metadata Extractor to the Development section.

- **API Link**: https://apify.com/george.the.developer/url-metadata-extractor
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: Extract Open Graph, meta tags, and structured data from any URL

Free tier available. No device/service purchase required.