### PR TITLE
Add Sugra API (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |
+| [Sugra](https://sugra.ai) | One API for market data, economics, commodities, climate, and global news. LLM-ready JSON | `apiKey` | Yes | Yes | |
 | [Tax Data](https://apilayer.com/marketplace/tax_data-api) | Instant VAT number and tax validation across the globe | `apiKey` | Yes | Unknown | |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes | |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds Sugra, one API for market data, economics, commodities, climate, and global news, returned as LLM-ready JSON. 1,400+ endpoints across 146 primary sources, single API key.

- Link: https://sugra.ai
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes
- Free tier available (permanent, no card required)

Entry added to the Finance category in alphabetical order (between Styvio and Tax Data). Description is 89 characters (under the 100 limit); name does not end with "API" and contains no TLD, per CONTRIBUTING.