### PR TITLE
Add AI Dev Jobs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Jobs
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [AI Dev Jobs](https://aidevboard.com/docs) | Search AI/ML developer jobs with salary data | No | Yes | Yes |
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Jobs section.

**API URL:** https://aidevboard.com/api/v1/jobs  
**Docs:** https://aidevboard.com/docs  
**Auth:** No (free search endpoints, 100 req/hr, no auth required for read)  
**HTTPS:** Yes  
**CORS:** Yes  

AI Dev Jobs provides a free REST API to search 6,400+ AI/ML developer jobs across 370+ companies, with salary data, filtering by location/role/company, and pagination support.

- Free tier: 100 requests/hour, no authentication required
- OpenAPI spec available at /openapi.yaml
- Proper CORS headers for browser-based apps