### PR TITLE
Add Webclaw API

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
+| [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
Adds [Webclaw](https://webclaw.io) to the **Development** section.

**API:** https://webclaw.io/docs/api
**Auth:** API key (Bearer token)
**HTTPS:** Yes
**CORS:** Yes
**Free tier:** 500 pages/month, no credit card required

Webclaw is a web content extraction API for LLMs. It converts any URL into clean markdown, JSON, or structured data via scrape, crawl, batch, search, extract, and summarize endpoints. Built in Rust, open source (AGPL-3.0).