### PR TITLE
Add Amazonscraperapi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
+| [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**What is this project?**
Amazonscraperapi is a managed REST API for scraping Amazon product detail pages, search results, and batch ASIN lookups. It uses residential proxies, a TLS-impersonation backend, and provides clean JSON output for downstream pipelines.

**Why is it useful?**
Amazon hardened its anti-bot stack significantly through 2025-2026, breaking most self-hosted scrapers. This API handles the proxy + fingerprint + retry layer behind a simple REST interface with an apiKey header. 1000 free requests on signup, no credit card.

**How does it comply with the rules?**
- [x] Free for use (1000 free requests, plus a free /asin-lookup tool)
- [x] HTTPS support
- [x] Authentication via apiKey header
- [x] Single-line entry in alphabetical order in the Development section
- [x] No marketing language; matches existing tone (ScrapeNinja, ScraperApi, ScrapingAnt, ScrapingBee, ScrapingDog, WebScraping.AI, ZenRows are listed in the same section)