### PR TITLE
Add DocuForge API to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
 | [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth` | Yes | Unknown |
+| [DocuForge API](https://github.com/rnhowcla/docuforge-api) | Document processing: clean Excel, convert CSV, extract PDF text |  | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Clockify](https://clockify.me/developers-api ) | Clockify's REST-based API can be used to push/pull data to/from it & integrate it with other systems | `apiKey` | Yes | Unknown |
 | [CloudConvert](https://cloudconvert.com/api/v2) | Online file converter for audio, video, document, ebook, archive, image, spreadsheet, presentation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
+| [DocuForge API](https://github.com/rnhowcla/docuforge-api) | Document processing for Excel, CSV & PDF files | apiKey | No | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add [DocuForge API](https://github.com/rnhowcla/docuforge-api) — a free document processing REST API.

- Excel: clean, deduplicate, convert to CSV, auto-format
- CSV: convert to Excel, clean empty rows
- PDF: extract text, get metadata, merge PDFs
- Free tier: 50 calls/month, no credit card needed
