### PR TITLE
Add Urantia Papers API to Books

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Rig Veda](https://aninditabasu.github.io/indica/html/rv.html) | Gods and poets, their categories, and the verse meters, with the mandal and sukta number | No | Yes | Unknown |
 | [The Bible](https://docs.api.bible) | Everything you need from the Bible in one discoverable place | `apiKey` | Yes | Unknown |
 | [Thirukkural](https://api-thirukkural.web.app/) | 1330 Thirukkural poems and explanation in Tamil and English | No | Yes | Yes |
+| [Urantia Papers](https://urantia.dev) | Full-text + semantic search across the Urantia Papers, with audio narration, entities, translations | No | Yes | Yes |
 | [Vedic Society](https://aninditabasu.github.io/indica/html/vs.html) | Descriptions of all nouns (names, places, animals, things) from vedic literature | No | Yes | Unknown |
 | [Wizard World](https://wizard-world-api.herokuapp.com/swagger/index.html) | Get information from the Harry Potter universe | No | Yes | Yes |
 | [Wolne Lektury](https://wolnelektury.pl/api/) | API for obtaining information about e-books available on the WolneLektury.pl website | No | Yes | Unknown |


### PR DESCRIPTION
adds the Urantia Papers API to the Books section. it's a free, no-auth, https + cors public API for full-text and semantic search across the Urantia Papers, with audio narration, entities, and translations.

- docs: https://urantia.dev
- openapi spec: https://api.urantia.dev/openapi.json
- license: MIT (code) / CC0 (content)

added alphabetically between Thirukkural and Vedic Society. description is 99 chars.
