### PR TITLE
Add AI Dev Jobs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Jobs
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [AI Dev Jobs](https://aidevboard.com/openapi.yaml) | AI/ML job search API with 5,600+ roles from 300+ companies | No | Yes | Yes |
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds the AI Dev Jobs API to the Jobs section.

- **API**: [AI Dev Jobs](https://aidevboard.com/openapi.yaml)
- **Description**: AI/ML job search API with 5,600+ roles from 300+ companies
- **Auth**: No (free, no API key required for search)
- **HTTPS**: Yes
- **CORS**: Yes

The API provides endpoints for searching AI/ML jobs, filtering by company, location, and salary, and retrieving job details. Full OpenAPI spec available at the link above.