### PR TITLE
Add BuyWhere API to Shopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,6 +1522,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes | Unknown |
+| [BuyWhere](https://buywhere.ai) | Real-time product catalog API for AI agents across merchants in 7 countries (SG, MY, TH, VN, PH, ID, US) | `apiKey` | Yes | Unknown |
 | [Digi-Key](https://www.digikey.com/en/resources/api-solutions) | Retrieve price and inventory of electronic components as well as place orders | `OAuth` | Yes | Unknown |
 | [Dummy Products](https://dummyproducts-api.herokuapp.com/) | An api to fetch dummy e-commerce products JSON data with placeholder images | `apiKey` | Yes | Yes |
 | [eBay](https://developer.ebay.com/) | Sell and Buy on eBay | `OAuth` | Yes | Unknown |
@@ -1535,7 +1536,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |
 | [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |
-| [BuyWhere](https://buywhere.ai/docs) | Agent-native product catalog API for AI agent commerce | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -1535,6 +1535,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |
 | [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |
+| [BuyWhere](https://buywhere.ai/docs) | Agent-native product catalog API for AI agent commerce | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Description
Add [BuyWhere](https://buywhere.ai) - Agent-native product catalog API for AI agent commerce.

## Category
Shopping

## Details
- **Auth**: apiKey (Bearer token)
- **HTTPS**: Yes
- **CORS**: Unknown

BuyWhere provides a product catalog layer for AI agents to discover, compare, and purchase products across merchants in Southeast Asia. Free self-serve beta with no credit card required.