### PR TITLE
Add Personality.fyi to Personality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,7 @@ API | Description | Auth | HTTPS | CORS |
 | [kanye.rest](https://kanye.rest) | REST API for random Kanye West quotes | No | Yes | Yes |
 | [kimiquotes](https://kimiquotes.herokuapp.com/doc) | Team radio and interview quotes by Finnish F1 legend Kimi Räikkönen | No | Yes | Yes |
 | [Medium](https://github.com/Medium/medium-api-docs) | Community of readers and writers offering unique perspectives on ideas | `OAuth` | Yes | Unknown |
+| [Personality.fyi](https://personality.fyi/api) | Free MBTI personality types and OEJTS test scoring | No | Yes | Yes |
 | [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | Programming Quotes API for open source projects | No | Yes | Unknown |
 | [Quotable Quotes](https://github.com/lukePeavey/quotable) | Quotable is a free, open source quotations API | No | Yes | Unknown |
 | [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | REST API for more than 5000 famous quotes | No | Yes | Unknown |


### PR DESCRIPTION
Adding Personality.fyi to the Personality section.

- **URL**: https://personality.fyi/api
- **Description**: Free MBTI personality types and OEJTS test scoring
- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes

Endpoints:
- `GET /api/v1/types` — list of 16 MBTI types
- `GET /api/v1/types/{CODE}` — full type profile
- `GET /api/v1/test/items` — 32 OEJTS test items + scoring spec
- `POST /api/v1/test/score` — compute MBTI type from Likert answers

Items are based on the public-domain Open Extended Jungian Type Scales (OEJTS) by Eric Jorgenson. Pure JSON, no LLM calls, edge-cached.

Verified with curl:
```
$ curl https://personality.fyi/api/v1/types/INTJ
{"code":"INTJ","name":"Architect",...}
```