### PR TITLE
Add UNMIRI NGS Interpretation API to Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,7 @@ API | Description | Auth | HTTPS | CORS |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |
 | [Orion Health](https://developer.orionhealth.io/) | Medical platform which allows the development of applications for different healthcare scenarios | `OAuth` | Yes | Unknown |
 | [Quarantine](https://quarantine.country/coronavirus/api/) | Coronavirus API with free COVID-19 live updates | No | Yes | Yes |
+| [UNMIRI NGS Interpretation](https://api.unmiri.com/openapi.json) | Cross-vendor NGS (genomics) interpretation and genomics-aware clinical decision support over synthetic oncology samples | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds the UNMIRI NGS Interpretation API to the Health section (placed alphabetically).

- API / OpenAPI 3.1 spec: https://api.unmiri.com/openapi.json
- Auth: No (public sandbox; runs against synthetic samples only, no PHI)
- HTTPS: Yes
- CORS: Yes (Access-Control-Allow-Origin: *)

The sandbox runs cross-vendor NGS interpretation, variant evidence lookup, and genomics-aware CDS recommendations against pre-loaded synthetic oncology samples. Companion open-source schema (Apache 2.0): github.com/unmirihealth/unmiri-ngs-fhir-schema.
