### PR TITLE
Add Indonesia Government Open Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, Germany](https://www.govdata.de/daten/-/details/govdata-metadatenkatalog) | Germany Government Open Data | No | Yes | Unknown |
 | [Open Government, Greece](https://data.gov.gr/) | Greece Government Open Data | `OAuth` | Yes | Unknown |
 | [Open Government, India](https://data.gov.in/) | Indian Government Open Data | `apiKey` | Yes | Unknown |
+| [Open Government, Indonesia](https://data.go.id/) | Indonesian Government Open Data | No | Yes | Unknown |
 | [Open Government, Ireland](https://data.gov.ie/pages/developers) | Ireland Government Open Data | No | Yes | Unknown |
 | [Open Government, Italy](https://www.dati.gov.it/) | Italy Government Open Data | No | Yes | Unknown |
 | [Open Government, Korea](https://www.data.go.kr/) | Korea Government Open Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Added **Open Government, Indonesia** to the Government section with a link to the official Indonesian government open data portal at [data.go.id](https://data.go.id/).

### Added:
| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| Open Government, Indonesia | Indonesian Government Open Data | No | Yes | Unknown |

### Why:
Indonesia is the 4th most populous country in the world with an active open data initiative. The portal provides APIs for government datasets including demographics, economics, public services, and more. This fills a gap in the Government section where Southeast Asian countries are underrepresented.

## Checklist
- [x] Alphabetical order maintained (inserted between India and Ireland)
- [x] Table format matches existing entries
- [x] API is publicly accessible and free
- [x] HTTPS supported