### PR TITLE
Add OpenAlex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1456,6 +1456,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ocean Facts](https://oceanfacts.herokuapp.com/) | Facts pertaining to the physical science of Oceanography | No | Yes | Unknown |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
+| [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
Adds [OpenAlex](https://openalex.org/) — a free, open catalog of the global scholarly graph (works, authors, institutions, sources, concepts/topics, publishers, funders). It's run by the nonprofit OurResearch and is widely used as a successor to Microsoft Academic Graph.

**Category:** Science & Math

**Entry added (alphabetical order, between `Open Science Framework` and `Purple Air`):**

```
| [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
```

**Verification**

- Live and working — `GET https://api.openalex.org/works?search=climate&per-page=1` returns HTTP 200 with valid JSON (5M+ results indexed).
- HTTPS: Yes, valid public certificate.
- Auth: No — endpoints are open; an optional polite-pool email parameter is documented but not required.
- CORS: Yes — response includes `access-control-allow-origin: *`, `access-control-allow-methods: GET, HEAD, POST, OPTIONS`.
- Documentation: https://docs.openalex.org/ (canonically https://developers.openalex.org)

**Checklist**

- [x] HTTPS confirmed
- [x] Live and returning JSON right now
- [x] CORS verified via response headers
- [x] Not already in README (searched `OpenAlex` / `Open Alex`)
- [x] Alphabetical ordering preserved within Science & Math
- [x] Description under 100 chars (77)
- [x] Auth value matches accepted set (`No`)
- [x] One entry per PR
- [x] Title doesn't end in "API" (entry title is "OpenAlex")