### PR TITLE
Add SustainMetrics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
 | [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |
+| [SustainMetrics](https://www.sustainmetrics.net/api) | 18,000+ GHG emission factors from DEFRA, EPA, ADEME, Ember | `apiKey` | Yes | Yes |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
 | [Website Carbon](https://api.websitecarbon.com/) | API to estimate the carbon footprint of loading web pages | No | Yes | Unknown |
 


### PR DESCRIPTION
Adding SustainMetrics to the Environment section.

- Name: SustainMetrics
- URL: https://www.sustainmetrics.net/api
- Description: 18,000+ GHG emission factors from DEFRA, EPA, ADEME, Ember
- Auth: apiKey (X-API-Key header)
- HTTPS: Yes (HSTS enforced)
- CORS: Yes (Access-Control-Allow-Origin: *)
- Free tier: 50 calls/day

SustainMetrics unifies official greenhouse gas emission factors from four authoritative sources into a single queryable REST API:
- UK DEFRA 2023-2025 (Open Government Licence v3.0)
- US EPA 2023-2025 (Public Domain)
- ADEME France 2024 (Licence Ouverte v2.0)
- Ember 193 countries 2024 (CC BY 4.0)

Sample query:
\`\`\`bash
curl "https://www.sustainmetrics.net/api/v1/factors?source=defra&year=2025&category=fuels" \
  -H "X-API-Key: YOUR_KEY"
\`\`\`

Free tier is 50 requests/day with email-only signup.

Alphabetical placement between "Srp Energy" and "UK Carbon Intensity" in Environment section. Description is 64 characters (under 100 limit). Checklist items from CONTRIBUTING.md verified.