### PR TITLE
Add OpenData.best API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, USA](https://www.data.gov/) | United States Government Open Data | No | Yes | Unknown |
 | [Open Government, Victoria State Government](https://www.data.vic.gov.au/) | Victoria State Government Open Data | No | Yes | Unknown |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
+| [OpenData.best](https://docs.opendata.best) | 865 govt & business data products across 42 countries | `apiKey` | Yes | Yes |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What does this PR do?

Adds [OpenData.best](https://docs.opendata.best) to the Government category.

## API Details

- **Name**: OpenData.best
- **Description**: 865 govt & business data products across 42 countries
- **Auth**: `apiKey`
- **HTTPS**: Yes
- **CORS**: Yes
- **Documentation**: https://docs.opendata.best/docs

OpenData.best provides a unified REST API to access government and business data products across 42 countries (445M+ records). Categories include business registries, procurement, compliance/sanctions, health, legal, construction, education, and financial data.

Free tier available.