### PR TITLE
Add SportScore API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1603,6 +1603,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |
 | [Sport Places](https://developers.decathlon.com/products/sport-places) | Crowd-source sports places around the world | No | Yes | No |
 | [Sport Vision](https://developers.decathlon.com/products/sport-vision) | Identify sport, brands and gear in an image. Also does image sports captioning | `apiKey` | Yes | Yes |
+| [SportScore](https://sportscore.com/developers/) | Live scores, fixtures, standings and stats for football, basketball, cricket and tennis | No | Yes | Yes |
 | [Sportmonks Cricket](https://docs.sportmonks.com/cricket/) | Live cricket score, player statistics and fantasy API | `apiKey` | Yes | Unknown |
 | [Sportmonks Football](https://docs.sportmonks.com/football/) | Football score/schedule, news api, tv channels, stats, history, display standing e.g. epl, la liga | `apiKey` | Yes | Unknown |
 | [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |


### PR DESCRIPTION
### Adding

- **API:** SportScore
- **URL:** https://sportscore.com/developers/
- **Category:** Sports & Fitness

### Table row

| [SportScore](https://sportscore.com/developers/) | Live scores, fixtures, standings and stats for football, basketball, cricket and tennis | No | Yes | Yes |

### Compliance checklist

- [x] Entry is alphabetical within the Sports & Fitness section (between "Sport Vision" and "Sportmonks Cricket" — "SportS" < "Sportm" by ASCII)
- [x] Name does not include the top-level domain
- [x] Description is under 100 characters (89 characters) and does not end with "API"
- [x] Auth type is one of the allowed values (`No`)
- [x] CORS value is one of the allowed values (`Yes`)
- [x] API has a free-forever tier with no signup (~10,000 req/24h/IP)
- [x] API is not a marketing redirect — the `/developers/` URL is a technical reference page with OpenAPI spec, Redoc docs, and a 6-variant badge gallery
- [x] No affiliate links, no paid tier required for the listed functionality

### About SportScore

Free, key-less, CORS-open REST API for football (soccer), basketball, cricket and tennis. 8 endpoints covering live matches, match detail, team schedules, standings, top scorers, player stats, knockout brackets, and live trackers. OpenAPI spec at https://sportscore.com/developers/openapi.yaml and interactive "try it" docs at https://sportscore.com/developers/api/.
