### PR TITLE
Add TourneyRadar chess tournament API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
 | [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
+| [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
TourneyRadar is a global chess tournament aggregator. The API helps developers access global OTB tournament data from chess-results.com without needing a key.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ Yes] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ Yes] My addition is ordered alphabetically
- [ Yes] My submission has a useful description
- [ Yes] The description does not have more than 100 characters
- [Yes ] The description does not end with punctuation
- [ Yes] Each table column is padded with one space on either side
- [ Yes] I have searched the repository for any relevant issues or pull requests
- [Yes ] Any category I am creating has the minimum requirement of 3 items
- [Yes ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
