### PR TITLE
Add Nekos.life API

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MangaDex](https://api.mangadex.org/docs.html) | Manga Database and Community | `apiKey` | Yes | Unknown |
 | [Mangapi](https://rapidapi.com/pierre.carcellermeunier/api/mangapi3/) | Translate manga pages from one language to another | `apiKey` | Yes | Unknown |
 | [MyAnimeList](https://myanimelist.net/clubs.php?cid=13727) | Anime and Manga Database and Community | `OAuth` | Yes | Unknown |
+| [Nekos.life](https://nekos.life/) | Anime cat girl (neko) images and GIFs | No | Yes | Unknown |
 | [NekosBest](https://docs.nekos.best) | Neko Images & Anime roleplaying GIFs | No | Yes | Yes |
 | [Shikimori](https://shikimori.one/api/doc) | Anime discovery, tracking, forum, rates | `OAuth` | Yes | Unknown |
 | [Studio Ghibli](https://ghibliapi.herokuapp.com) | Resources from Studio Ghibli films | No | Yes | Yes |


### PR DESCRIPTION
Add Nekos.life to Anime section.

Nekos.life is a free API providing random anime neko (cat girl) images and GIFs. Simple REST API that returns JSON with image URLs. No authentication required.

**API Details:**
- **URL:** https://nekos.life/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Unknown

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.