### PR TITLE
Add Eleata Peppol (Finance section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
-| [eleata Peppol API](https://peppol.eleata.io) | Validate EU electronic invoices (Peppol BIS 3, XRechnung, Factur-X, UBL) against published Schematron rules | `apiKey` | Yes | Yes | |
+| [Eleata Peppol](https://peppol.eleata.io) | Validate EU electronic invoices (Peppol BIS 3, XRechnung, Factur-X, UBL) against published Schematron rules | `apiKey` | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -750,6 +750,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
+| [eleata Peppol API](https://peppol.eleata.io) | Validate EU electronic invoices (Peppol BIS 3, XRechnung, Factur-X, UBL) against published Schematron rules | `apiKey` | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## What's this API?

[eleata Peppol API](https://peppol.eleata.io) is a REST API for validating EU electronic invoices against the official Schematron rule sets published by CEN, OpenPeppol, KoSIT, and FNFE-MPE.

Supports the four major EU formats:
- Peppol BIS 3 (B2B invoicing across EU)
- XRechnung 2.x (German B2G mandate since 2020)
- Factur-X 1.07.2 (French B2B mandate Sept 2026 — PDF/A-3 hybrid extracted natively)
- UBL 2.1 (generic)

## Free access

Free tier: 200 validations / month, no credit card required. Paid tiers exist for higher volume but the free tier is sufficient for development and integration testing.

## Authentication

API key in the `Authorization: Bearer ...` header. Self-serve at https://peppol.eleata.io/signup/ — no sales call.

## Why list it

The two main reference engines for EU e-invoicing (Mustang, phive) ship only as Java JARs / web forms. There has been no open API + SDK option for developers integrating EU invoicing into their stack. eleata exposes the same Schematron validation as a simple REST endpoint with SDKs for Node, Python, and Go.

## Checklist

- [x] HTTPS only
- [x] CORS enabled
- [x] Free tier with no card
- [x] Inserted alphabetically (between Econdb and Fed Treasury) in the Finance section
- [x] Format matches the contributing guidelines
- [x] Not a smart-device-dependent API
- [x] No marketing language in the README entry

Thanks for maintaining this list — happy to address any feedback.