### PR TITLE
Add FilePost to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown | |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |
+| [FilePost](https://filepost.dev/docs) | Upload files via REST API and get back a permanent public CDN URL | `apiKey` | Yes | Yes | |
 | [Filestack](https://www.filestack.com) | Filestack File Uploader & File Upload API | `apiKey` | Yes | Unknown |    |
 | [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown | |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |


### PR DESCRIPTION
Added FilePost to the Cloud Storage & File Sharing section.

FilePost is a REST API — you POST a file, you get back a permanent CDN URL. No setup, no S3 config. I use it in automation workflows where I need to host files programmatically without dealing with cloud storage configuration.

- API docs: https://filepost.dev/docs
- Has a free tier
- HTTPS only, supports CORS
- Returns a permanent public URL