### PR TITLE
Add HeroHunt People Search to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | Jobs with GraphQL | No | Yes | Yes |
 | [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Yes | Unknown |
 | [GraphQL Jobs](https://graphql.jobs/docs/api/) | Jobs with GraphQL | No | Yes | Yes |
+| [HeroHunt People Search](https://www.herohunt.ai/people-search-api) | Search 1 billion people profiles across LinkedIn and GitHub for talent sourcing | `apiKey` | Yes | Yes |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
## What does this API do?

[HeroHunt People Search](https://www.herohunt.ai/people-search-api) is a people search API that searches 1 billion profiles across LinkedIn and GitHub using natural language queries. It returns structured candidate profiles with optional contact enrichment (verified emails and phone numbers).

## Checklist

- [x] API has a free tier (free plan available at herohunt.ai/app/api/sign-up)
- [x] Auth: apiKey
- [x] HTTPS: Yes
- [x] CORS: Yes
- [x] Alphabetical placement in Jobs section (between GraphQL Jobs and Jobs2Careers)
- [x] Description under 100 characters
- [x] No "API" suffix in name