### PR TITLE
Add JahKnow API — OpenAI-compatible AI chat completions (Machine Learning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,6 +1188,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
 | [IPS Online](https://docs.identity.ps/docs) | Face and License Plate Anonymization | `apiKey` | Yes | Unknown |
 | [Irisnet](https://irisnet.de/api/) | Realtime content moderation API that blocks or blurs unwanted images in real-time | `apiKey` | Yes | Yes |
+| [JahKnow API](https://api.websoquick.com) | OpenAI-compatible AI chat completions API with a free tier, self-hosted and private | `apiKey` | Yes | Yes |
 | [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## API Info

| Field | Value |
|---|---|
| API Name | JahKnow API |
| Category | Machine Learning |
| URL | https://api.websoquick.com |
| Auth | apiKey |
| HTTPS | Yes |
| CORS | Yes |
| Description | OpenAI-compatible AI chat completions API with a free tier, self-hosted and private |

## Checklist
- [x] Entry is added in alphabetical order
- [x] Entry follows the format: `| [API Name](link) | Description | Auth | HTTPS | CORS |`
- [x] Auth is one of: `apiKey`, `OAuth`, `X-Mashape-Key`, `No`
- [x] HTTPS is `Yes` or `No`
- [x] CORS is `Yes`, `No`, or `Unknown`
- [x] Description is concise and does not end with a period
- [x] API has been tested and is publicly accessible