### PR TITLE
Add Crime Brasil API (Government)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
+| [Crime Brasil](https://crimebrasil.com.br/api/data-sources) | Brazilian crime data — geocoded incidents from state police (SSP/RS, ISP/RJ, SEJUSP/MG), federal highway accidents (PRF DATATRAN), and Porto Alegre traffic incidents (EPTC) | No | Yes | Yes |
 | [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |
 | [City, Berlin](https://daten.berlin.de/) | Berlin(DE) City Open Data | No | Yes | Unknown |
 | [City, Gdańsk](https://ckan.multimediagdansk.pl/en) | Gdańsk (PL) City Open Data | No | Yes | Unknown |


### PR DESCRIPTION
## Adds: [Crime Brasil](https://crimebrasil.com.br) — Government section

Inserted alphabetically after "Brazilian Chamber of Deputies Open Data".

## API details

| Field | Value |
|---|---|
| Documentation | https://crimebrasil.com.br/api/data-sources |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| License | CC BY 4.0 |

## What it provides

Brazilian crime and public-safety data consolidated from official state police sources:

- **SSP/RS** (Rio Grande do Sul State Police): 2,988,995 geocoded incidents 2022–2025 at neighborhood level
- **ISP/RJ** (Rio de Janeiro Public Safety Institute): 810,057 records at municipality level
- **SEJUSP/MG** (Minas Gerais Public Safety Secretariat): 964,743 violent-crime records at municipality level
- **EPTC/POA** (Porto Alegre Traffic Engineering): 75,176 urban traffic incidents
- **PRF/DATATRAN**: 417,589 federal highway accidents across all 27 Brazilian states

All data exposed via REST API returning JSON. Free, no account needed, daily updates.

## Free-tier guarantee

The core API is free forever for journalists, researchers, civic tech, and non-commercial use. No registration required. CORS-enabled for browser-side use.

Disclosure: I'm the maintainer.