### PR TITLE
Add GetXAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,6 +1594,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Foursquare](https://developer.foursquare.com/) | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth` | Yes | Unknown |
 | [Fuck Off as a Service](https://www.foaas.com) | Asks someone to fuck off | No | Yes | Unknown |
 | [Full Contact](https://docs.fullcontact.com/) | Get Social Media profiles and contact Information | `OAuth` | Yes | Unknown |
+| [GetXAPI](https://docs.getxapi.com) | Twitter scraping and posting — 44 endpoints from $0.001 per call | `apiKey` | Yes | No |
 | [HackerNews](https://github.com/HackerNews/API) | Social news for CS and entrepreneurship | No | Yes | Unknown |
 | [Hashnode](https://hashnode.com) | A blogging platform built for developers | No | Yes | Unknown |
 | [Instagram](https://www.instagram.com/developer/) | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What does this API do?

[GetXAPI](https://docs.getxapi.com) is a Twitter/X scraping and posting API with 44 endpoints — tweet search, user lookup, followers/following, timelines, replies, DMs, create/like/retweet tweets, and articles.

## Checklist

- [x] API has a free tier ($0.1 in free credits on signup, no credit card required)
- [x] Auth: `apiKey` (Bearer token)
- [x] HTTPS: Yes
- [x] CORS: No
- [x] Alphabetical placement in Social section (between `Full Contact` and `HackerNews`)
- [x] Description under 100 characters (64 chars)
- [x] No TLD in name
- [x] Name does not end with 'API'
- [x] Documentation: https://docs.getxapi.com
- [x] All commits squashed