### PR TITLE
Add Agentic Engineering Jobs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference) | Job board API for agentic AI engineers (LangChain, LlamaIndex, CrewAI) | No | Yes | No |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |
 | [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |

--- a/README.md
+++ b/README.md
@@ -1146,7 +1146,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference) | Job board API for agentic AI engineers (LangChain, LlamaIndex, CrewAI) | No | Yes | No |
+| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/api-reference) | Job board API for agentic AI engineers (LangChain, LlamaIndex, CrewAI) | No | Yes | Yes |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |
 | [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adding a free, public job-board API to the Jobs section.

- Free, no auth required for read endpoints
- HTTPS, documented at https://agentic-engineering-jobs.com/api-reference
- OpenAPI 3.0 spec at /api/v1/openapi.json
- Niche focus: job postings for engineers building agentic systems (LangChain, LlamaIndex, CrewAI, etc.)

Placed alphabetically between Adzuna and Arbeitnow. Happy to adjust the description length if needed.