### PR TITLE
Add German Tax Calculator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
+| [German Tax Calculator](https://rechner-hub.de/steuerrechner-api/) | Tax calculations for Germany: income tax, crypto, commuter allowance, and more | `apiKey` | Yes | No | |
 | [Goldprice.dev](https://goldprice.dev/docs) | Cross-validated gold, silver & copper spot, futures & 30-year history in 13 currencies | No | Yes | Unknown | |
 | [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |


### PR DESCRIPTION
Adds the German Tax Calculator API to the Finance section.

- Documentation: https://rechner-hub.de/steuerrechner-api/
- Free tier: 50 requests/day (Basic plan on RapidAPI)
- Auth: apiKey (RapidAPI)
- HTTPS: Yes
- CORS: No (server-to-server via marketplace proxy)
- API provides German income tax, crypto tax, commuter allowance, inheritance tax, and other DACH-region calculations based on current BMF/SGB-IV/GrEStG legislation