### PR TITLE
Add CPSC Consumer Product Recalls API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
+| [CPSC Consumer Product Recalls](https://cpsc.starfile.org/api) | Every U.S. Consumer Product Safety Commission recall with hazards, manufacturers, retailers, countries | No | Yes | Yes |
 | [Conversor IAE CNAE](https://www.conversoriaecnae.es/api/v1/docs) | Spanish IAE/CNAE tax activity codes, 2009→2025 crosswalk and AEAT obligations | `apiKey` | Yes | No |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
 | [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds `cpsc.starfile.org/api` to Government — a free, no-auth, CORS-enabled JSON API for every U.S. CPSC consumer product recall.

- **Auth**: None
- **HTTPS**: Yes
- **CORS**: Yes
- **Source**: saferproducts.gov REST API (public record)
- **Refresh**: Weekly
- **Example**: https://cpsc.starfile.org/api/manufacturer/bissell

9,742 recalls indexed by manufacturer, retailer, country of manufacture, and year. No equivalent currently in the list.