### PR TITLE
Use raw strings for regex patterns in format.py

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]


### PR DESCRIPTION
The three regex patterns in `scripts/validate/format.py` use plain (non-raw) string literals containing invalid escape sequences (`\s`, `\*`, `\[`, `\]`, `\(`, `\)`):

```python
anchor_re = re.compile(anchor + '\s(.+)')
category_title_in_index_re = re.compile('\*\s\[(.*)\]')
link_re = re.compile('\[(.+)\]\((http.*)\)')
```

These raise `SyntaxWarning: invalid escape sequence` on Python 3.12+ (DeprecationWarning on earlier 3.x) and are slated to become a `SyntaxError` in a future release.

This switches them to raw strings (`r'...'`). The compiled pattern bytes are **identical** (verified: `r'\s(.+)' == '\s(.+)'` is `True`), so validation behavior is unchanged — it only removes the warnings. This also matches `scripts/validate/links.py`, which already uses a raw string for its regex.

Verified with `python -W error::SyntaxWarning`: the file compiles cleanly after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)