### PR TITLE
Add Sharpe API to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [PumpFunData](https://pumpfundata.com/docs) | Historical Pump.fun and PumpSwap AMM swap data as hourly Parquet files | `apiKey` | Yes | Unknown |
+| [Sharpe](https://www.sharpe.ai/docs/free-api) | Crypto funding, derivatives, arbitrage, narratives, listings, and news data | No | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Sharpe to the Cryptocurrency section.

The API is crypto-specific and exposes public endpoints for funding, derivatives, arbitrage, narrative rotation, exchange listings, and news. The row uses the free API docs, keeps the description under 100 characters, and places Sharpe alphabetically.

Validation note: `git diff --check` passes. The repository's format script currently crashes before reaching the changed row, and duplicate-link validation reports an unrelated existing TasteDive duplicate.

Disclosure: I work on Sharpe.