### PR TITLE
Add Audexum TTS API to Text Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Code Detection API](https://codedetectionapi.runtime.dev) | Detect, label, format and enrich the code in your app or in your data pipeline | `OAuth` | Yes | Unknown |
 | [apilayer languagelayer](https://languagelayer.com/) | Language Detection JSON API supporting 173 languages | `OAuth` | Yes | Unknown |
 | [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | A collection of information retrieval and natural language APIs | `apiKey` | Yes | Unknown |
+| [Audexum](https://audexum.com/docs) | Text-to-speech REST API with 43 voices and 33 languages | `apiKey` | Yes | Yes |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added Audexum to the Text Analysis section.

- API: https://audexum.com/docs
- Auth: apiKey (Bearer token)
- HTTPS: Yes
- CORS: Yes
- Description: Text-to-speech REST API, 43 voices, 33 languages, freemium