### PR TITLE
Add Open-Meteo to Weather category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,6 +1926,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
+| [Open-Meteo](https://open-meteo.com) | Open-source weather API with no API key required, providing hourly forecasts | No | Yes | Yes |
 | [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |
 | [Open-Meteo](https://open-meteo.com/) | Global weather forecast API for non-commercial use | No | Yes | Yes |
 | [openSenseMap](https://api.opensensemap.org/) | Data from Personal Weather Stations called senseBoxes | No | Yes | Yes |


### PR DESCRIPTION
## Description
Added Open-Meteo to the Weather category.

Open-Meteo is a free, open-source weather API that requires no API key.
It provides hourly forecasts and historical weather data.

## Checklist
- [x] Entry is in alphabetical order
- [x] HTTPS is supported
- [x] Auth field is correct (No)
- [x] Link is working