### PR TITLE
Add ScaleRecipe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |
 | [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
+| [ScaleRecipe](https://www.scale-recipe.com/developers) | Free API for scaling recipe ingredients with smart culinary fractions and unit promotion | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
 | [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
 | [Rustybeer](https://rustybeer.herokuapp.com/) | Beer brewing tools | No | Yes | No |


### PR DESCRIPTION
Adds **ScaleRecipe** to **Food & Drink** — a free public API for scaling recipe ingredient quantities with smart culinary fractions (½, ¼, ⅓) and unit promotion (3 tsp → 1 tbsp).

- Endpoint: `POST https://www.scale-recipe.com/api/scale`
- Docs: https://www.scale-recipe.com/developers
- OpenAPI 3.0 spec: https://www.scale-recipe.com/openapi.yaml

Also submitted to APIs.guru: APIs-guru/openapi-directory#2476

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
