### PR TITLE
Add vatnode to Business section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
+| [vatnode](https://vatnode.dev/docs) | EU VAT number validation with VIES consultation numbers for audit-ready records | `apiKey` | Yes | No |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
### What's the API?

[vatnode](https://vatnode.dev) — REST API for validating EU VAT numbers via VIES, returning the official VIES consultation number for qualified checks alongside `checkId` and `verifiedAt` audit-trail fields. National registry fallback for several EU countries when VIES is unavailable.

Docs: https://vatnode.dev/docs

### Why is this useful?

EU B2B sellers are required to validate customer VAT IDs to apply the reverse-charge rule. The VIES consultation number is the evidence tax authorities reference at audit time, but most existing VAT APIs don't surface it. This entry helps developers find an API that returns that audit-ready record.

### Checklist

- [x] Free tier available (100 checks/month, no credit card required)
- [x] HTTPS-only
- [x] Auth: `apiKey`
- [x] Description under 100 characters
- [x] Alphabetically inserted in `Business` section after Trello
- [x] No marketing copy

Thanks for maintaining this list.