### PR TITLE
Add bulkconvert

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ API | Description | Auth | HTTPS | CORS |
 <br >
 <br >
 ### Documents & Productivity
+| [bulkconvert](https://www.bulkconvert.io) | Convert files between 32 formats (PDF, DOCX, MP3, MP4, etc). EU-hosted, free tier without signup. | `apiKey` | Yes | No |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Airtable](https://airtable.com/api) | Integrate with Airtable | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **bulkconvert** under `### Documents & Productivity`.

> Privacy-first file conversion API. 32 format pairs, EU-hosted, free tier (3/day) on every account, Bearer-token HTTP API.

- URL: https://www.bulkconvert.io
- Repo: https://github.com/DirckM/bulk-convert