### PR TITLE
Remove Zoo Animals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ API | Description | Auth | HTTPS | CORS
 | [Shibe.Online](http://shibe.online/) | Random pictures of Shiba Inu, cats or birds | No | Yes | Yes |
 | [The Dog](https://thedogapi.com/) | A public service all about Dogs, free to use when making your fancy new App, Website or Service | `apiKey` | Yes | No |
 | [xeno-canto](https://xeno-canto.org/explore/api) | Bird recordings | No | Yes | Unknown |
-| [Zoo Animals](https://zoo-animal-api.herokuapp.com/) | Facts and pictures of zoo animals | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
The Zoo Animals API returns a 404 error from the Heroku router, indicating it is no longer active. Following the contributing guidelines, I am removing this dead link.