### PR TITLE
Add SkynetX — crypto derivatives & market-data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [SkynetX](https://skynetx.io/docs/api) | Real-time crypto derivatives, funding rates, open interest, liquidations, ETF flows, options max-pain | `apiKey` | Yes | Yes |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
### Add SkynetX to Finance > Cryptocurrency

Adds **SkynetX** (https://skynetx.io), a real-time crypto derivatives & market-data API built for trading agents and quant systems.

**Coverage**
- Derivatives: funding rates, open interest, liquidations, long/short, basis across Binance, Bybit, OKX, Hyperliquid, dYdX, GMX, Drift
- Spot: prices, volumes, large orders
- Options: max-pain, IV surface, Greeks, PCR (Deribit)
- ETFs: spot BTC/ETH daily flows, AUM, biggest movers
- On-chain: whale transfers, stablecoin supply, exchange balances
- Indicators: CGDI, CDRI, fear & greed, bull-market peak signals

**Auth**: Bearer API key (anonymous tier available for public series like fear & greed)
**HTTPS**: Yes
**CORS**: Yes on public endpoints (`/api/v1/*`)
**Docs**: https://skynetx.io/docs/api
**OpenAPI 3.1**: https://skynetx.io/openapi.json
**LLM-friendly**: https://skynetx.io/llms.txt

Entry placed alphabetically in the Cryptocurrency sub-table (Sk comes before So).

- [x] My submission is not a duplicate
- [x] My entry is alphabetized correctly
- [x] The entry renders properly in the table
- [x] Description is under 100 characters