### PR TITLE
Add Resend to Email category

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
 | [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
 | [Mailtrap](https://mailtrap.docs.apiary.io/#) | A service for the safe testing of emails sent from the development and staging environments | `apiKey` | Yes | Unknown |
+| [Resend](https://resend.com/) | Modern email API built for developers | `apiKey` | Yes | No |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [Verifier](https://verifier.meetchopra.com/docs#/) | Verifies that a given email is real | `apiKey` | Yes | Yes |


### PR DESCRIPTION
### Description
Added the Resend API to the Email category. Resend is a modern email API built for developers with a focus on ease of use and great documentation.

### Checklist:
- [x] I have read the contribution guidelines.
- [x] I have followed the alphabetical order.
- [x] I have validated the API's HTTPS and CORS status.