### PR TITLE
Add Kiprio APIs: VAT validation, IBAN validation, Email validation, Screenshot, Unfurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [VATlayer](https://vatlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | VAT number validation | `apiKey` | Yes | Unknown | |
+| [Kiprio VAT](https://kiprio.com/vat-api/) | Validate EU VAT numbers for all 27 EU member states via VIES | `apiKey` | Yes | Unknown | |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown | |
@@ -551,6 +552,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
+| [Kiprio Screenshot](https://kiprio.com/screenshot-api/) | Capture full-page screenshots of any URL as PNG or PDF | `apiKey` | Yes | Unknown |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
@@ -603,6 +605,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Suprsonic](https://suprsonic.ai) | Unified agent API: search, scrape, enrich, image gen, TTS, STT, messaging. One key, 20+ capabilities | `apiKey` | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
+| [Unfurl API](https://kiprio.com/unfurl-api/) | Extract Open Graph metadata, title, image, and description from any URL | `apiKey` | Yes | Unknown |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
@@ -681,6 +684,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
 | [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |
+| [Kiprio Email](https://kiprio.com/email-validation-api/) | Validate email addresses with MX record checks and disposable detection | `apiKey` | Yes | Unknown |
 | [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |
 | [mail.tm](https://docs.mail.tm) | Temporary Email Service | No | Yes | Yes |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
@@ -773,6 +777,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown | |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
+| [Kiprio IBAN](https://kiprio.com/iban-api/) | Validate IBAN numbers and retrieve bank details for 75+ countries | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## New APIs from Kiprio.com

Adding 5 developer-focused APIs from [kiprio.com](https://kiprio.com):

| API | Category | Description |
|---|---|---|
| [Kiprio VAT](https://kiprio.com/vat-api/) | Data Validation | Validate EU VAT numbers across 27 member states via VIES |
| [Kiprio IBAN](https://kiprio.com/iban-api/) | Finance | Validate IBAN and retrieve bank details for 75+ countries |
| [Kiprio Email](https://kiprio.com/email-validation-api/) | Email | Email validation with MX record checks and disposable detection |
| [Kiprio Screenshot](https://kiprio.com/screenshot-api/) | Development | Full-page URL screenshots as PNG or PDF |
| [Unfurl API](https://kiprio.com/unfurl-api/) | Development | Open Graph metadata extraction from any URL |

All APIs:
- Have a free tier (no credit card required to start)
- Are served over HTTPS (kiprio.com)
- Use apiKey authentication
- Are placed alphabetically within their sections

Happy to split into separate PRs if that is preferred.