### PR TITLE
fix: resolve UnboundLocalError and invalid regex escape sequences in …

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]
@@ -43,6 +43,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
 
     categories = {}
     category_line_num = {}
+    category = None 
 
     for line_num, line_content in enumerate(contents):
 
@@ -60,7 +61,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
         ][0]
 
         title_match = link_re.match(raw_title)
-        if title_match:
+        if title_match and category is not None:
                 title = title_match.group(1).upper()
                 categories[category].append(title)
 


### PR DESCRIPTION
## Summary
Bug fix for the validation script. This is not an API addition — 
the default PR checklist does not apply.

Closes #6041

## Problem
`scripts/validate/format.py` crashed with `UnboundLocalError` when 
running format validation, blocking valid pull requests from passing 
automated checks.

## Changes made
- Initialized `category = None` before the loop in `get_categories_content()` 
- Added `and category is not None` guard on the append line
- Added `r` prefix to three regex strings with invalid escape sequences 
  (`\s`, `\*`, `\[`)

## Testing
Before fix:
`UnboundLocalError: cannot access local variable 'category' 
where it is not associated with a value`

After fix:
Script runs fully and reports actual formatting issues as expected.


…validator

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My addition is ordered alphabetically
- [ ] My submission has a useful description
- [ ] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [ ] Each table column is padded with one space on either side
- [ ] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
