### PR TITLE
Add Warnely (Open Data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,7 @@ API | Description | Auth | HTTPS | CORS |
 | [UPC database](https://upcdatabase.org/api) | More than 1.5 million barcode numbers from all around the world | `apiKey` | Yes | Unknown |
 | [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
 | [Voidly](https://voidly.ai/api-docs) | Internet censorship measurements, incidents, and ISP-level blocking data across 126 countries | No | Yes | No |
+| [Warnely](https://warnely.com/developers) | Composite travel-safety scores for 180 countries (FCDO + US State + GPI + WGI + live incident wire), OpenAPI 3.1 spec, CC BY 4.0 | No | Yes | Yes |
 | [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth` | Yes | Unknown |
 | [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
 | [Yelp](https://www.yelp.com/developers/documentation/v3) | Find Local Business | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds Warnely to the **Open Data** section.

## API entry

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [Warnely](https://warnely.com/developers) | Composite travel-safety scores for 180 countries (FCDO + US State + GPI + WGI + live incident wire), OpenAPI 3.1 spec, CC BY 4.0 | No | Yes | Yes |

## Details

- **Base URL**: `https://warnely.com/api/v1`
- **Auth**: None
- **CORS**: Open (`*`)
- **HTTPS**: Yes
- **Licence**: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
- **Docs**: https://warnely.com/developers
- **OpenAPI 3.1 spec**: https://warnely.com/openapi.json
- **Rate limit**: 100 req/min/IP

## Try it

```
curl https://warnely.com/api/v1/countries/TH
```

Returns the composite Warnely safety score, risk tier, FCDO + US State advisories, drug law tier, LGBTQ+ legal status, and quick facts for Thailand. Open data sourced from UK FCDO travel advice, US State Department travel advisories, Global Peace Index, World Bank Worldwide Governance Indicators, WHO country profiles, and a daily-refreshed news incident wire.

## Checklist

- [x] My submission is formatted according to the example in CONTRIBUTING.md
- [x] My submission has a useful description
- [x] The endpoint base URL is correct
- [x] My addition is in the correct alphabetical position within the correct category
- [x] The API is free or has at least a free tier (entirely free, no commercial tier exists)