### PR TITLE
Add DNS Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey` | Yes | Yes |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
+| [DNS Lookup API](https://kiprio.com/v1/dns-lookup) | Query DNS records for any domain — A, MX, TXT, NS, CNAME, and more, with TTL and structured JSON output | `apiKey` | Yes | Yes |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |


### PR DESCRIPTION
Adds DNS Lookup API to the Development section.

Free DNS record lookup API that returns structured JSON for A, MX, TXT, NS, CNAME and other record types with TTL values. Free demo tier requires no authentication.