### PR TITLE
Add EmailJS API to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |
+| [EmailJS](https://www.emailjs.com/docs/) | Send emails directly from client-side JavaScript without a backend server | `apiKey` | Yes | Yes |
 | [Email Validation](https://www.abstractapi.com/email-verification-validation-api) | Validate email addresses for deliverability and spam | `apiKey` | Yes | Yes |
 | [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [API addition checklist](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md#api-addition-checklist)
- [x] I confirm this API has a free tier or is completely free
- [x] I have added a single API entry per pull request
- [x] I have verified the API name does not end with "API" or contain a TLD
- [x] I have verified the description is under 100 characters and has no ending punctuation
- [x] I have verified the entry is alphabetically ordered within its category
- [x] I have squashed all my commits into a single commit

## Additional Information

**API Documentation:** https://www.emailjs.com/docs/

**Test Request:**
```bash
curl -X POST "https://api.emailjs.com/api/v1.0/email/send" \
  -H "Content-Type: application/json" \
  -d '{
    "service_id": "YOUR_SERVICE_ID",
    "template_id": "YOUR_TEMPLATE_ID",
    "user_id": "YOUR_PUBLIC_KEY",
    "accessToken": "YOUR_PRIVATE_KEY"
  }'