### PR TITLE
Add OpenMeteo to Weather APIs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MetaWeather](https://www.metaweather.com/api/) | Weather | No | Yes | No |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |
+| [OpenMeteo](https://open-meteo.com) | Global weather forecast API for non-commercial use | No | Yes | Yes |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
 | [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |
 | [Open-Meteo](https://open-meteo.com/) | Global weather forecast API for non-commercial use | No | Yes | Yes |


### PR DESCRIPTION
## Description

This PR adds [OpenMeteo](https://open-meteo.com) to the Weather category.

### About OpenMeteo
- **Free** weather forecast API for non-commercial use
- **No API key required**
- **Open source** (AGPL license)
- Global weather forecasts with high resolution (1-11km)
- Historical weather data available
- Supports HTTPS and CORS

### API Details
| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [OpenMeteo](https://open-meteo.com) | Global weather forecast API for non-commercial use | No | Yes | Yes |

### Checklist
- [x] API is publicly documented
- [x] API does not require auth for basic use
- [x] API supports HTTPS
- [x] API supports CORS
- [x] Added in alphabetical order within the Weather section
- [x] Description is concise and accurate

OpenMeteo is widely used in the open-source community for weather data integration and provides a genuinely free tier without API keys, making it a valuable addition to the list.