### PR TITLE
Add PropLine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,6 +1650,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
+| [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |


### PR DESCRIPTION
Adds PropLine, a real-time player-props betting odds API with graded prop resolution across 13 books (incl. Pinnacle + exchanges).

- Free tier: 1,000 requests/day, no credit card
- HTTPS: Yes · Auth: apiKey · CORS: Unknown
- Entry placed alphabetically in the Sports & Fitness section
- Follows the required `| [Name](link) | Description | Auth | HTTPS | CORS |` format