### PR TITLE
Add Parlay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1598,6 +1598,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
+| [ParlayAPI](https://parlay-api.com/docs) | Real-time sports betting odds aggregating 21+ sportsbooks, DFS apps, exchanges, and prediction markets across 38+ sports. Free tier, 1K req/month | `apiKey` | Yes | No |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1598,7 +1598,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
-| [ParlayAPI](https://parlay-api.com/docs) | Real-time sports betting odds aggregating 21+ sportsbooks, DFS apps, exchanges, and prediction markets across 38+ sports. Free tier, 1K req/month | `apiKey` | Yes | No |
+| [Parlay](https://parlay-api.com/docs) | Real-time sports betting odds from 21+ sportsbooks across 38+ sports with free tier (1K req/month) | `apiKey` | Yes | No |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1853,6 +1853,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
+| [Parlay](https://parlay-api.com/docs) | Real-time sports odds and player props from 45+ sportsbooks and sources across 90+ sports | `apiKey` | Yes | Yes |
 | [PlayerElo](https://playerelo.football/api-access) | Player-level Elo ratings, predictions and history for 176 football leagues | `apiKey` | Yes | Unknown |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

---

Adds [Parlay](https://parlay-api.com/docs) (parlay-api.com) to **Sports & Fitness**, between Padel Snipe and PlayerElo.

**Disclosure: I'm the founder of ParlayAPI** — first-party submission.

- Real-time sports odds and player-props API aggregating 45+ sportsbooks and data sources across 90+ sports, over REST and WebSocket
- Free tier: 1,000 credits/month, no credit card required — https://parlay-api.com/pricing
- Auth: `apiKey` (public discovery endpoints such as `/v1/sports` need none)
- HTTPS: Yes · CORS: Yes (`Access-Control-Allow-Origin` echoes the request origin — re-verified 2026-08-25)
- Docs: https://parlay-api.com/docs · OpenAPI spec: https://parlay-api.com/openapi.json

**Update 2026-08-25:** rebased onto current `master` (resolves the merge conflict), squashed to a single commit, refreshed the description to current measured coverage numbers, and corrected CORS to `Yes` (the API now serves CORS headers). Entry name kept as "Parlay" per earlier review feedback.
