### PR TITLE
Add Quantum Surety Bond Watch API (Texas contractor bond compliance, no auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
+| [Quantum Surety Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Texas contractor and notary surety bond compliance from TDLR public records | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |


### PR DESCRIPTION
## Description

This adds the Quantum Surety Bond Watch API to the Government section.

**Quantum Surety Bond Watch** provides live Texas contractor and notary bond compliance data sourced from TDLR (Texas Department of Licensing and Regulation) public records via data.texas.gov.

- No authentication required
- HTTPS only
- CORS enabled (Access-Control-Allow-Origin: *)
- Updated daily from TDLR Socrata dataset (7358-krk7)
- Covers 816,000+ TDLR-licensed contractors and 558,000+ Texas notaries

**Example endpoints:**


**API docs:** https://verify.quantumsurety.bond/api-docs.html

**Data source:** Texas Department of Licensing and Regulation via data.texas.gov (public domain)
