### PR TITLE
Add OpenF1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1648,6 +1648,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
+| [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |


### PR DESCRIPTION
Add OpenF1 to Sports & Fitness section.

OpenF1 is a free, open-source API providing real-time and historical Formula 1 data. Includes lap times, car telemetry, driver positions, session information, race results, and more. No authentication required.

**API Details:**
- **URL:** https://openf1.org/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.