### PR TITLE
feat: add Indian Pincode API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
+| [Indian Pincode](https://indianpincode.com/) | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data | No | Yes | Yes |
 | [INEI](http://iinei.inei.gob.pe/microdatos/) | Peruvian Statistical Government Open Data | No | No | Unknown |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
 | [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds **[Indian Pincode](https://indianpincode.com/)** to the Government section.

## API Details

| Field | Value |
|-------|-------|
| **Name** | Indian Pincode |
| **URL** | https://indianpincode.com/ |
| **Description** | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data |
| **Auth** | No |
| **HTTPS** | Yes |
| **CORS** | Yes |

## Why it qualifies

- Completely free, no authentication required
- Covers all 165k+ post offices across India with GPS coordinates, state, district, taluk, and delivery status data
- HTTPS + CORS enabled — works from any browser/app
- Live REST API: `GET /api/v1/pincode/{code}` and `GET /api/v1/search?q=`
- India is the world's largest postal network — a reliable free lookup has been a long-standing gap in this list

## Testing

```bash
curl https://indianpincode.com/api/v1/pincode/560001
```

Returns JSON with pincode details, GPS coordinates, post office list, district/state info.

I've placed the entry alphabetically within the Government section (before INEI).