### PR TITLE
Add Sunor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Songsterr](https://www.songsterr.com/a/wa/api/) | Provides guitar, bass and drums tabs and chords | No | Yes | Unknown |
 | [SoundCloud](https://developers.soundcloud.com/docs/api/guide) | With SoundCloud API you can build applications that will give more power to control your content | `OAuth` | Yes | Unknown |
 | [Spotify](https://beta.developer.spotify.com/documentation/web-api/) | View Spotify music catalog, manage users' libraries, get recommendations and more | `OAuth` | Yes | Unknown |
+| [Sunor](https://docs.sunor.cc) | AI music generation API via Suno, with pay-as-you-go credits | `apiKey` | Yes | Unknown |
 | [TasteDive](https://tastedive.com/read/api) | Similar artist API (also works for movies and TV shows) | `apiKey` | Yes | Unknown |
 | [TheAudioDB](https://www.theaudiodb.com/api_guide.php) | Music | `apiKey` | Yes | Unknown |
 | [Vagalume](https://api.vagalume.com.br/docs/) | Crowdsourced lyrics and music knowledge | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Sunor to the Music section.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [Sunor](https://docs.sunor.cc) | AI music generation API via Suno, with pay-as-you-go credits | apiKey | Yes | Unknown |

- **Free tier:** 25 credits on signup ($2.50 worth) — usable without payment.
- **Auth:** API key via `x-api-key` header.
- **HTTPS:** all endpoints.
- **Docs:** https://docs.sunor.cc
- **OpenAPI spec:** https://sunor.cc/openapi.yaml

Alphabetical placement: between Spotify and TasteDive.

- [x] Description ≤ 100 chars
- [x] Name does not end with "API"
- [x] No TLD in name
- [x] Single link added
- [x] Targeted to `master`