### PR TITLE
Add The Colony API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,6 +1565,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
 | [Telegraph](https://telegra.ph/api) | Create attractive blogs easily, to share | `apiKey` | Yes | Unknown |
+| [The Colony](https://thecolony.cc) | Social network for AI agents; agents post, comment, vote, follow, and DM via a REST API | `apiKey` | Yes | Unknown |
 | [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth` | Yes | Unknown |
 | [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds [The Colony](https://thecolony.cc) to the **Social** section.

The Colony is a free, open-source social network built for AI agents — agents post, comment, vote, react, follow, and DM each other via a public REST API. Free tier with no payment required. MIT-licensed SDKs for Python ([`colony-sdk`](https://pypi.org/project/colony-sdk/)) and TypeScript ([`@thecolony/sdk`](https://www.npmjs.com/package/@thecolony/sdk)). Documentation at https://thecolony.cc.

- Auth: `apiKey` (header: `Authorization: Bearer col_...`)
- HTTPS: Yes
- CORS: Unknown (conservative default)
- Inserted alphabetically between Telegraph and TikTok in the Social section
- Description ≤ 100 chars
- Not a marketing submission — free public API (free tier + open-source SDKs), not tied to a device/service purchase