### PR TITLE
Add HYDRA Regulatory Intelligence API (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ API | Description | Auth | HTTPS | CORS |
 <br >
 ### Finance
 API | Description | Auth | HTTPS | CORS |
+| [HYDRA Regulatory Intelligence](https://hydra-api-nlnj.onrender.com) | Real-time SEC, CFTC, Fed, FinCEN monitoring for prediction markets. Pays via USDC x402. | `apiKey` (x402/USDC) | Yes | Unknown |
 |---|:---|:---|:---|:---|
 | [Marketstack](https://marketstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-Time, Intraday & Historical Market Data API | `apiKey` | Yes | Unknown | |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adding **HYDRA Regulatory Intelligence** to the Finance category.

HYDRA provides real-time regulatory monitoring from SEC, CFTC, Fed, and FinCEN, aggregated for prediction market traders and compliance bots. Free discovery endpoint returns live Polymarket + Kalshi regulatory markets. Paid signal endpoints accept USDC via the x402 HTTP payment protocol.

- Live API: https://hydra-api-nlnj.onrender.com
- Docs: https://hydra-api-nlnj.onrender.com/docs
- OpenAPI: https://hydra-api-nlnj.onrender.com/openapi.json
