### PR TITLE
Add FXMacroData to Currency Exchange section

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangeratesapi.io](https://exchangeratesapi.io) | Exchange rates with currency conversion | `apiKey` | Yes | Yes |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
+| [FXMacroData](https://fxmacrodata.com/api-docs) | Macroeconomic indicators, central bank rates, FX spot rates, COT positioning, and release calendars for 18+ currencies | `apiKey` | Yes | Yes |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
 


### PR DESCRIPTION
Adds [FXMacroData](https://fxmacrodata.com) to the Currency Exchange section.

FXMacroData is a REST API providing macroeconomic indicators, central bank policy rates, FX spot rates, COT positioning, commodity prices, bond yields, and release calendars for 18+ currencies.

- **Docs:** https://fxmacrodata.com/api-docs
- **OpenAPI spec:** https://fxmacrodata.com/api/openapi.json
- **Auth:** API key (query parameter)
- **HTTPS:** Yes
- **CORS:** Yes