### PR TITLE
Add FilingFirehose to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
+| [FilingFirehose](https://filingfirehose.com/docs) | SEC EDGAR JSON API with body-text-classified 8-Ks (flags items the filer didn't report), Schedule 13D/G with 21+ activist filers auto-tagged, S-3/424B5 ATM offering detection. Free public tier covers past 72 hours. | No | Yes | Yes | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adds FilingFirehose, an SEC EDGAR JSON API I built. Has a genuine free public tier (last 72h of every form, no API key required, no rate limit beyond fairness). Differentiator: body-text classification of 8-K filings — flags items the filer didn't report (7.3% of recent Item 8.01 filings have buried 1.05/5.02 events). Also tags 21+ activist filers on Schedule 13D/G and detects ATM offerings on S-3/424B5.

Free tier sample request (no auth needed, works right now):

```
curl "https://filingfirehose.com/v1/public/8k?suspected_buried_only=true"
```

Inserted alphabetically in **Finance** section before existing `SEC EDGAR Data` entry (which is the official sec.gov endpoint — we're complementary, parsing on top of that).

Per CONTRIBUTING.md: yes, there's a paid tier (\$29-\$299/mo) but the free public tier is fully functional, no purchase required to use everything in the entry above.