### PR TITLE
Add Quotable Wisdom API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Medium](https://github.com/Medium/medium-api-docs) | Community of readers and writers offering unique perspectives on ideas | `OAuth` | Yes | Unknown |
 | [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | Programming Quotes API for open source projects | No | Yes | Unknown |
 | [Quotable Quotes](https://github.com/lukePeavey/quotable) | Quotable is a free, open source quotations API | No | Yes | Unknown |
+| [Quotable Wisdom](https://rapidapi.com/quotable2026/api/quotable-wisdom) | 240,000+ curated quotes filterable by category, mood, faith tradition, era, and length | `apiKey` | Yes | Unknown |
 | [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | REST API for more than 5000 famous quotes | No | Yes | Unknown |
 | [quoteclear](https://quoteclear.web.app/) | Ever-growing list of James Clear quotes from the 3-2-1 Newsletter | No | Yes | Yes |
 | [Quotes on Design](https://quotesondesign.com/api/) | Inspirational Quotes | No | Yes | Unknown |


### PR DESCRIPTION
## API Added

**Quotable Wisdom** — added to the **Personality** section.

| Field | Value |
|---|---|
| Name | Quotable Wisdom |
| URL | https://rapidapi.com/quotable2026/api/quotable-wisdom |
| Description | 240,000+ curated quotes filterable by category, mood, faith tradition, era, and length |
| Auth | apiKey |
| HTTPS | Yes |
| CORS | Unknown |

## Notes

- 240,000+ professionally curated quotes (not raw scraped data)
- Filters: 43 categories, 8 moods, 7 faith traditions, 6 eras, 3 length buckets
- Free tier available (100 calls/month, no credit card)
- Live sandbox on RapidAPI
- Docs: https://quotable2026.github.io/api-docs/