### PR TITLE
Add AI Dev Jobs to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Jobs
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [AI Dev Jobs](https://aidevboard.com/docs) | AI and ML developer jobs with salary data and company info | `apiKey` | Yes | Unknown |
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Jobs section. It's a free REST API for AI/ML developer jobs with salary data and company info from 417+ companies including Anthropic, OpenAI, and Google DeepMind. API docs at https://aidevboard.com/docs.

- Auth: API key via `X-API-Key` header
- HTTPS: Yes
- CORS: Unknown