### PR TITLE
Add TideTurtle API to Weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -1935,6 +1935,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QWeather](https://dev.qweather.com/en/) | Location-based weather data | `apiKey` | Yes | Yes |
 | [RainViewer](https://www.rainviewer.com/api.html) | Radar data collected from different websites across the Internet | No | Yes | Unknown |
 | [Storm Glass](https://stormglass.io/) | Global marine weather from multiple sources | `apiKey` | Yes | Yes |
+| [TideTurtle](https://tideturtle.com/developers) | Tide times + charts for 1,414 coastal places worldwide, REST + MCP | No | Yes | Yes |
 | [Tomorrow](https://docs.tomorrow.io) | Weather API Powered by Proprietary Technology | `apiKey` | Yes | Unknown |
 | [US Weather](https://www.weather.gov/documentation/services-web-api) | US National Weather Service | No | Yes | Yes |
 | [Visual Crossing](https://www.visualcrossing.com/weather-api) | Global historical and weather forecast data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **TideTurtle** to the Weather section.

Tide times + charts for 1,414 coastal places worldwide. CORS-open, no API key, no signup.

- **Title:** TideTurtle
- **URL:** https://tideturtle.com/developers
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes
- **OpenAPI spec:** https://tideturtle.com/api/v1/openapi.json
- **Sources:** NOAA CO-OPS, UK Environment Agency Flood, BSH (Germany), Open-Meteo Marine
- **Methodology + accuracy notes:** https://tideturtle.com/methodology

Sample endpoints:
- `GET /api/v1/places` — full curated index (1,414 places)
- `GET /api/v1/places/{country}/{region}/{slug}` — single place tide data
- `GET /api/v1/tides?lat&lon` — closest place to lat/lon

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically (between Storm Glass and Tomorrow in Weather)
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been squashed into a single commit