### PR TITLE
Add BrewPage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey` | No | Unknown |
 | [Bored](https://www.boredapi.com/) | Find random activities to fight boredom | No | Yes | Unknown |
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey` | Yes | Yes |
+| [BrewPage](https://brewpage.app) | Free hosting for HTML, JSON, key-value, files, multi-file sites with short URLs and TTL retention | No | Yes | No |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey` | Yes | Yes |
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |


### PR DESCRIPTION
### API

[BrewPage](https://brewpage.app) — free, anonymous hosting for HTML, JSON, key-value pairs, files, and multi-file sites. Publishes resources at short URLs (`https://brewpage.app/{ns}/{id10}`) with a 15-30 day TTL. Public OpenAPI: https://kochetkov-ma.github.io/brewpage-openapi/

### Section

Development (alphabetical placement between `Brainshop.ai` and `Browshot`).

### Columns

| Column | Value | Reason |
|---|---|---|
| Auth | `No` | anonymous publishing; per-resource owner tokens are returned in the response, not required for publish |
| HTTPS | `Yes` | Caddy auto-TLS |
| CORS | `No` | direct API is same-origin only (verified: 403 with `Origin` header) |

### Endpoints sample

- `POST /api/html` — publish HTML
- `POST /api/json/{collection}` — publish JSON document
- `POST /api/kv/{ns}/{key}` — set key-value pair
- `POST /api/files` — upload file
- `POST /api/sites` — publish multi-file site

### Documentation

- OpenAPI spec: https://github.com/kochetkov-ma/brewpage-openapi
- Rendered docs: https://kochetkov-ma.github.io/brewpage-openapi/
- llms.txt: https://brewpage.app/llms.txt

### Checklist

- [x] Free, no purchase required
- [x] Public REST API with full documentation
- [x] Alphabetical placement preserved
- [x] Description under 100 characters (97)
- [x] Single space padding around table cells
- [x] PR title format `Add <Name> API`