### PR TITLE
Add JokeAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
+| [JokeAPI](https://v2.jokeapi.dev/) | Programmable jokes in multiple languages with filtering options | No | Yes | Yes |
 | [justmeme.wtf](https://justmeme.wtf/api-docs) | Free meme API with 2400+ templates, search, trending, and AI generation | No | Yes | Yes |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
 | [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |


### PR DESCRIPTION
Add JokeAPI to Entertainment section.

JokeAPI is a free, RESTful API that serves jokes from multiple categories in multiple languages. Supports various joke types (single, twopart), blacklist flags for filtering inappropriate content, and response formats (JSON, XML, YAML). No authentication required.

**API Details:**
- **URL:** https://v2.jokeapi.dev/
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes

I have read the CONTRIBUTING guidelines and confirm this API is not already listed.