### PR TITLE
fix: guard validator against UnboundLocalError on table row before first category (#6041)

### DIFF
--- a/scripts/tests/test_validate_format.py
+++ b/scripts/tests/test_validate_format.py
@@ -69,9 +69,6 @@ class TestValidadeFormat(unittest.TestCase):
                 self.assertEqual(res, ex_res)
 
     def test_get_categories_content_does_not_crash_on_table_row_before_header(self):
-        # Regression: a table row appearing before any '### Category' header
-        # used to crash with UnboundLocalError because `category` was only
-        # assigned inside the header branch.
         fake_contents = [
             '| [AA](https://www.ex.com) | Desc | `apiKey` | Yes | Yes |',
             '### A',
@@ -82,8 +79,6 @@ class TestValidadeFormat(unittest.TestCase):
 
         categories, category_line_num = get_categories_content(fake_contents)
 
-        # The stray row before the first header is ignored; only entries
-        # under category 'A' are recorded.
         self.assertEqual(categories, {'A': ['AB']})
         self.assertEqual(category_line_num, {'A': 1})
 

--- a/scripts/tests/test_validate_format.py
+++ b/scripts/tests/test_validate_format.py
@@ -68,6 +68,25 @@ class TestValidadeFormat(unittest.TestCase):
             with self.subTest():
                 self.assertEqual(res, ex_res)
 
+    def test_get_categories_content_does_not_crash_on_table_row_before_header(self):
+        # Regression: a table row appearing before any '### Category' header
+        # used to crash with UnboundLocalError because `category` was only
+        # assigned inside the header branch.
+        fake_contents = [
+            '| [AA](https://www.ex.com) | Desc | `apiKey` | Yes | Yes |',
+            '### A',
+            'API | Description | Auth | HTTPS | CORS |',
+            '|---|---|---|---|---|',
+            '| [AB](https://www.ex.com) | Desc | `apiKey` | Yes | Yes |',
+        ]
+
+        categories, category_line_num = get_categories_content(fake_contents)
+
+        # The stray row before the first header is ignored; only entries
+        # under category 'A' are recorded.
+        self.assertEqual(categories, {'A': ['AB']})
+        self.assertEqual(category_line_num, {'A': 1})
+
     def test_if_check_alphabetical_order_return_correct_msg_error(self):
         correct_lines = [
             '### A',

--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -56,8 +56,6 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
         if not line_content.startswith('|') or line_content.startswith('|---'):
             continue
 
-        # Skip stray table rows that appear before the first category header;
-        # without this guard, the append below would raise UnboundLocalError.
         if category is None:
             continue
 

--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]
@@ -43,6 +43,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
 
     categories = {}
     category_line_num = {}
+    category = None
 
     for line_num, line_content in enumerate(contents):
 
@@ -53,6 +54,11 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
             continue
 
         if not line_content.startswith('|') or line_content.startswith('|---'):
+            continue
+
+        # Skip stray table rows that appear before the first category header;
+        # without this guard, the append below would raise UnboundLocalError.
+        if category is None:
             continue
 
         raw_title = [


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

---

Fixes #6041.

`get_categories_content()` crashed with `UnboundLocalError` when a table row appeared before any `### Category` header, because `category` was only bound inside the header branch. This blocked PR #6003 from passing CI.

Initialize `category = None` and skip stray table rows seen before the first header. Also switch the three module-level regexes to raw string literals to silence the `SyntaxWarning: invalid escape sequence` warnings that the same traceback shows.

Existing tests still pass; added one regression test covering the bug.
