### PR TITLE
Add RecipeAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
 | [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
+| [RecipeAPI](https://recipeapi.io) | Recipes, ingredients, nutrition data and cooking instructions | `apiKey` | Yes | Yes |
 | [Rustybeer](https://rustybeer.herokuapp.com/) | Beer brewing tools | No | Yes | No |
 | [Spoonacular](https://spoonacular.com/food-api) | Recipes, Food Products, and Meal Planning | `apiKey` | Yes | Unknown |
 | [Systembolaget](https://api-portal.systembolaget.se) | Govornment owned liqour store in Sweden | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding RecipeAPI to the Food & Drink section.

**API:** [RecipeAPI](https://recipeapi.io)
**Description:** Recipes, ingredients, nutrition data and cooking instructions
**Auth:** apiKey
**HTTPS:** Yes
**CORS:** Yes

Free tier available (500 requests/month, no credit card required).