### PR TITLE
Add GetXAPI to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -1598,6 +1598,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Foursquare](https://developer.foursquare.com/) | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth` | Yes | Unknown |
 | [Fuck Off as a Service](https://www.foaas.com) | Asks someone to fuck off | No | Yes | Unknown |
 | [Full Contact](https://docs.fullcontact.com/) | Get Social Media profiles and contact Information | `OAuth` | Yes | Unknown |
+| [GetXAPI](https://www.getxapi.com/) | Read Twitter / X data and post tweets, likes, retweets, follows, DMs via REST | `apiKey` | Yes | Unknown |
 | [HackerNews](https://github.com/HackerNews/API) | Social news for CS and entrepreneurship | No | Yes | Unknown |
 | [Hashnode](https://hashnode.com) | A blogging platform built for developers | No | Yes | Unknown |
 | [Instagram](https://www.instagram.com/developer/) | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds GetXAPI to the Social section, sorted alphabetically between Full Contact and HackerNews.

GetXAPI is a pay-per-call Twitter / X data API. 47 endpoints across reads and writes. $0.001 per call, no monthly minimum.

- Auth: `apiKey` (Bearer)
- HTTPS: Yes  
- CORS: Unknown (not confirmed)
- Site: https://www.getxapi.com
- Docs: https://docs.getxapi.com
- Wikidata: https://www.wikidata.org/wiki/Q139996278

Description fits the 5-column table format. Voice matches existing entries.