### PR TITLE
Add DummyImage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
 | [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth` | Yes | Unknown |
+| [DummyImage](https://dummyimage.com/) | Generate placeholder images with custom size, colors and text | No | Yes | Unknown |
 | [EmojiHub](https://github.com/cheatsnake/emojihub) | Get emojis by categories and groups | No | Yes | Yes |
 | [Europeana](https://pro.europeana.eu/resources/apis/search) | European Museum and Galleries content | `apiKey` | Yes | Unknown |
 | [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art | `apiKey` | No | Unknown |


### PR DESCRIPTION
Add DummyImage to Art & Design section.

DummyImage is a free placeholder image generation service that allows developers to create custom placeholder images with specified dimensions, background color, text color, and custom text. No authentication required.

**API Details:**
- **URL:** https://dummyimage.com/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Unknown

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.