### PR TITLE
Add VirtualSMS to Phone category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,6 +1368,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |
+| [VirtualSMS](https://virtualsms.io) | SMS verification with real physical SIM cards in 100+ countries | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds [VirtualSMS](https://virtualsms.io) to the Phone category.

**API Description:** SMS verification API using real physical SIM cards from carriers in 100+ countries. Supports one-time activations and number rentals. Returns phone numbers and received SMS codes via REST API.

- Auth: API key
- HTTPS: Yes
- CORS: Yes
- [API Documentation](https://github.com/virtualsms-io/api-docs)
