### PR TITLE
Add Helium API

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
+| [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
 | [IEX Cloud](https://iexcloud.io/docs/api/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes | |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds the Helium API to the Finance section.

- **API Name:** Helium
- **Description:** News with media bias scoring, balanced news synthesis, live market data, AI options pricing
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes
- **Link:** https://heliumtrades.com/mcp-page/

Helium provides free public API access for news with media bias scoring, balanced news feed synthesis, live stock market data, and AI-powered options pricing models.