### PR TITLE
Add Memesio API

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
+| [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |
 | [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
 | [TasteDive](https://tastedive.com/read/api) | Content-based recommendations for movies, music, TV shows, books, games, and podcasts | `apiKey` | Yes | No |


### PR DESCRIPTION
## Description

Adds Memesio to the Entertainment category.

Memesio provides a documented meme creation API with public template discovery, captioned meme creation, hosted share links, and OpenAPI metadata.

## Checks

- [x] One API added
- [x] Category: Entertainment
- [x] API documentation: https://memesio.com/developers/api
- [x] Auth: No for public/rate-limited template discovery and basic creation
- [x] HTTPS: Yes
- [x] CORS: No observed in Origin checks
- [x] Description is under 100 characters and has no ending punctuation

Local validation: `git diff --check` and custom row checks passed. The repository format validator currently errors before category parsing on the full README, so I did not rely on it for this PR.
