### PR TITLE
Add Alpha (Mossland) API

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ API | Description | Auth | HTTPS | CORS |
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
+| [Alpha (Mossland)](https://alpha.moss.land/developers) | Korean crypto channel stance + RAG Q&A + canonical entity/topic/event store | No | Yes | Yes |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |
 | [Bitcambio](https://nova.bitcambio.com.br/api/v3/docs#a-public) | Get the list of all traded assets in the exchange | No | Yes | Unknown |
 | [BitcoinAverage](https://apiv2.bitcoinaverage.com/) | Digital Asset Price Data for the blockchain industry | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Alpha by Mossland to the Cryptocurrency category.

**API**: https://alpha.moss.land/developers

Alpha is a free, no-auth, HTTPS-only public API exposing Korean crypto narrative analysis built on top of YouTube channels, news RSS, and macro feeds. Surfaces include:

- `GET /api/canonical/{entities,topics,events}.json` — canonical normalized store (CORS enabled)
- `POST /api/ask` — natural-language RAG Q&A returning answer + citations (CORS enabled)
- `POST /api/mcp` — Model Context Protocol JSON-RPC 2.0 server with 12 tools (free remote MCP server, no auth)
- `GET /api/health`, `/sitemap.xml`, `/rss.xml`, `/llms.txt` (LLM-friendly)

Operated by Mossland (https://moss.land), an open-source crypto/AI ecosystem; full citation policy and rate-limit guidance on the documentation page.

Verified against contribution guidelines:
- Free with no purchase requirement; no auth needed for any listed endpoint.
- Description ≤ 100 chars.
- Alphabetical placement (between Alchemy Ethereum and Binance).
- Name does not contain TLD or trailing "API".