### PR TITLE
Add AgentWeb API

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
+| [AgentWeb](https://api.agentweb.live/docs) | Business directory with phone, email, hours for 11M+ businesses worldwide | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown 
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |


### PR DESCRIPTION
Adds AgentWeb to the Business category.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [AgentWeb](https://api.agentweb.live/docs) | Business directory with phone, email, hours for 11M+ businesses worldwide | `apiKey` | Yes | Yes |

- **Free tier:** 1,000 reads/day, instant signup, no credit card
- **Data:** 11M+ businesses across 227 countries with phone, email, hours, address, coordinates, social links
- **Formats:** JSON (default), markdown prose (`?format=text`), compact shorthand
- **Docs:** https://api.agentweb.live/docs
- **Website:** https://agentweb.live