### PR TITLE
Add HackMyIP - Free IP Geolocation & Privacy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1527,6 +1527,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FingerprintJS Pro](https://dev.fingerprintjs.com/docs) | Fraud detection API offering highly accurate browser fingerprinting | `apiKey` | Yes | Yes |
 | [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | Screen order information using AI to detect frauds | `apiKey` | Yes | Unknown |
 | [FullHunt](https://api-docs.fullhunt.io/#introduction) | Searchable attack surface database of the entire internet | `apiKey` | Yes | Unknown |
+| [HackMyIP](https://hackmyip.com/api-docs) | IP geolocation, DNS lookup, WHOIS, VPN detection, and privacy scoring | No | Yes | Yes |
 | [GitGuardian](https://api.gitguardian.com/doc) | Scan files for secrets (API Keys, database credentials) | `apiKey` | Yes | No |
 | [GreyNoise](https://docs.greynoise.io/reference/get_v3-community-ip) | Query IPs in the GreyNoise dataset and retrieve a subset of the full IP context data | `apiKey` | Yes | Unknown |
 | [HackerOne](https://api.hackerone.com/) | The industry’s first hacker API that helps increase productivity towards creative bug bounty hunting | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding HackMyIP to the Security section.

**API:** [hackmyip.com](https://hackmyip.com/api-docs)

- IP geolocation, DNS lookup, WHOIS/RDAP, VPN detection, privacy scoring
- 5 endpoints: /ip, /ip/:address, /dns/:domain, /whois/:domain, /headers
- No authentication required
- HTTPS: Yes
- CORS: Yes
- Rate limit: 60 req/min
- [API Documentation](https://hackmyip.com/api-docs)