### PR TITLE
Add DeFi Chain Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
+| [DeFi Chain Metrics](https://apify.com/george.the.developer/defi-chain-metrics-api) | DeFi protocol TVL, volume, and chain metrics across networks | `apiKey` | Yes | Yes |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added DeFi Chain Metrics to the Cryptocurrency section.

- **API Link**: https://apify.com/george.the.developer/defi-chain-metrics-api
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Description**: DeFi protocol TVL, volume, and chain metrics across networks

Free tier available. No device/service purchase required.