### PR TITLE
Add Descripio Amazon Reviews API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes | Unknown |
 | [Digi-Key](https://www.digikey.com/en/resources/api-solutions) | Retrieve price and inventory of electronic components as well as place orders | `OAuth` | Yes | Unknown |
+| [Descripio Amazon Reviews](https://docs.descripio.com) | Amazon product reviews for 12 marketplaces | `apiKey` | Yes | Unknown |
 | [Dummy Products](https://dummyproducts-api.herokuapp.com/) | An api to fetch dummy e-commerce products JSON data with placeholder images | `apiKey` | Yes | Yes |
 | [eBay](https://developer.ebay.com/) | Sell and Buy on eBay | `OAuth` | Yes | Unknown |
 | [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | Manage shop and interact with listings | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds the Descripio Amazon Reviews API to the Shopping section.\n\n- **API URL**: https://docs.descripio.com\n- **Description**: Amazon product reviews for 12 marketplaces\n- **Auth**: apiKey\n- **HTTPS**: Yes\n- **CORS**: Unknown\n- Alphabetically placed between Digi-Key and Dummy Products