### PR TITLE
Add Auto Body Shop Directory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1845,6 +1845,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Vehicle
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Auto Body Shop Directory](https://autobodyshopnear.com/developers/body-shop-api) | Find auto body shops by ZIP code, city, location, or profile | No | Yes | No |
 | [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe | No | Yes | No |
 | [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Yes | Unknown |
 | [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds Auto Body Shop Directory to the Vehicle category.

Auto Body Shop Directory is a free public API for finding auto body shops by ZIP code, city, location, or shop profile.

Entry added alphabetically before Brazilian Vehicles and Prices.

- Documentation: https://autobodyshopnear.com/developers/body-shop-api
- Auth: No
- HTTPS: Yes
- CORS: No
- Description length: 65 characters, no trailing punctuation

Checklist:
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
