### PR TITLE
feat: add RankParse API to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |
+| [RankParse](https://rankparse.com/docs) | Backlinks, domain authority, tech stack, and 18+ SEO signals powered by pre-processed Common Crawl data | `apiKey` | Yes | Yes |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey` | Yes | No |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |


### PR DESCRIPTION
Adds RankParse to the Development section in alphabetical order.

RankParse is a backlink and SEO data API powered by pre-processed Common Crawl data, served from Cloudflare's edge. It provides backlinks, domain authority, tech stack detection, referring domains, anchor text analysis, and 15+ additional SEO signals.

- **Free tier:** 100 credits on signup, no credit card required
- **Auth:** API key via X-API-Key header
- **Docs:** https://rankparse.com/docs
- **HTTPS:** Yes
- **CORS:** Yes (Cloudflare Workers)