### PR TITLE
Add GeoScore API to Text Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,6 +1657,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |
 | [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
+| [GeoScore](https://geoscoreapi.com) | Score content for AI search citation readiness. Returns a 0-100 GEO score, 8 structural metrics, and improvement fixes | `apiKey` | Yes | Yes |
 | [Hirak OCR](https://ocr.hirak.site/) | Image to text -text recognition- from image more than 100 language, accurate, unlimited requests | `apiKey` | Yes | Unknown |
 | [Hirak Translation](https://translate.hirak.site/) | Translate between 21 of most used languages, accurate, unlimited requests | `apiKey` | Yes | Unknown |
 | [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/) | Translation API with free tier and reasonable prices | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description
Adds [GeoScore](https://geoscoreapi.com) to the Text Analysis section.

**GeoScore** is a REST API that scores any text or URL for AI search citation readiness (GEO — Generative Engine Optimization). It returns a 0–100 score, 8 structural metrics, and a ranked list of concrete fixes.

## API Details
- **URL:** https://geoscoreapi.com
- **Auth:** apiKey (X-GeoScore-Key header)
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** Yes (50 analyses/month)
- **Docs:** https://api.geoscoreapi.com/docs

## Checklist
- [x] Entry is in alphabetical order within the category
- [x] Auth type is correct (apiKey)
- [x] HTTPS is correct (Yes)
- [x] CORS is correct (Yes)
- [x] Link is working