### PR TITLE
Add CryptoSignal API to Cryptocurrency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |
+| [CryptoSignal](http://149.104.12.203:8080) | AI-powered crypto trading signals with multi-model ensemble (DeepSeek, Qwen, Kimi). Real-time market analysis, momentum detection & trade recommendations | `apiKey` | No | Yes |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds [CryptoSignal API](http://149.104.12.203:8080) to the Cryptocurrency section.

CryptoSignal is an AI-powered crypto trading signal API that uses a multi-model ensemble (DeepSeek-V4, Qwen, Kimi) with a validation layer to reduce hallucination. Features:

- Real-time market analysis & trade recommendations
- Multi-timeframe momentum detection
- Volume alerts
- 7-day free trial included
- 30% referral commission program