### PR TITLE
Add CongressInvests API - real-time U.S. congressional stock trade disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
+| [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |


### PR DESCRIPTION
## API Description

**Name:** CongressInvests
**Description:** Real-time U.S. congressional stock trade disclosures scraped from Senate EFD and House Clerk. Query by ticker, chamber, or date. Free tier (100 req/day) requires no key.
**Category:** Finance
**Auth:** `apiKey` (optional — free tier works without one)
**HTTPS:** Yes
**CORS:** Yes
**Link:** https://congressinvests.com
**Docs:** https://congressinvests.com/docs

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] Entry is in alphabetical order within its category
- [x] All URLs are working
- [x] HTTPS is supported
- [x] CORS status has been verified