### PR TITLE
Add SnapAPI to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MyAnimeList](https://myanimelist.net/clubs.php?cid=13727) | Anime and Manga Database and Community | `OAuth` | Yes | Unknown |
 | [NekosBest](https://docs.nekos.best) | Neko Images & Anime roleplaying GIFs | No | Yes | Yes |
 | [Shikimori](https://shikimori.one/api/doc) | Anime discovery, tracking, forum, rates | `OAuth` | Yes | Unknown |
+| [SnapAPI](https://snap.michaelcli.com) | Website screenshots, metadata extraction, PDF generation, text extraction | `apiKey` | Yes | Yes |
 | [Studio Ghibli](https://ghibliapi.herokuapp.com) | Resources from Studio Ghibli films | No | Yes | Yes |
 | [Trace Moe](https://soruly.github.io/trace.moe-api/#/) | A useful tool to get the exact scene of an anime from a screenshot | No | Yes | Yes |
 | [Waifu.im](https://waifu.im/docs) | Get waifu pictures from an archive of over 4000 images and multiple tags | No | Yes | Yes |


### PR DESCRIPTION
Adding SnapAPI to the Development section.

**SnapAPI** provides website screenshots, metadata extraction (Open Graph, Twitter Cards), PDF generation, and text extraction.

- Auth: API Key
- HTTPS: Yes  
- CORS: Yes
- Free tier: 50 requests/month
- Website: https://snap.michaelcli.com