### PR TITLE
Add Word Orb to Dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Synonyms](https://www.synonyms.com/synonyms_api.php) | Synonyms, thesaurus and antonyms information for any given word | `apiKey` | Yes | Unknown |
 | [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
 | [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
+| [Word Orb](https://wordorb.ai) | 162K English words with IPA, etymology, part of speech, and 601K translations across 47 languages | No | Yes | Yes |
 | [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adding Word Orb to the Dictionaries section. It's a free dictionary + multilingual word API with:

- **162,253 English words** with IPA pronunciations, etymology, part of speech
- **601,143 translations** across 47 languages
- Free anonymous tier (no API key required)
- HTTPS only
- CORS enabled (`Access-Control-Allow-Origin: *`)

Example: `curl https://wordorb.ai/api/v1/word/hello` returns JSON with definitions, IPA, translations, and age-tiered content.

### Checklist
- [x] Entry is in alphabetical order (between Wordnik and Words)
- [x] Link works and uses HTTPS
- [x] Auth is `No` (free anonymous tier)
- [x] CORS is `Yes` (verified via response headers)
- [x] Description is specific, not generic

Maintained by Lesson of the Day, PBC — a US public benefit corporation.