### PR TITLE
Add ModelPartFinder Error Codes API to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
 | [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |
 | [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
+| [ModelPartFinder Error Codes](https://modelpartfinder.com/docs/api) | Lookup appliance and equipment error codes by brand and code, with recommended replacement parts | No | Yes | Yes |
 | [Nasdaq Data Link](https://docs.data.nasdaq.com/) | Stock market data | `apiKey` | Yes | Unknown |
 | [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | Open data about nobel prizes and events | No | Yes | Yes |
 | [Open Data Minneapolis](https://opendata.minneapolismn.gov/) | Spatial (GIS) and non-spatial city data for Minneapolis | No | Yes | No |


### PR DESCRIPTION
Adds ModelPartFinder's free public error-code lookup API to the **Open Data** category.

### What it returns
GET `https://modelpartfinder.com/api/v1/error-code/{brand}/{code}` returns JSON:

```
{
  "ok": true,
  "brand": "Whirlpool",
  "code": "F01",
  "description": "Main electronic control board failure...",
  "appliance": "Dryer",
  "recommended_skus": [...],
  "source_url": "https://modelpartfinder.com/error-codes/whirlpool-f01"
}
```

### Compliance with CONTRIBUTING.md

- ✅ HTTPS: Yes
- ✅ Auth: No (no API key, no signup)
- ✅ CORS: Yes (Access-Control-Allow-Origin: *)
- ✅ Documentation page: https://modelpartfinder.com/docs/api
- ✅ Stable endpoint behind Cloudflare; the entry has been live for 24+ hours
- ✅ Alphabetical placement (M after Microlink.io, before Nasdaq Data Link)
- ✅ Single-line addition, no other changes

### Why it's useful
Repair pros, IoT integrators, and chatbot authors can resolve appliance/equipment error codes (Whirlpool F01, Samsung tE, Bosch E:18, etc.) to a description + recommended replacement parts without scraping vendor sites or paying for OEM service-code lookups. Currently 114+ codes indexed across 15 brands.