### PR TITLE
Add NotaSalud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lexigram](https://docs.lexigram.io/) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
 | [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
 | [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
+| [NotaSalud](https://notasalud.com/api-cie-10) | Spanish ICD-10 and ICD-11 search API | No | Yes | Yes |
 | [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
 | [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
 | [Open Data NHS Scotland](https://www.opendata.nhs.scot) | Medical reference data and statistics by Public Health Scotland | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1148,7 +1148,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lexigram](https://docs.lexigram.io/) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
 | [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
 | [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
-| [NotaSalud](https://notasalud.com/api-cie-10) | Spanish ICD-10 and ICD-11 search API | No | Yes | Yes |
+| [NotaSalud](https://notasalud.com/api-cie-10) | Spanish CIE-10 code search API | No | Yes | No |
 | [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
 | [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
 | [Open Data NHS Scotland](https://www.opendata.nhs.scot) | Medical reference data and statistics by Public Health Scotland | No | Yes | Unknown |


### PR DESCRIPTION
## Summary
Add NotaSalud to the Health section.

## API details
- Free public JSON endpoint for Spanish CIE-10 code search
- No authentication required
- HTTPS supported
- Access-Control-Allow-Origin was not observed in response/preflight headers, so CORS is treated as No/Unknown

Verified endpoint example: https://notasalud.com/buscar/cie-10?q=diabetes&limit=3
