### PR TITLE
Add Signaliz API

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ API | Description | Auth | HTTPS | CORS |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
+| [Signaliz](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction) | GTM enrichment, lead generation, email verification, and company signals | `apiKey` | Yes | Unknown |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Yes | Unknown |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary
- Adds Signaliz to the Business section.
- Signaliz has public docs, API-key authentication, HTTPS, and a free tier.

## Verification
- Checked `CONTRIBUTING.md` formatting and eligibility guidance.
- Ran `git diff --check`.
- Verified public docs and free tier from https://signaliz.com and https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction.
