### PR TITLE
Add Guía Apuestas Legal API — Argentina's legal casino data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
+| [Guía Apuestas Legal](https://guiaapuestaslegal.com/api/) | Real-time data on Argentina's legal online casinos: bonuses, rollover, withdrawal times, live odds, and embeddable widgets | No | Yes | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What's this API?

Public API aggregating real-time data on Argentina's 6 legal online casinos (those with .bet.ar license).

## What it returns

- **Casino data**: bonus amounts, rollover rates, withdrawal times, accepted payment methods
- **Live odds**: today's matches with comparative odds across all 6 casinos
- **Rankings**: by rollover (lower = better), withdrawal speed, effective bonus value
- **Embeddable widgets**: drop-in iframes for blogs/sites

## Technical checklist

- [x] HTTPS
- [x] No auth required (completely free)
- [x] CORS enabled
- [x] JSON responses (with \`_attribution\` field)
- [x] Live and operational

## Resources

- Docs + interactive playground: https://guiaapuestaslegal.com/api/
- Example: https://guiaapuestaslegal.com/wp-json/gal/v1/rollover
- OpenAPI spec available

## Entry added

\`\`\`
| [Guía Apuestas Legal](https://guiaapuestaslegal.com/api/) | Real-time data on Argentina's legal online casinos: bonuses, rollover, withdrawal times, live odds, and embeddable widgets | No | Yes | Yes |
\`\`\`

Thanks for maintaining this awesome list 🙏