### PR TITLE
Add Catbox API to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [AnonFiles](https://anonfiles.com/docs/api) | Upload and share your files anonymously | No | Yes | Unknown | |
 | [BayFiles](https://bayfiles.com/docs/api) | Upload and share your files | No | Yes | Unknown | |
+| [Catbox](https://catbox.moe/tools.php) | File hosting service supporting uploads, albums, and temporary files via Litterbox | `apiKey` | Yes | Unknown |
 | [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown | |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BayFiles](https://bayfiles.com/docs/api) | Upload and share your files | No | Yes | Unknown | |
 
 | [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
-| [Catbox](https://catbox.moe/tools.php) | File hosting service supporting uploads, albums, and temporary files via Litterbox | `apiKey` | Yes | Unknown |
+| [Catbox](https://catbox.moe/tools.php) | File hosting service supporting uploads, albums, and temporary files via Litterbox | `apiKey` | Yes | Unknown | |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown | |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -334,8 +334,9 @@ API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [AnonFiles](https://anonfiles.com/docs/api) | Upload and share your files anonymously | No | Yes | Unknown | |
 | [BayFiles](https://bayfiles.com/docs/api) | Upload and share your files | No | Yes | Unknown | |
-| [Catbox](https://catbox.moe/tools.php) | File hosting service supporting uploads, albums, and temporary files via Litterbox | `apiKey` | Yes | Unknown |
+
 | [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
+| [Catbox](https://catbox.moe/tools.php) | File hosting service supporting uploads, albums, and temporary files via Litterbox | `apiKey` | Yes | Unknown |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown | |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |


### PR DESCRIPTION


[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>


## Pull Request Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [API addition checklist](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md#api-addition-checklist)
- [x] I confirm this API has a free tier or is completely free
- [x] I have added a single API entry per pull request
- [x] I have verified the API name does not end with "API" or contain a TLD
- [x] I have verified the description is under 100 characters and has no ending punctuation
- [x] I have verified the entry is alphabetically ordered within its category
- [x] I have squashed all my commits into a single commit

## Additional Information

**API Documentation:** https://catbox.moe/tools.php

**Test Request:**

echo "Test file" > test.txt
curl -F "reqtype=fileupload" -F "fileToUpload=@test.txt" https://catbox.moe/user/api.php

**Test Response:**

https://files.catbox.moe/6bw123.txt

**What this API provides:**
- File hosting for images, documents, and other file types
- Anonymous uploads (no API key required for basic functionality)
- Album creation and management
- Litterbox for temporary files with expiration times
- Account-based uploads with ability to delete files (requires userhash)

**Source:** Catbox.moe - Community-supported file hosting service
