### PR TITLE
Add DepScope — Package Health API for npm/PyPI/Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey` | Yes | Yes |
+| [DepScope](https://depscope.dev) | Package health, vulnerabilities, and version check for npm, PyPI, Cargo | No | Yes | Yes |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |


### PR DESCRIPTION
## DepScope

Free API to check package health, vulnerabilities, and versions for npm, PyPI, and Cargo packages.

- **URL:** https://depscope.dev
- **Auth:** None
- **HTTPS:** Yes
- **CORS:** Yes
- **Category:** Development

**Example:** `curl https://depscope.dev/api/check/npm/express`

Returns health score (0-100), vulnerabilities, version info, and actionable recommendation.