### PR TITLE
Add Keyvalue API

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
+| [Keyvalue](https://keyvalue.immanuel.co/) | Simple key-value storage REST API for quick prototyping | No | Yes | Unknown |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add Keyvalue to Development section.

Keyvalue is a free and simple key-value storage REST API. Perfect for quick prototyping, storing configuration data, and simple data persistence without setting up a database.

**API Details:**
- **URL:** https://keyvalue.immanuel.co/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Unknown

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.