### PR TITLE
Add NARC Soil to Agriculture

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
 | [Website Carbon](https://api.websitecarbon.com/) | API to estimate the carbon footprint of loading web pages | No | Yes | Unknown |
-
+| [NARC Soil](https://soil.narc.gov.np/api) | Soil composition and fertilizer recommendation data for Nepal | No | Yes | Unknown |
 **[⬆ Back to Index](#index)**
 <br >
 <br >


### PR DESCRIPTION
Added NARC Soil public API listing under Agriculture category.

The API provides soil composition and fertilizer recommendation data for Nepal using geographic coordinates.
