### PR TITLE
Add Anycrap API

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Entertainment
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Anycrap](https://anycrap.shop/developers) | 35,000+ absurdist AI-generated product concepts with names, descriptions, and images | `apiKey` | Yes | Yes |
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds [Anycrap](https://anycrap.shop/developers) to the **Entertainment** section.

**Anycrap** is a free REST API serving 35,000+ hand-curated absurdist AI-generated product concepts — things like *Thought-Cancelling Headphones*, *Dehydrated Water*, and *Anti-Gravity Toilet*. Each product includes a name, description, AI-generated image, and category labels.

## Checklist

- [x] Entry placed in alphabetical order within the section
- [x] Description is under 100 characters
- [x] API supports HTTPS
- [x] API supports CORS
- [x] Free API key with no credit card required
- [x] Documentation available at https://anycrap.shop/developers
- [x] PR title follows `Add Api-name API` format