### PR TITLE
Add Padel Snipe to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,6 +1658,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
+| [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Padel Snipe** to the Sports & Fitness section.

- Open JSON API listing mapped padel clubs across 9 European countries (GPS coordinates, city, indoor/outdoor court counts)
- Auth: No · HTTPS: Yes · CORS: Yes — free, no key required
- License CC-BY 4.0, also listed on data.gouv.fr
- Single-line addition, placed alphabetically between OpenLigaDB and Premier League Standings