### PR TITLE
Add KDP Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Books](https://developers.google.com/books/) | Books | `OAuth` | Yes | Unknown |
 | [GurbaniNow](https://github.com/GurbaniNow/api) | Fast and Accurate Gurbani RESTful API | No | Yes | Unknown |
 | [Gutendex](https://gutendex.com/) | Web-API for fetching data from Project Gutenberg Books Library | No | Yes | Unknown |
+| [KDP Intelligence](https://kdp-intelligence-api.vercel.app/docs) | KDP niche demand scores, competition analysis and revenue estimates | No | Yes | Yes |
 | [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | No |
 | [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Yes |
 | [PoetryDB](https://github.com/thundercomb/poetrydb#readme) | Enables you to get instant data from our vast poetry collection | No | Yes | Yes |


### PR DESCRIPTION
## Add KDP Intelligence API to Books

**API:** [KDP Intelligence](https://kdp-intelligence-api.vercel.app/docs)
**Description:** KDP niche demand scores, competition analysis and revenue estimates
**Auth:** No (free listing endpoint; paid detail endpoint uses x402 micropayments)
**HTTPS:** Yes
**CORS:** Yes

### About

The KDP Intelligence API provides Kindle Direct Publishing niche research data — demand scores, competition intensity, BSR ranges, monthly revenue estimates, and pricing data.

- Free discovery endpoint: `GET /v1/niches`
- Paid detail endpoint: `GET /v1/niche/{keyword}` (0.03 USDC via x402 protocol)
- OpenAPI 3.1.0 spec: https://kdp-intelligence-api.vercel.app/openapi.json