### PR TITLE
Add CyberBriefing — cybersecurity threat intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1472,6 +1472,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
+| [CyberBriefing](https://cyberbriefing.info/docs) | Cybersecurity threat intelligence: articles, CVEs, IOCs, and MITRE ATT&CK actor profiles | `apiKey` | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |


### PR DESCRIPTION
## Description

Adds [CyberBriefing](https://cyberbriefing.info) to the **Security** section.

CyberBriefing is a cybersecurity threat intelligence REST API providing:
- **2.7M+ security articles** spanning 27 years (1998–present)
- **103,000+ CVEs** with CVSS scores, severity, exploit availability
- **IOC lookup** — IPs, domains, file hashes, URLs
- **Threat actor profiles** — 181 APT/threat groups with TTPs
- **Keyword search** across the full article corpus
- **Free tier**: 200 req/day, no CC required

## API Details

- **Auth**: `apiKey` (via `X-API-Key` header)
- **HTTPS**: Yes
- **CORS**: Yes

## Checklist

- [x] Endpoint is functional and publicly accessible
- [x] Uses HTTPS
- [x] Has free tier (200 req/day)
- [x] API documentation available at https://cyberbriefing.info/docs/api
- [x] Follows alphabetical order (placed between Bugcrowd and Censys)