### PR TITLE
Add RevCarData to Vehicle APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1851,6 +1851,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |
 | [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | Yes | No |
 | [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Yes | Unknown |
+| [RevCarData](https://revcardata.com) | 86,000+ global vehicle specifications and EV metrics | `apiKey` | Yes | Yes |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
### Description
Added RevCarData to the Vehicle category. 

* **Link:** https://revcardata.com
* **API Docs:** https://api.revcardata.com/docs
* **Features:** 86,000+ global vehicle specifications, EV metrics, YMME structure, and pricing data.
* **Auth:** API Key
* **HTTPS:** Yes
* **CORS:** Yes

We offer a Free Developer Tier (100 requests/month) for testing purposes. Developers can generate a free test key instantly via our dashboard **without requiring a credit card**.