### PR TITLE
Fix Food & Drink section not rendering as a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Yahoo Finance](https://www.yahoofinanceapi.com/) | Real time low latency Yahoo Finance API for stock market, crypto currencies, and currency exchange | `apiKey` | Yes | Yes | |
 | [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth` | Yes | Yes | |
 | [Zoho Books](https://www.zoho.com/books/api/v3/) | Online accounting software, built for your business | `OAuth` | Yes | Unknown | |
+
 **[⬆ Back to Index](#index)**
 <br >
 <br >


### PR DESCRIPTION
## Problem

The `Food & Drink` section currently does not render as a table on GitHub. Instead, the section heading and the entire markdown table appear as raw text in the rendered README.

## Root cause

The `Finance` section immediately above `Food & Drink` is missing a blank line between its last data row and the `**[⬆ Back to Index](#index)**` line that follows it.

Because there is no blank line, GitHub's GFM parser absorbs the bold-link line as a final, malformed table row in `Finance`. That malformed continuation prevents the parser from recognizing the subsequent `### Food & Drink` heading and its own table as a new section, so the entire Food & Drink markdown block is rendered as plain text.

This is purely a Markdown formatting issue. None of the existing API entries are changed.

## Fix

Add a single blank line after the last `Finance` data row (`Zoho Books`), so that the `Finance` table terminates cleanly and the `### Food & Drink` heading is parsed as a new heading.

## Verification

Verified locally by rendering the surrounding markdown through GitHub's GFM endpoint (`POST /markdown` with `mode=gfm`) before and after the fix:

- Before: only the `Finance` table renders; `### Food & Drink` and its rows appear as raw text.
- After: both `Finance` and `Food & Drink` render as proper HTML tables with their headings.

## Notes

- One line added, no API entries modified.
- All other category sections in the README already include the blank line between the last data row and the `Back to Index` link; this brings `Finance` in line with the established pattern.
- This is targeted at the `master` branch per CONTRIBUTING.md.