### PR TITLE
Add CharitySense API

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
+| [CharitySense](https://data.charitysense.com/developers) | IRS Form 990 nonprofit search and charity research data | No | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |


### PR DESCRIPTION
Adds CharitySense, a no-auth HTTPS API for IRS Form 990 nonprofit search and charity research.

Docs: https://data.charitysense.com/developers
OpenAPI: https://data.charitysense.com/openapi.yaml
