### PR TITLE
Add Onyx Bazaar API to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
 | [Nasdaq Data Link](https://docs.data.nasdaq.com/) | Stock market data | `apiKey` | Yes | Unknown |
 | [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | Open data about nobel prizes and events | No | Yes | Yes |
+| [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) | Free public leaderboard of x402 paid HTTP services indexed from Coinbase CDP discovery API | No | Yes | Unknown |
 | [Open Data Minneapolis](https://opendata.minneapolismn.gov/) | Spatial (GIS) and non-spatial city data for Minneapolis | No | Yes | No |
 | [openAFRICA](https://africaopendata.org/) | Large datasets repository of African open data | No | Yes | Unknown |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Onyx Bazaar** under the **Open Data** section.

**What it is:** A free public leaderboard of every paid x402 HTTP service indexed from Coinbase's CDP discovery API. Refreshed every 15 minutes. Four views (top by volume / unique payers / recently active / cheapest). JSON variant at [`/bazaar.json`](https://onyx-actions.onrender.com/bazaar.json) for programmatic consumers.

**Why it fits Open Data:** It's a public dataset of payment-protocol service activity (analogous to the existing entries for `BotsArchive`, `OpenSanctions`, `Voidly` — public datasets surfacing protocol/network activity). No signup, no API key, no payment to use the dashboard or the JSON.

**Currently indexes:** 1,000+ services / 122,000+ calls per 30 days across Base mainnet (949), Solana (33), Base-Sepolia (17), and Stellar testnet.

**Submission checklist (per [CONTRIBUTING.md](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)):**
- [x] No payment / device purchase required to use this API
- [x] Free public access (no key, no signup)
- [x] HTTPS supported
- [x] One link per Pull Request
- [x] Alphabetical ordering preserved (slot: between `Nobel Prize` and `Open Data Minneapolis`)
- [x] Description ≤ 100 characters
- [x] PR title format: `Add <Api-name> API`
- [x] Auth: `No` (correct value from accepted inputs)
- [x] Single new line, no other changes

Live links:
- Dashboard: https://onyx-actions.onrender.com/bazaar
- JSON: https://onyx-actions.onrender.com/bazaar.json
- Source (MIT): https://github.com/dimitrilaouanis-tech/onyx-mcp
