### PR TITLE
Add paralelo.bo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
+| [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds **paralelo.bo** to the Currency Exchange section.

paralelo.bo is a free public API for the Bolivia parallel-market USD/BOB exchange rate, aggregated every 60 seconds from major P2P platforms. Useful for any application dealing with Bolivian payments, international transfers, or LATAM currency analysis.

- **Documentation**: https://paralelo.bo/api
- **OpenAPI 3.1 spec**: https://paralelo.bo/api/openapi.json
- **Endpoints**: JSON, plain text (`/api/v1/rate.txt`), historical CSV/JSON, and an MCP server at `/mcp`
- **Auth**: None
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **License**: Data published under CC-BY 4.0

Entry inserted in correct alphabetical position (between "National Bank of Poland" and "VATComply.com"). Description is 87 characters (under the 100-char limit).