### PR TITLE
Add Road511 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
+| [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds Road511 — a unified REST/GeoJSON API that normalizes traffic data (events, cameras, DMS signs, bridge clearances, truck restrictions, EV charging, weather stations) from 65 US state and Canadian province 511 systems into a single interface.

Checklist:
- [x] I have searched the repo and confirmed Road511 is not already listed
- [x] Added one API per pull request
- [x] Entry is in alphabetical order (between REFUGE Restrooms and Sabre for Developers)
- [x] Description under 100 characters
- [x] No "API" suffix in the name, no TLD in the name
- [x] Auth / HTTPS / CORS fields verified
- [x] Table pipes padded with one space on either side