### PR TITLE
Add TaxID API

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
+| [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adding TaxID to the Currency Exchange category.

TaxID is a REST API that validates EU VAT numbers against the EU Commission's VIES system, returning company name and address for all 27 EU member states. Free tier available with 100 validations/month, no credit card required.

- Documentation: https://www.taxid.dev/docs
- Free tier: 100 validations/month
- Auth: API key
- HTTPS: Yes

### Checklist
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been squashed into a single commit