### PR TITLE
Add PostStack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
 | [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
 | [Mailtrap](https://mailtrap.docs.apiary.io/#) | A service for the safe testing of emails sent from the development and staging environments | `apiKey` | Yes | Unknown |
+| [PostStack](https://poststack.dev/docs) | EU-hosted email API for transactional and marketing email, with contacts, broadcasts, and analytics | `apiKey` | Yes | No |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [Verifier](https://verifier.meetchopra.com/docs#/) | Verifies that a given email is real | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds PostStack to the **Email** section.

PostStack is an EU-hosted transactional and marketing email API. Free tier is 3,000 emails/month with no credit card required, paid plans from €5/month — meets the "free or free tier, no required device purchase" rule in CONTRIBUTING.

Entry placed alphabetically between `Mailtrap` and `Sendgrid`. Description is 99 characters (under the 100-char cap). Single line change, single link, no other modifications.

| Field | Value |
| --- | --- |
| API | https://poststack.dev/docs |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No (the send API is server-only by design) |

Docs: https://poststack.dev/docs
Free tier: https://poststack.dev/pricing