### PR TITLE
Add Resolved Markets API

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [PumpFunData](https://pumpfundata.com/docs) | Historical Pump.fun and PumpSwap AMM swap data as hourly Parquet files | `apiKey` | Yes | Unknown |
+| [Resolved Markets](https://resolvedmarkets.com/docs) | Orderbook data for Polymarket prediction markets and Hyperliquid perps; REST + WebSocket | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What this PR adds

Adds **Resolved Markets** to the `Cryptocurrency` section.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [Resolved Markets](https://resolvedmarkets.com/docs) | Orderbook data for Polymarket prediction markets and Hyperliquid perps; REST + WebSocket | `apiKey` | Yes | Unknown |

## About the API

Resolved Markets is a REST + WebSocket API that serves real-time and historical
orderbook snapshots for Polymarket prediction markets (crypto up/down, NBA, FOMC,
weather, S&P 500, social) and Hyperliquid perpetual futures. All responses are
JSON, all timestamps are UTC.

Documentation: https://resolvedmarkets.com/docs

## Free tier (per the contributing rule about free access)

A real, no-trial Free tier exists:

- BTC prediction markets, full end-to-end access
- 24 hours of history
- 60 requests/minute
- 1 API key
- REST only (no WebSocket on the free tier)

No device, hardware, or other paid product is required to use the API — sign up
at https://resolvedmarkets.com, generate a key at /api-keys, and the BTC
endpoints work immediately.

## Compliance with the contributing guidelines

- [x] One link added in this PR
- [x] Placed in the most appropriate section (`Cryptocurrency`)
- [x] Alphabetical ordering preserved (between `PumpFunData` and `Solana JSON RPC`)
- [x] Description is under 100 characters
- [x] Each column padded with one space on either side
- [x] API name does not end with the word "API"
- [x] API name does not include a TLD
- [x] `Auth` column uses an allowed value (`apiKey` — the API uses an
      `X-API-Key` header which `Authorization: Bearer` is also accepted for)
- [x] `CORS` column uses an allowed value (`Unknown` — CORS behavior is not
      explicitly documented; conservative answer per the guidelines)
- [x] HTTPS: Yes (`https://api.resolvedmarkets.com` is the only base URL)
- [x] Proper public documentation page exists at the linked URL
- [x] Free, non-trial access available (no device/service purchase required)
- [x] Single squashed commit on a feature branch, targeted at `master`
- [x] Not an updated/new version of an already-listed API (Resolved Markets is
      not currently in the list)

## Why Cryptocurrency and not a new section

The API's primary dataset is crypto-denominated orderbooks (BTC/ETH/SOL/XRP
prediction markets and Hyperliquid crypto perps). Per the guideline "If an API
seems to fall into multiple categories, please place the listing within the
section most in line with the services offered," Cryptocurrency is the best
fit even though the API also covers sports, weather, and economics markets.