### PR TITLE
Add IPLogs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,6 +1485,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Hashable](https://hashable.space/pages/api/) | A REST API to access high level cryptographic functions and methods | No | Yes | Yes |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
+| [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing. | No | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |


### PR DESCRIPTION
## What

Adds IPLogs to the Security category — a free, no-signup VPN, proxy, Tor and datacenter IP detection API.

## Why

The Security section covers breach lookups, OSINT, vulnerability data, and email/domain reputation, but there's no entry for VPN/proxy/datacenter IP classification. IPLogs fills that gap with a free public REST endpoint at `https://iplogs.com/v1/check` — no signup, no API key, CORS-enabled, IPv4 + IPv6.

## Verification

- Live demo: https://iplogs.com
- Public docs: https://iplogs.com/docs
- Quick test:
  \`\`\`
  curl -X POST https://iplogs.com/v1/check \\
    -H 'content-type: application/json' \\
    -d '{"ip":"8.8.8.8"}'
  \`\`\`

## Checklist

- [x] Description ≤ 100 chars (77 chars)
- [x] Does not start with "A "/"An "/"The "
- [x] Name does not include TLD or "API" suffix
- [x] Alphabetically placed (between "Intelligence X" and "LoginRadius")
- [x] Auth = `No` (truly auth-free public API)
- [x] HTTPS = `Yes`
- [x] CORS = `Yes` (enabled for browser clients)
- [x] One link only
- [x] Single commit, targets `master`