### PR TITLE
Add Astroworld API

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AmiiboAPI](https://amiiboapi.com/) | Nintendo Amiibo Information | No | Yes | Yes |
 | [Animal Crossing: New Horizons](http://acnhapi.com/) | API for critters, fossils, art, music, furniture and villagers | No | Yes | Unknown |
+| [Astroworld](https://api.astroworldmc.com) | Free Minecraft data: mobs, biomes, items, enchantments, structures, commands, versions, achievements, trades | No | Yes | Yes |
 | [Autochess VNG](https://github.com/didadadida93/autochess-vng-api) | Rest Api for Autochess VNG | No | Yes | Yes |
 | [Barter.VG](https://github.com/bartervg/barter.vg/wiki) | Provides information about Game, DLC, Bundles, Giveaways, Trading | No | Yes | Yes |
 | [Battle.net](https://develop.battle.net/documentation/guides/getting-started) | Diablo III, Hearthstone, StarCraft II and World of Warcraft game data APIs | `OAuth` | Yes | Yes |


### PR DESCRIPTION
Adds [Astroworld](https://api.astroworldmc.com) to **Games & Comics**.

Free public Minecraft data API covering mobs, biomes, items, enchantments, structures, commands, versions, achievements, and trades. No auth, HTTPS, CORS enabled. Useful for tools, dashboards, Discord bots, and other Minecraft developer projects.

Entry inserted alphabetically.