### PR TITLE
Add Domain Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1521,6 +1521,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
+| [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |


### PR DESCRIPTION
Adds Domain Intelligence to the Security category.

A single-endpoint REST API that aggregates DNS, WHOIS/RDAP, SSL certificate inspection, subdomain enumeration via Certificate Transparency logs, and email-security posture (SPF/DMARC) into one parallel call.

- Free tier: 1,000 req/mo via RapidAPI
- Public no-signup demo (5/IP/day) available on the landing page: https://oti-labs.com/domain-intelligence-api
- Command-line: `curl https://oti-labs.com/demo/example.com | jq`
- Open source (MIT): https://github.com/osiris-technical-institute/domain-intelligence-api

Placed alphabetically between Dehash.lt and EmailRep. Description is 84 chars. Auth is `apiKey` because production requests require an X-RapidAPI-Key header (free tier accessible without payment).