### PR TITLE
fix: remove duplicate TasteDive API entry from Music section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1276,7 +1276,6 @@ API | Description | Auth | HTTPS | CORS |
 | [SoundCloud](https://developers.soundcloud.com/docs/api/guide) | With SoundCloud API you can build applications that will give more power to control your content | `OAuth` | Yes | Unknown |
 | [Spotify](https://beta.developer.spotify.com/documentation/web-api/) | View Spotify music catalog, manage users' libraries, get recommendations and more | `OAuth` | Yes | Unknown |
 | [Sunor](https://docs.sunor.cc) | AI music generation API via Suno, with pay-as-you-go credits | `apiKey` | Yes | Unknown |
-| [TasteDive](https://tastedive.com/read/api) | Similar artist API (also works for movies and TV shows) | `apiKey` | Yes | Unknown |
 | [TheAudioDB](https://www.theaudiodb.com/api_guide.php) | Music | `apiKey` | Yes | Unknown |
 | [Vagalume](https://api.vagalume.com.br/docs/) | Crowdsourced lyrics and music knowledge | `apiKey` | Yes | Unknown |
 | [Verome](https://github.com/Kirazul/Verome-API) | Music API for searching, streaming and exploring music data from YouTube Music, YouTube, and Last.fm | No | Yes | Unknown |


### PR DESCRIPTION
Closes #6223

## Summary

Removes the duplicate entry for [TasteDive](https://tastedive.com/read/api) from the **Music** section.

The same URL (`https://tastedive.com/read/api`) appears twice:
1. **Entertainment** section: "Content-based recommendations for movies, music, TV shows, books, games, and podcasts" (kept)
2. **Music** section: "Similar artist API (also works for movies and TV shows)" (removed)

The Entertainment section entry has a more complete description of TasteDive's capabilities, covering all the media types it supports.