### PR TITLE
Add Shirabe Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Non-Working Days](https://isdayoff.ru) | Simple REST API for checking working, non-working or short days for Russia, CIS, USA and other | No | Yes | Yes |
 | [Public Holidays](https://www.abstractapi.com/holidays-api) | Data on national, regional, and religious holidays via API | `apiKey` | Yes | Yes |
 | [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | Yes | No |
+| [Shirabe Calendar](https://shirabe.dev/docs/rokuyo-api) | Japanese rokuyo (六曜), rekichu auspicious days, eto, 24 solar terms | `apiKey` | Yes | Yes |
 | [The Calendar](https://the-calendar.net/api/) | Public holidays for US states and 30 countries plus sports and finance calendars as static JSON | No | Yes | Yes |
 | [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | Bank holidays in England and Wales, Scotland and Northern Ireland | No | Yes | Unknown |
 


### PR DESCRIPTION
**API**: Shirabe Calendar
**Link**: https://shirabe.dev/docs/rokuyo-api
**Description**: Japanese rokuyo (六曜), rekichu auspicious days, eto, 24 solar terms
**Auth**: `apiKey` (X-API-Key header, optional anonymous Free tier)
**HTTPS**: Yes
**CORS**: Yes

Shirabe Calendar provides Japanese traditional calendar data (rokuyo / rekichu / eto / 24 solar terms) with purpose-specific auspicious-day scoring across 8 categories (wedding, funeral, moving, construction, business opening, car delivery, marriage registration, travel). Coverage: 1873-01-01 to 2100-12-31. Anonymous free tier (10,000 req/month, IP-rate-limited), paid tier available via https://shirabe.dev.

- Full documentation: https://shirabe.dev/docs/rokuyo-api
- OpenAPI 3.1 spec: https://shirabe.dev/openapi.yaml
- Source (MIT): https://github.com/techwell-inc-jp/shirabe-calendar-api
- Operated by Techwell Inc. (株式会社テックウェル), Fukuoka, Japan

Placed alphabetically in Calendar section between "Russian Calendar" and "UK Bank Holidays".

---

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (N/A - not creating new category)
- [x] All changes have been squashed into a single commit
