### PR TITLE
Fix UnboundLocalError in get_categories_content for rows before the first category

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -43,6 +43,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
 
     categories = {}
     category_line_num = {}
+    category = None
 
     for line_num, line_content in enumerate(contents):
 
@@ -60,7 +61,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
         ][0]
 
         title_match = link_re.match(raw_title)
-        if title_match:
+        if title_match and category is not None:
                 title = title_match.group(1).upper()
                 categories[category].append(title)
 


### PR DESCRIPTION
### Bug

In `scripts/validate/format.py`, `get_categories_content` assigns `category` only when it sees a `###` header, but references it when appending a title:

```python
for line_num, line_content in enumerate(contents):
    if line_content.startswith(anchor):
        category = line_content.split(anchor)[1].strip()
        ...
        continue
    ...
    title_match = link_re.match(raw_title)
    if title_match:
            title = title_match.group(1).upper()
            categories[category].append(title)   # category may be unbound
```

If a table row containing a `[title](http...)` link appears **before** the first `###` header, `category` was never assigned and Python raises `UnboundLocalError: cannot access local variable 'category'`.

This is reachable on the repo's own `README.md`: it has promo/sponsor tables (e.g. the APILayer block) above the first `### Animals` header, so `check_file_format(open('README.md').readlines())` crashes. It isn't caught today because CI runs `links.py` (not `format.py`) on the README, and the `get_categories_content` unit-test fixtures all start with `### A`.

### Fix

Initialize `category = None` and only append once a category header has been seen, so rows before the first category are skipped instead of crashing. Verified:
- normal input (`### A` … `### B`) parses identically (no regression);
- a link row before the first header is now skipped, and `check_file_format` runs on `README.md` without raising.