### PR TITLE
Add Not Human Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
+| [Not Human Search](https://nothumansearch.ai/openapi.yaml) | AI tool discovery with agentic scoring for 8,600+ tools and MCP servers | No | Yes | Yes |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds the Not Human Search API to the Machine Learning section.

- **API**: [Not Human Search](https://nothumansearch.ai/openapi.yaml)
- **Description**: AI tool discovery with agentic scoring for 8,600+ tools and MCP servers
- **Auth**: No (free, no API key required)
- **HTTPS**: Yes
- **CORS**: Yes

The API provides endpoints for searching AI tools, checking agentic readiness scores, and discovering MCP servers. Full OpenAPI spec available at the link above.