### PR TITLE
Add Open Scholarships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1328,6 +1328,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | Open data about nobel prizes and events | No | Yes | Yes |
 | [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) | Free public leaderboard of x402 paid HTTP services indexed from Coinbase CDP discovery API | No | Yes | Unknown |
 | [Open Data Minneapolis](https://opendata.minneapolismn.gov/) | Spatial (GIS) and non-spatial city data for Minneapolis | No | Yes | No |
+| [Open Scholarships](https://scholarships.grudged.io) | Free, openly-licensed directory of US scholarships and student aid from official sources | No | Yes | Yes |
 | [openAFRICA](https://africaopendata.org/) | Large datasets repository of African open data | No | Yes | Unknown |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |


### PR DESCRIPTION
Adds **Open Scholarships** to the **Open Data** category.

| Field | Value |
|---|---|
| API | [Open Scholarships](https://scholarships.grudged.io) |
| Description | Free, openly-licensed directory of US scholarships and student aid from official sources |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

A free, CC BY 4.0 licensed, machine-readable directory of scholarships and student financial aid, sourced from primary official sources (state agencies, public universities, foundations). No key, no signup, CORS-open, returns JSON.

- Docs / endpoints: https://scholarships.grudged.io
- OpenAPI spec: https://scholarships.grudged.io/openapi.json
- Source + data (CC BY 4.0): https://github.com/Grudged/open-scholarships

Checklist:
- [x] One API per PR
- [x] Alphabetical order within the category
- [x] Description under 100 characters, no "API"/TLD in the name
- [x] HTTPS + CORS verified