### PR TITLE
Add len.sh API

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
+| [len.sh](https://len.sh) | Screenshots, OG images, and PDF generation API | `apiKey` | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |


### PR DESCRIPTION
Adds [len.sh](https://len.sh) to the Development category — a headless rendering API for generating screenshots, OG images, and PDFs via simple URL-based requests with signed URLs.

**Category:** Development

**Disclosure:** I am the creator of this API.