### PR TITLE
Add Inference Labs (free LLM pricing API) to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Hugging Face](https://huggingface.co) | AI model hub with inference API for NLP, computer vision, and audio | `apiKey` | Yes | Yes |
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
+| [Inference Labs](https://inference-labs.com/api/) | Free public dataset of current per-token pricing, context window, and tier for the major 2026 LLMs (GPT-5, Claude, Gemini, Bedrock, Llama). CC BY 4.0; OpenAPI 3.1 spec available. | No | Yes | Yes |
 | [IPS Online](https://docs.identity.ps/docs) | Face and License Plate Anonymization | `apiKey` | Yes | Unknown |
 | [Irisnet](https://irisnet.de/api/) | Realtime content moderation API that blocks or blurs unwanted images in real-time | `apiKey` | Yes | Yes |
 | [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [Inference Labs](https://inference-labs.com/api/) to the Machine Learning section.

It's a free public dataset of current per-token pricing, context window, and quality tier for the major 2026 frontier LLMs (GPT-5, Claude, Gemini, Bedrock, Llama, Nova). No API key, no rate limit, CC BY 4.0, CORS-open, served over HTTPS, OpenAPI 3.1 spec available at `/api/openapi.yaml`.

Entry placed alphabetically between `Inferdo` and `IPS Online`.