### PR TITLE
Add OpenVan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
+| [OpenVan](https://openvan.camp/docs) | Fuel prices for 121 countries, food cost index & vanlife weather scores for RV travel | No | Yes | Yes |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## API Description

[OpenVan.camp](https://openvan.camp) provides free, real-time travel data specifically for vanlife/RV travelers:

- **Fuel prices** — retail prices (gasoline, diesel, LPG, E85) for 121 countries from 200+ government sources, updated every 6 hours
- **VanBasket food cost index** — cost-of-living comparison across 92 countries vs. a world baseline
- **VanSky weather scores** — vanlife-specific weather suitability (0–100) with van comfort, sleep conditions, solar yield

**No authentication required. CORS enabled. CC BY 4.0.**

**API Documentation:** https://openvan.camp/docs  
**OpenAPI spec:** https://openvan.camp/docs.openapi

## Checklist

- [x] API is publicly accessible
- [x] API is free / has free tier
- [x] API uses HTTPS
- [x] CORS is enabled
- [x] No authentication required
- [x] Description is under 100 characters
- [x] Entry is in alphabetical order within Transportation section
- [x] All links are working