### PR TITLE
Add 4 Kiprio APIs: Email Validate, Screenshot, VAT, IBAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [VATlayer](https://vatlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | VAT number validation | `apiKey` | Yes | Unknown | |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
+| [Kiprio VAT](https://kiprio.com/vat-api/) | Validate EU VAT numbers for all 27 EU member states via VIES | `apiKey` | Yes | Unknown |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown | |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
@@ -489,6 +490,7 @@ API | Description | Auth | HTTPS | CORS |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
+| [Kiprio Screenshot](https://kiprio.com/screenshot-api/) | Capture full-page screenshots of any URL as PNG or PDF | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |
 | [Base](https://www.base-api.io/) | Building quick backends | `apiKey` | Yes | Yes |
@@ -684,6 +686,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
 | [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |
+| [Kiprio Email](https://kiprio.com/email-validation-api/) | Validate email addresses with MX record checks and disposable detection | `apiKey` | Yes | Unknown |
 | [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |
 | [mail.tm](https://docs.mail.tm) | Temporary Email Service | No | Yes | Yes |
 | [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
@@ -761,6 +764,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data API](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
+| [Kiprio IBAN](https://kiprio.com/iban-api/) | Validate IBAN bank account numbers and retrieve bank details for 77 countries | `apiKey` | Yes | Unknown |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## New APIs from Kiprio.com

Adding 4 developer-focused APIs from [kiprio.com](https://kiprio.com):

| API | Category | Description |
|---|---|---|
| [Kiprio Email](https://kiprio.com/email-validation-api/) | Email | Validate email addresses with MX record checks and disposable detection |
| [Kiprio Screenshot](https://kiprio.com/screenshot-api/) | Development | Capture full-page screenshots of any URL as PNG or PDF |
| [Kiprio VAT](https://kiprio.com/vat-api/) | Data Validation | Validate EU VAT numbers for all 27 EU member states via VIES |
| [Kiprio IBAN](https://kiprio.com/iban-api/) | Finance | Validate IBAN bank account numbers and retrieve bank details for 77 countries |

All APIs:
- Are live and tested (HTTP 200 on all endpoints)
- Support HTTPS
- Require an API key (free tier available)
- Are documented at kiprio.com