### PR TITLE
Add caldays (public holidays API for 195+ countries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Calendar
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [caldays](https://caldays.com/api) | Public holidays for 195+ countries | No | Yes | Yes |
 | [Calendarific](https://calendarific.com/) | Worldwide Holidays | `apiKey` | Yes | Unknown |
 | [Checkiday - National Holiday](https://apilayer.com/marketplace/checkiday-api) | Industry-leading holiday data with over 5,000 holidays and thousands of descriptions | `apiKey` | Yes | Unknown |
 | [Church Calendar](http://calapi.inadiutorium.cz/) | Catholic liturgical calendar | No | No | Unknown |


### PR DESCRIPTION
Adds **caldays** to the Calendar section, in alphabetical order.

- Free public-holiday data — **no auth / no API key required**
- **HTTPS**, JSON responses, **CORS** enabled (`Access-Control-Allow-Origin: *`)
- Covers 195+ countries — example: https://caldays.com/api/holidays/us
- Docs: https://caldays.com/api · License: CC BY 4.0

Checklist:
- [x] Only one API added
- [x] Added in alphabetical order within the Calendar category
- [x] Description is concise, no trailing period, does not contain the word "API"
- [x] Auth = No, HTTPS = Yes, CORS = Yes (verified live)