### PR TITLE
Add FileUp API to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown | |
 | [Filestack](https://www.filestack.com) | Filestack File Uploader & File Upload API | `apiKey` | Yes | Unknown |    |
+| [FileUp](https://github.com/RealSinaSnp/FileUp) | Temporary file hosting with upload API, expiration times, and view limits | No | Yes | Unknown |
 | [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown | |
 | [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth` | Yes | Unknown | |
 | [Gyazo](https://gyazo.com/api/docs) | Save & Share screen captures instantly | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [API addition checklist](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md#api-addition-checklist)
- [x] I confirm this API has a free tier or is completely free
- [x] I have added a single API entry per pull request
- [x] I have verified the API name does not end with "API" or contain a TLD
- [x] I have verified the description is under 100 characters and has no ending punctuation
- [x] I have verified the entry is alphabetically ordered within its category
- [x] I have squashed all my commits into a single commit

## Additional Information

**API Documentation:** https://github.com/RealSinaSnp/FileUp

**Test Request:**

curl -L -F "file=@test.txt" -F "expireMinutes=30" -F "maxViews=5" https://upload.sinasnp.com/api/public/upload

**Test Response:**

{"fileName":"test_20260504043303.txt","size":38,"url":"http://upload.sinasnp.com/files/public/txt/test_20260504043303.txt","expireAt":"2026-05-04T04:33:03.973346Z","maxViews":5}

**What this API provides:**
- Temporary file hosting with no authentication required
- Configurable expiration times (expireMinutes parameter)
- Configurable view limits (maxViews parameter)
- Returns file URL, size, expiration time, and max views
- Free tier with 100MB max file size

**Source:** FileUp - Open source temporary file hosting service