### PR TITLE
Add Local-Eye and AgentSeek APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
 | [Suprsonic](https://suprsonic.ai) | Unified agent API: search, scrape, enrich, image gen, TTS, STT, messaging. One key, 20+ capabilities | `apiKey` | Yes | Yes |
+| [Local-Eye](https://localeye.co) | Residential IPs, GPU screenshots, and phone verification for AI agents | `apiKey` | Yes | Yes |
+| [AgentSeek](https://agentseek.co) | AI agent discovery registry and DNS for agents | `apiKey` | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
@@ -1413,6 +1415,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |
+| [Local-Eye](https://localeye.co) | AI phone verification that calls businesses to confirm hours and info | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Added APIs

### Local-Eye (Development + Phone sections)
- Residential IP proxy for AI agents to bypass bot detection
- GPU-rendered screenshots of web pages
- AI phone verification that calls businesses to confirm hours and info
- OpenAPI spec: https://localeye.co
- Free tier available

### AgentSeek (Development section)
- AI agent discovery registry
- DNS-like system for agents to find and connect with other agents by capability
- OpenAPI spec: https://agentseek.co
- Free tier available

Added to both the Development section and Phone section (Local-Eye phone verification).

I have read the CONTRIBUTING and README guidelines and made sure this PR follows them.