### PR TITLE
Add justmeme.wtf - Free Meme API

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
+| [justmeme.wtf](https://justmeme.wtf/api-docs) | Free meme API with 2400+ templates, search, trending, and AI generation | No | Yes | Yes |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
 | [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |
 | [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |


### PR DESCRIPTION
Adding justmeme.wtf API to the Entertainment section.

**API:** [justmeme.wtf](https://justmeme.wtf/api-docs)

- 2,400+ meme templates
- 7 endpoints: templates, search, trending, categories, random, AI generate
- No authentication required
- HTTPS: Yes
- CORS: Yes
- Rate limit: 60 req/min
- [GitHub repo](https://github.com/JustMeme-wtf/justmeme-api)