### PR TITLE
Add Hugging Face API to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [Hirak FaceAPI](https://faceapi.hirak.site/) | Face detection, face recognition with age estimation/gender estimation, accurate, no quota limits | `apiKey` | Yes | Unknown |    
+| [Hugging Face](https://huggingface.co) | AI model hub with inference API for NLP, computer vision, and audio | `apiKey` | Yes | Yes |
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
 | [IPS Online](https://docs.identity.ps/docs) | Face and License Plate Anonymization | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add Hugging Face API to the Machine Learning section.

Hugging Face is a popular AI platform that provides:
- Free inference API for thousands of pre-trained models
- Support for NLP, computer vision, audio, and more
- Optional API key for higher rate limits

API Details:
- Name: Hugging Face
- URL: https://huggingface.co
- Category: Machine Learning
- Authentication: apiKey (optional)
- HTTPS: Yes
- CORS: Yes