### PR TITLE
Add DummyJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,6 +1672,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
+| [DummyJSON](https://dummyjson.com/) | Fake REST API with products, users, posts, comments, todos and more | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |


### PR DESCRIPTION
Add DummyJSON to Test Data section.

DummyJSON is a free fake REST API for testing and prototyping. Provides realistic mock data including products, users, posts, comments, todos, recipes, carts, quotes, and more. Supports pagination, search, and CRUD operations.

**API Details:**
- **URL:** https://dummyjson.com/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.