### PR TITLE
Add ip2geo.dev API

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IP Geolocation](https://www.abstractapi.com/ip-geolocation-api) | Geolocate website visitors from their IPs | `apiKey` | Yes | Yes |
 | [IP2Location](https://www.ip2location.com/web-service/ip2location) | IP geolocation web service to get more than 55 parameters | `apiKey` | Yes | Unknown |
 | [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy) | Detect proxy and VPN using IP address | `apiKey` | Yes | Unknown |
+| [ip2geo.dev](https://ip2geo.dev) | Programmatically convert IP addresses into geolocation data | `apiKey` | Yes | Yes |
 | [ipapi.co](https://ipapi.co/api/#introduction) | Find IP address location information | No | Yes | Yes |
 | [IPGEO](https://api.techniknews.net/ipgeo/) | Unlimited free IP Address API with useful information | No | Yes | Unknown |
 | [ipgeolocation](https://ipgeolocation.io/) | IP Geolocation AP with free plan 30k requests per month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [ip2geo.dev](https://ip2geo.dev) to the **Geocoding** section.

- [x] Formatting matches guidelines
- [x] Addition is ordered alphabetically
- [x] Submission has useful description
- [x] Description does not end with punctuation and is under 100 characters
- [x] Each table column is padded with one space on either side
- [x] Searched repository for relevant issues/PRs
- [x] All changes squashed into a single commit