### PR TITLE
Add Rendex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
 | [Renderly](https://renderlyapi.com) | HTML to PDF conversion API built on Chromium | `apiKey` | Yes | Yes |
+| [Rendex](https://rendex.dev) | Render HTML, Markdown, or URLs to PNG/JPEG/WebP/PDF, with extraction and templating | `apiKey` | Yes | Unknown |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Rendex** to the *Documents & Productivity* section, ordered alphabetically before Restpack.

- Free tier available; API key auth over HTTPS.
- Categorized here because its core outputs are rendered documents and images from HTML, Markdown, or a URL (PNG/JPEG/WebP/PDF), alongside the existing PDF/HTML tools like pdflayer and Restpack — plus reader-mode content extraction.

Single link added; format matches the existing rows in the section.
