### PR TITLE
Add TCG Price Lookup API to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |
 | [SuperHeroes](https://superheroapi.com) | All SuperHeroes and Villains data from all universes under a single API | `apiKey` | Yes | Unknown |
 | [TCGdex](https://www.tcgdex.net/docs) | Multi languages Pokémon TCG Information | No | Yes | Yes |
+| [TCG Price Lookup](https://tcgpricelookup.com/tcg-api) | Live trading card prices across Pokemon, MTG, Yu-Gi-Oh, Lorcana, One Piece, Star Wars Unlimited, and Flesh and Blood | `apiKey` | Yes | Yes |
 | [Tebex](https://docs.tebex.io/plugin/) | Tebex API for information about game purchases | `X-Mashape-Key` | Yes | No |
 | [TETR.IO](https://tetr.io/about/api/) | TETR.IO Tetra Channel API | No | Yes | Unknown |
 | [Tronald Dump](https://www.tronalddump.io/) | The dumbest things Donald Trump has ever said | No | Yes | Unknown |


### PR DESCRIPTION
## What is TCG Price Lookup?

[TCG Price Lookup](https://tcgpricelookup.com/tcg-api) is a REST API for live trading card prices across **8 major TCGs**: Pokémon, MTG, Yu-Gi-Oh!, Disney Lorcana, One Piece, Star Wars: Unlimited, and Flesh and Blood.

Returns **TCGPlayer market prices**, **eBay sold-listing averages**, and **PSA / BGS / CGC graded card prices** from a single endpoint.

## Why add it?

This list already has Pokémon TCG (single-game, card data only) and TCGdex (single-game, multi-language). TCG Price Lookup covers **8 games with real pricing data** from two marketplaces + every major grading service, filling a gap the other entries don't cover.

| Field | Value |
|---|---|
| **API URL** | https://tcgpricelookup.com/tcg-api |
| **Auth** | API key via X-API-Key header |
| **HTTPS** | Yes |
| **CORS** | Yes |
| **Free tier** | 10,000 requests/month, no credit card |
| **SDKs** | JS, Python, Go, Rust, PHP |
| **GitHub** | [TCG-Price-Lookup](https://github.com/TCG-Price-Lookup) |

- [x] Alphabetical order in Games & Comics
- [x] Format matches existing table
- [x] API is publicly accessible with free tier
- [x] HTTPS + CORS supported