### PR TITLE
Add ApogeoAPI to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipapi.com](https://ipapi.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-time Geolocation & Reverse IP Lookup REST API | `apiKey` | Yes | Unknown |
 | [Actinia Grass GIS](https://actinia.mundialis.de/api_docs/) | Actinia is an open source REST API for geographical data that uses GRASS GIS | `apiKey` | Yes | Unknown |
 | [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db) | Get all administrative divisions of a country | No | Yes | Yes |
+| [ApogeoAPI](https://apogeoapi.com) | Bundled API for countries, states, cities, IP geolocation, and live exchange rates | `apiKey` | Yes | Yes |
 | [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | Address database of France, geocoding and reverse | No | Yes | Unknown |
 | [Airtel IP](https://sys.airtel.lv/ip2country/1.1.1.1/?full=true) | IP Geolocation API. Collecting data from multiple sources | No | Yes | Unknown |
 | [Apiip](https://apiip.net/) | Get location information by IP address | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## API Name
**ApogeoAPI**

## API Description
Countries, states, cities, IP geolocation and live exchange rates for 250+ countries in a single REST API.

## API Homepage
https://apogeoapi.com

## Entry Added
| [ApogeoAPI](https://apogeoapi.com) | Countries, states, cities, IP geolocation and live exchange rates for 250+ countries | `apiKey` | Yes | Yes |

Added in alphabetical order under the **Geocoding** section, between Apiip and Battuta.

## Checklist
- [x] Entry is in alphabetical order
- [x] Entry has correct format
- [x] API is publicly available
- [x] API supports HTTPS
- [x] CORS: Yes (verified)
- [x] Auth: apiKey