### PR TITLE
fix: use raw strings for regex patterns in format.py

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]


### PR DESCRIPTION

**Repo:** public-apis/public-apis (⭐ 425367)
**Type:** bugfix
**Files changed:** 1
**Lines:** +3/-3

## What
Convert three `re.compile(...)` pattern literals in `scripts/validate/format.py`
to raw strings (`r'...'`). The patterns contain `\s`, `\*`, and `\[` escape
sequences which are invalid in regular Python string literals.

## Why
Python 3.12 promoted invalid escape sequences in string literals from a
silent issue to a `SyntaxWarning` (and Python 3.13 keeps that behavior, with
plans to escalate to `SyntaxError` in a future release — see PEP 8 / CPython
issue tracker). On Python 3.13 the file emits three warnings on import:

```
SyntaxWarning: invalid escape sequence '\s'
SyntaxWarning: invalid escape sequence '\*'
SyntaxWarning: invalid escape sequence '\['
```

Raw strings are the idiomatic fix for regex patterns and remove the warnings
without changing semantics.

## Testing
- `python3 -W error::SyntaxWarning -c "from validate import format, links"` now
  succeeds (previously raised SyntaxError under `-W error`).
- `python3 -m pytest scripts/tests/test_validate_format.py` — 24 passed,
  74 subtests passed, no regressions.

## Risk
Low — purely a string-literal prefix change; the compiled regex bytes are
identical for these patterns.
