### PR TITLE
Add II-Commons API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1474,6 +1474,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |
 | [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
+| [II-Commons](https://github.com/Intelligent-Internet/II-Commons-Skills/blob/main/skills/ii-commons/references/api.md) | Daily-updated retrieval across arXiv, PubMed/PMC, and US policy corpora | No | Yes | Unknown |
 | [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | High Energy Physics info. system | No | Yes | Unknown |
 | [isEven (humor)](https://isevenapi.xyz/) | Check if a number is even | No | Yes | Unknown |
 | [ISRO](https://isro.vercel.app) | ISRO Space Crafts Information | No | Yes | No |


### PR DESCRIPTION
Adds II-Commons to the Science & Math section.\n\nII-Commons provides documented HTTPS endpoints for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora. Basic usage works without authentication; API tokens are optional for higher usage limits.\n\nDocumentation: https://github.com/Intelligent-Internet/II-Commons-Skills/blob/main/skills/ii-commons/references/api.md