### PR TITLE
Add retailerapi to Shopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1568,6 +1568,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
+| [retailerapi](https://retailerapi.com) | Unified product data across major US retailers (Walmart, Amazon, eBay, Target, Best Buy, Lowe's, Home Depot). Lookup by UPC, EAN, ISBN, GTIN, ASIN, or item_id. Free tier 1,000 lookups/mo. | `apiKey` | Yes | Yes |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |
 | [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds retailerapi to the Shopping section.

- Homepage: https://retailerapi.com
- API base: https://api.retailerapi.com
- Docs: https://docs.retailerapi.com
- Free tier: 1,000 lookups/month, no card

Unified product-data API across major US retailers — Walmart, Amazon, eBay, Target, Best Buy, Lowe's, Home Depot. Resolves any UPC, EAN, ISBN, GTIN, ASIN, or retailer item_id into a full product record with current price, marketplace sellers, 90-day price history, and reviews. Cross-retailer cells fold into product responses with `include_cross_retailer=true`. Bearer-token auth via `Authorization: Bearer rk_live_…`.