### PR TITLE
Add Runyankole Bible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Quran Cloud](https://alquran.cloud/api) | A RESTful Quran API to retrieve an Ayah, Surah, Juz or the entire Holy Quran | No | Yes | Yes |
 | [Quran-api](https://github.com/fawazahmed0/quran-api#readme) | Free Quran API Service with 90+ different languages and 400+ translations | No | Yes | Yes |
 | [Rig Veda](https://aninditabasu.github.io/indica/html/rv.html) | Gods and poets, their categories, and the verse meters, with the mandal and sukta number | No | Yes | Unknown |
+| [Runyankole Bible](https://runyankole-bible-api.vercel.app) | Free REST API for the Runyankore-Rukiga Bible — 66 books, 31106 verses | No | Yes | Yes |
 | [The Bible](https://docs.api.bible) | Everything you need from the Bible in one discoverable place | `apiKey` | Yes | Unknown |
 | [Thirukkural](https://api-thirukkural.web.app/) | 1330 Thirukkural poems and explanation in Tamil and English | No | Yes | Yes |
 | [Vedic Society](https://aninditabasu.github.io/indica/html/vs.html) | Descriptions of all nouns (names, places, animals, things) from vedic literature | No | Yes | Unknown |


### PR DESCRIPTION
## API Name
Runyankole Bible API

## API URL
https://runyankole-bible-api.vercel.app

## Category
Books

## Description
Free, public REST API for the Runyankore-Rukiga Bible (Baibuli Erikwera 1964). 
Provides 66 books and 31,106 verses with endpoints for verse lookup, chapter 
retrieval, keyword search, and random verse. No auth required, CORS enabled.

## Checklist
- [x] I have read the contributing guidelines
- [x] The API is publicly available
- [x] HTTPS is supported
- [x] The API returns JSON