### PR TITLE
Add Orizn Visa API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1768,6 +1768,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
+| [Orizn Visa](https://visa.orizn.app) | Visa requirements for 199 countries, 39K+ passport-destination pairs in 15 languages | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add **Orizn Visa** to the Transportation section.

- **URL:** https://visa.orizn.app
- **Auth:** API key
- **HTTPS:** Yes
- **CORS:** Yes

Orizn Visa is a free API that provides visa requirement data for 199 countries, covering 39,000+ passport-destination pairs in 15 languages. Useful for travel apps and services that need to check visa policies programmatically.

The entry is placed in alphabetical order within the Transportation section.