### PR TITLE
Add Harmonized Tariff Schedule API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
+| [Harmonized Tariff Schedule](https://hts.starfile.org/api) | Every U.S. HTS import tariff code with duty rates, product descriptions, and chapter metadata | No | Yes | Yes |
 | [Indian Pincode](https://indianpincode.com/) | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data | No | Yes | Yes |
 | [INEI](http://iinei.inei.gob.pe/microdatos/) | Peruvian Statistical Government Open Data | No | No | Unknown |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |


### PR DESCRIPTION
Adds `hts.starfile.org/api` to Government — a free, no-auth, CORS-enabled JSON API for every U.S. Harmonized Tariff Schedule (HTS) code.

- **Auth**: None
- **HTTPS**: Yes
- **CORS**: Yes
- **Source**: USITC Harmonized Tariff Schedule (public record)
- **Refresh**: Weekly
- **Example**: https://hts.starfile.org/api/code/0101.30.00.00
- **Endpoints**: /api/code/:htsno, /api/search?q=, /api/chapter/:n

29,581 codes with duty rates and product descriptions. No equivalent currently in the list.