### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,8 @@ API | Description | Auth | HTTPS | CORS |
 <br >
 <br >
 ### Games & Comics
+
+| [REG-Vault](https://regvault.org/docs/api) | Retro-gaming metadata: 91k games across 99 systems, box art, manuals, screenshots, MCP server | No | Yes | Yes |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Age of Empires II](https://age-of-empires-2-api.herokuapp.com) | Get information about Age of Empires II resources | No | Yes | No |


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
