### PR TITLE
Add BOAMP & TED API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
+| [BOAMP & TED](https://tenderapi.fr) | French (BOAMP) and EU (TED) public procurement tenders and awards | `apiKey` | Yes | Yes |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |


### PR DESCRIPTION
Adds an entry for a unified REST API over French (BOAMP) and EU (TED) public procurement data in the Government section.

- Documentation: https://tenderapi.fr/docs
- OpenAPI spec: https://tenderapi.fr/openapi.json
- Auth: API key (X-API-Key header) — free tier with 100 req/day
- HTTPS: yes
- CORS: yes
- Data license: Licence Ouverte Etalab 2.0 (BOAMP) and EU open reuse (TED)

Entry is inserted alphabetically between "BCLaws" and "Brazil" in the Government section, following the existing format and sorting convention.