### PR TITLE
Add TensorFeed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,6 +1188,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
+| [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds TensorFeed to the Machine Learning section.

TensorFeed is a real-time AI industry intelligence aggregator. The free public API exposes:
- AI news from 15+ sources (Anthropic, OpenAI, Google, TechCrunch, The Verge, arXiv, HuggingFace, etc.)
- Live service status and incident tracking for major AI providers
- Model pricing across all major providers
- AI agent activity and traffic data
- 30+ free endpoints, all CORS-enabled, no API key, no signup

Documentation: https://tensorfeed.ai/developers
Discovery manifest: https://tensorfeed.ai/llms.txt
OpenAPI spec: https://tensorfeed.ai/openapi.json