### PR TITLE
Add JobDataLake to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,6 +1155,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
+| [JobDataLake](https://www.jobdatalake.com/docs) | 1M+ enriched job listings from 20,000+ companies with salary, skills, seniority | `apiKey` | Yes | Yes |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [JobDataLake](https://www.jobdatalake.com/docs) to the Jobs section.

- 1M+ enriched job listings from 20,000+ companies
- Structured fields: salary (USD), skills, seniority, remote type, job function
- REST API with 15+ filters
- Free tier: 1,000 credits, no credit card required
- Also available as an MCP server for AI tools