### PR TITLE
Add ZIP-Codes-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,8 @@ API | Description | Auth | HTTPS | CORS |
 | [ZipCodeAPI](https://www.zipcodeapi.com) | US zip code distance, radius and location API | `apiKey` | Yes | Unknown |
 | [Zippopotam.us](http://www.zippopotam.us) | Get information about place such as country, city, state, etc | No | No | Unknown |
 | [Ziptastic](https://ziptasticapi.com/) | Get the country, state, and city of any US zip-code | No | Yes | Unknown |
-
+| [Zip-Codes](https://www.zip-codes.com/api) | US ZIP and Canadian postal code lookup, radius, demographics, boundaries | `apiKey` | Yes | Yes | [Go!](https://api.zip-codes.com/postman/ZIP_Codes_API_v2.postman_collection.json)
+  |
 **[⬆ Back to Index](#index)**
 <br >
 <br >


### PR DESCRIPTION
  Adds Zip-Codes to the Geocoding section.

  - Marketing/landing page: https://www.zip-codes.com/api/
  - Docs: https://api.zip-codes.com/docs
  - OpenAPI spec: https://api.zip-codes.com/v2/openapi.json
  - Postman collection: https://api.zip-codes.com/postman/ZIP_Codes_API_v2.postman_collection.json

  Production API, generally available, paying customers in production. Free tier: 2,500 lookups/day, no credit card
  required. US ZIP + ZIP+4, Canadian postal codes, address validation, radius search (centroid + spatial), demographics
  (Census ACS 2011–2024), boundaries (Census, congressional, school district). HTTPS, CORS enabled.

  ---

  - [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
  - [x] My addition is ordered alphabetically
  - [x] My submission has a useful description
  - [x] The description does not have more than 100 characters
  - [x] The description does not end with punctuation
  - [x] Each table column is padded with one space on either side
  - [x] I have searched the repository for any relevant issues or pull requests
  - [x] Any category I am creating has the minimum requirement of 3 items
  - [x] All changes have been squashed into a single commit