### PR TITLE
Add EmergencyAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1884,6 +1884,7 @@ API | Description | Auth | HTTPS | CORS |
 | [WeatherAPI](https://www.weatherapi.com/) | Weather API with other stuff like Astronomy and Geolocation API | `apiKey` | Yes | Yes |
 | [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
 | [Yandex.Weather](https://yandex.com/dev/weather/) | Assesses weather condition in specific locations | `apiKey` | Yes | No |
+| [EmergencyAPI](https://emergencyapi.com) | Real-time Australian emergency incidents from 27 government feeds | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Added EmergencyAPI to the Weather section.

EmergencyAPI provides real-time Australian emergency incident data (bushfires, floods, storms, earthquakes, rescues) from 27 official government feeds across all 8 states and territories, unified into a single REST API.

- **URL:** https://emergencyapi.com
- **Auth:** API key (free tier available, 500 requests/day)
- **HTTPS:** Yes
- **CORS:** Yes