### PR TITLE
Add Invovate (invoice generation API) to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
+| [Invovate](https://invovate.com/api) | Generate PDF, JSON & UBL invoices in 11 languages from one JSON POST | `apiKey` | Yes | No |
 | [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |


### PR DESCRIPTION
Adds **Invovate** to the **Business** category (alphabetical, after Instatus).

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| [Invovate](https://invovate.com/api) | Generate PDF, JSON & UBL invoices in 11 languages from one JSON POST | `apiKey` | Yes | No |

- Public, free tier (JSON output works with no key; PDF/UBL use a free `inv_` API key).
- HTTPS only; docs at https://invovate.com/api ; OpenAPI 3.1 at https://invovate.com/openapi.json
- CORS = No (the API is origin-locked for browser calls; intended for server-side use).

My addition is on a single line and alphabetized within its category.