### PR TITLE
Add OpenRegistry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, USA](https://www.data.gov/) | United States Government Open Data | No | Yes | Unknown |
 | [Open Government, Victoria State Government](https://www.data.vic.gov.au/) | Victoria State Government Open Data | No | Yes | Unknown |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
+| [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What

Adds [OpenRegistry](https://openregistry.sophymarine.com) — a free real-time API that proxies **27 national company registries** (UK Companies House, France INSEE/RNE, Germany Handelsregister, Italy InfoCamere via EU BRIS, Spain BORME, Korea OpenDART, plus 21 more) directly from each government's public-data endpoint.

## Why it fits

- **Free / anonymous tier** out of the box (20 req/min/IP) — no signup, no API key
- **HTTPS**: yes (required by upstream registry APIs)
- **CORS**: marked `Unknown` because access is currently allowlisted to specific MCP-client origins; non-MCP HTTP clients work server-side
- **Government category**: the entire data surface is sourced directly from national company registries
- **Alphabetical placement**: `OpenRegistry` after the existing `Open Government, *` entries

## Provenance

Documentation under CC-BY-4.0 at https://github.com/sophymarine/openregistry.

This is a free public API; the paid tiers exist solely for higher rate limits and pre-synthesized source-URL fields, **none of the data behind those tiers is proprietary** — every byte of registry data is also available on the anonymous tier.
