### PR TITLE
Add Coolreadme API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Countly](https://api.count.ly/reference) | Countly web analytics | No | No | Unknown |
 | [Creative Commons Catalog](https://api.creativecommons.engineering/) | Search among openly licensed and public domain works | `OAuth` | Yes | Yes |
+| [Coolreadme](https://coolreadme.xyz/docs) | Generate dynamic GitHub README cards via URL — Netflix, X, Twitch, animated pet streaks | No | Yes | Yes |
 | [Datamuse](https://www.datamuse.com/api/) | Word-finding query engine | No | Yes | Unknown |
 | [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org | No | Yes | Unknown |
 | [Evil Insult Generator](https://evilinsult.com/api) | Evil Insults | No | Yes | Yes |


### PR DESCRIPTION
Adding [Coolreadme](https://coolreadme.xyz) to the **Open Source Projects** section, alphabetically between *Creative Commons Catalog* and *Datamuse*.

## What it is

A free API that returns dynamic SVG/PNG cards for embedding in GitHub READMEs (or any markdown file). Construct a URL with query params, drop it in `<img>` or `![]()`, and the platform renders it live.

Example:

```
https://coolreadme.xyz/api/cinematic?user=octocat&status=SHIPPING+CODE
https://coolreadme.xyz/api/cat-card?user=octocat
https://coolreadme.xyz/api/x-card?user=karpathy&handle=karpathy&likes=48.2k&views=4.2M
```

## Field values

| Field | Value | Verification |
|---|---|---|
| API | [Coolreadme](https://coolreadme.xyz) | Working |
| Description | Generate dynamic GitHub README cards via URL — Netflix, X, Twitch, animated pet streaks | 91 chars (≤100) |
| Auth | `No` | No tokens, no signup, no API keys |
| HTTPS | `Yes` | Vercel-hosted with HTTPS by default |
| CORS | `Yes` | Confirmed via `curl -I` — `access-control-allow-origin: *` |

## Format checklist

- [x] Added at the alphabetically correct position (between *Creative Commons Catalog* and *Datamuse*)
- [x] Single API addition per PR
- [x] Description ≤ 100 characters
- [x] Name does not include TLD (`Coolreadme`, not `coolreadme.xyz`)
- [x] Name does not end with "API"
- [x] Free with no purchase required (no devices, no paid tier)
- [x] Different from existing entries — this is a card builder; the listed `GitHub ReadMe Stats` is a stats-only widget
- [x] PR title format: `Add Api-name API`
- [x] Single squashed commit

## Related but distinct

The Open Source Projects section already includes `GitHub ReadMe Stats` (anuraghazra) and `Shields`. Coolreadme is complementary, not a duplicate — it produces app-style cards (Netflix layouts, X tweets, Steam libraries, animated pet streaks) rather than statistics or badges.