### PR TITLE
feat: add Open-Meteo free weather API to Weather section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
 | [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |
 | [Open-Meteo](https://open-meteo.com/) | Global weather forecast API for non-commercial use | No | Yes | Yes |
+| [Open-Meteo](https://open-meteo.com/) | Free weather forecast API with hourly resolution, 16-day forecasts and 80 years of historical data | No | Yes | Yes |
 | [openSenseMap](https://api.opensensemap.org/) | Data from Personal Weather Stations called senseBoxes | No | Yes | Yes |
 | [OpenUV](https://www.openuv.io) | Real-time UV Index Forecast | `apiKey` | Yes | Unknown |
 | [OpenWeatherMap](https://openweathermap.org/api) | Weather | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## API Name
Open-Meteo

## API Documentation Link
https://open-meteo.com/en/docs

## Category
Weather

## Short Description
Free open-source weather forecast API providing hourly forecasts up to 
16 days ahead and 80 years of historical weather data. Powered by 
national weather services (NOAA, ECMWF, DWD, Météo-France).

## Auth
No API key required — completely free for non-commercial use

## HTTPS
Yes

## CORS
Yes

## Why this should be added
Open-Meteo is one of the most widely used free weather APIs available
today. It requires no registration, no credit card, and no API key — 
you can start making requests immediately. It's actively maintained 
(3.5k+ GitHub stars) and used by thousands of developers worldwide.

Example request:
https://api.open-meteo.com/v1/forecast?latitude=37.77&longitude=-122.41&current_weather=true