### PR TITLE
Add SSL Inspector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1554,6 +1554,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SecurityTrails](https://securitytrails.com/corp/apidocs) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
+| [SSL Inspector API](https://kiprio.com/v1/ssl) | Inspect SSL/TLS certificates for any domain — expiry, issuer, protocol, cipher suite, and security grade | `apiKey` | Yes | Yes |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [Virushee](https://api.virushee.com/) | Virushee file/data scanning | No | Yes | Yes |


### PR DESCRIPTION
Adds SSL Inspector API to the Security section.

Free SSL/TLS certificate inspection API that returns expiry date, issuer, protocol version, cipher suite, and security grade for any domain. Free demo tier available with no authentication required.