### PR TITLE
Add Clinical Trials Directory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Health
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Clinical Trials Directory](https://trials.starfile.org/api) | Every clinical trial registered with ClinicalTrials.gov, indexed by condition and sponsor | No | Yes | Yes |
 | [CMS.gov](https://data.cms.gov/provider-data/) | Access to the data from the CMS - medicare.gov | `apiKey` | Yes | Unknown |
 | [Coronavirus](https://pipedream.com/@pravin/http-api-for-latest-wuhan-coronavirus-data-2019-ncov-p_G6CLVM/readme) | HTTP API for Latest Covid-19 Data | No | Yes | Unknown |
 | [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | UK Government coronavirus data, including deaths and cases by region | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |
+| [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |
 | [Teleport](https://developers.teleport.org/) | Quality of Life Data | No | Yes | Unknown |
 | [Umeå Open Data](https://opendata.umea.se/api/) | Open data of the city Umeå in northen Sweden | No | Yes | Yes |
 | [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |


### PR DESCRIPTION
Adds `trials.starfile.org/api` to the Health section — a free, no-auth, CORS-enabled JSON API mirroring all 581K registered clinical trials from ClinicalTrials.gov, indexed by condition, sponsor, phase, and recruiting status.

- **Auth**: None
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **Rate limit**: None (please cache)
- **Source**: ClinicalTrials.gov API v2 (U.S. National Library of Medicine, public domain)
- **Refresh**: Weekly
- **Example**: https://trials.starfile.org/api/trial/NCT06512883

Not a paid/marketing API — all endpoints free, all data public domain under 17 USC §105.