### PR TITLE
Add Overpass API to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1713,6 +1713,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
+| [Overpass](https://wiki.openstreetmap.org/wiki/Overpass_API) | Read-only API for querying OpenStreetMap data, including roads, transit, and POIs | No | Yes | Unknown |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds the Overpass API (OpenStreetMap) to the **Transportation** section.

Overpass is a read-only API that serves up custom selected parts of OpenStreetMap data — including roads, public transit stops, POIs, and routing-relevant features. It's the standard way to programmatically query OSM data, widely used in routing, mapping, and geodata applications.

## Why this fits the project

- **Completely free, no paid tier, no auth required** for the public instance (the main instance only asks users to stay under 10k queries/day). No marketing angle — it's community-run infrastructure.
- **Not already listed**: verified with grep; "OpenStreetMap" is listed in the Geocoding section but points at the main OSM API, which is a different service (read-write, OAuth'd, editing-focused) from Overpass (read-only, query-focused).
- **Documentation is public**: https://wiki.openstreetmap.org/wiki/Overpass_API — I verified the page loads and documents the query language, endpoints, and usage limits.

## Format compliance

- One link per PR ✅
- Alphabetical order within section: inserted between `OpenSky Network` and `Railway Transport for France` ✅
- API name does not end with "API" ✅ (entry title is `Overpass`)
- Description length: 82 characters (under 100) ✅
- All five columns filled with valid values ✅
- PR title follows `Add Api-name API` format ✅

## Test plan

- [x] URL verified live (HTTP 200, content matches expected documentation)
- [x] No duplicate in repo (`grep -i overpass` → 0 matches before this PR)
- [x] Table format matches surrounding rows exactly
- [x] `python scripts/validate/format.py README.md` — pre-existing Python 3.14 compatibility error (reproduces on master, unrelated to this change)