### PR TITLE
Add Random Profiles API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,6 +1633,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mockaroo](https://www.mockaroo.com/docs) | Generate fake data to JSON, CSV, TXT, SQL and XML | `apiKey` | Yes | Unknown |
 | [QuickMocker](https://quickmocker.com) | API mocking tool to generate contextual, fake or random data | No | Yes | Yes |
 | [Random Data](https://random-data-api.com) | Random data generator | No | Yes | Unknown |
+| [Random Profiles](https://random-profiles.com) | Fake user profiles and companies with 100+ fields each | `apiKey` | Yes | Yes |
 | [Randommer](https://randommer.io/randommer-api) | Random data generator | `apiKey` | Yes | Yes |
 | [RandomUser](https://randomuser.me) | Generates and list user data | No | Yes | Unknown |
 | [RoboHash](https://robohash.org/) | Generate random robot/alien avatars | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Random Profiles](https://random-profiles.com) to the **Test Data** section, alphabetically between `Random Data` and `Randommer`.

- URL: https://random-profiles.com
- Docs / OpenAPI: https://random-profiles.com/openapi.json
- Auth: `apiKey`
- HTTPS: Yes
- CORS: Yes
- Free tier: 100 profiles + 500 images + 100 companies per day (no credit card)

Random Profiles is a hosted fake-data API. It ships with 1,000 pre-seeded user profiles (100+ fields each — name, email, phone, address, job, financials, social, education, vehicle, relationships…) and 1,000 companies with AI-generated logos, linked via a cross-resource relationship graph. Useful for seeding databases, populating demos, and building test fixtures.

Entry placed alphabetically. Description is 54 chars (under the 100-char limit). Single link, single commit.