### PR TITLE
docs: add Renderly to Documents & Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
+| [Renderly](https://renderlyapi.com) | HTML to PDF conversion API built on Chromium | `apiKey` | Yes | Yes |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [Renderly](https://renderlyapi.com) to the Documents & Productivity section.

- **API**: HTML to PDF conversion REST API
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes

Renderly converts HTML to PDF via a single POST request, built on Chromium (so CSS Grid, custom fonts, and modern CSS all render exactly as in Chrome). Free tier available (50 PDFs/month).

Placed alphabetically between PrexView and Restpack.