### PR TITLE
Add x402 Data API - HTTP 402 payment protocol developer data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ API | Description | Auth | HTTPS | CORS |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
+| [x402 Data API](https://goto-spring-php-instructor.trycloudflare.com) | Developer data APIs with x402 HTTP 402 payment protocol - pay per request using USDC on Base chain | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## x402 Data API

Developer data APIs with x402 HTTP 402 payment protocol - pay per request using USDC on Base chain.

### Features
- GitHub Trending repositories ($0.01 USDC/request)
- NPM package statistics ($0.005 USDC/request)
- HackerNews top stories ($0.005 USDC/request)
- Crypto price lookup ($0.003 USDC/request)

### How it works
This API uses the x402 protocol (HTTP 402 Payment Required) for micro-payments. Clients pay per request using USDC on Base chain. No API key needed - payments are handled automatically via the HTTP 402 protocol.

### Endpoints
- `GET /api/github/trending` - GitHub trending repos
- `GET /api/npm/stats/:package` - NPM package stats  
- `GET /api/hackernews/top` - HN top stories
- `GET /api/crypto/price/:symbol` - Crypto prices

### Links
- API: https://goto-spring-php-instructor.trycloudflare.com
- Discovery: https://goto-spring-php-instructor.trycloudflare.com/.well-known/x402-discovery

Added to Blockchain section as it uses blockchain (Base chain) for payments.