### PR TITLE
Add TheRundown to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1662,7 +1662,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |
 | [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
 | [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
-| [TheRundown](https://therundown.io/) | Real-time sports odds across 30+ leagues and 16+ sportsbooks plus Kalshi and Polymarket prediction markets in one unified schema. Free tier, no credit card. | `apiKey` | Yes | Yes |
+| [TheRundown](https://therundown.io/) | Real-time sports odds: 30+ leagues, 18+ sportsbooks, prediction markets, one schema, free tier | `apiKey` | Yes | Yes |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1662,6 +1662,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |
 | [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
 | [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
+| [TheRundown](https://therundown.io/) | Real-time sports odds across 30+ leagues and 16+ sportsbooks plus Kalshi and Polymarket prediction markets in one unified schema. Free tier, no credit card. | `apiKey` | Yes | Yes |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1662,7 +1662,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |
 | [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
 | [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
-| [TheRundown](https://therundown.io/) | Real-time sports odds: 30+ leagues, 18+ sportsbooks, prediction markets, one schema, free tier | `apiKey` | Yes | Yes |
+| [TheRundown](https://therundown.io/) | Real-time sports data: odds, scores, stats & prediction markets, 30+ leagues, 18+ sportsbooks | `apiKey` | Yes | Yes |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adding TheRundown to the Sports & Fitness section.

- **Name:** TheRundown
- **URL:** https://therundown.io/
- **Description:** Real-time sports odds across 30+ leagues and 16+ sportsbooks plus Kalshi and Polymarket prediction markets in one unified schema. Free tier (20K data points/day), no credit card.
- **Auth:** `apiKey` (query param `?key=` or `X-Therundown-Key` header)
- **HTTPS:** Yes
- **CORS:** Yes

Quickstart: https://therundown.io/docs/quickstart  ·  Docs: https://docs.therundown.io/