### PR TITLE
docs: add Simplified Chinese translation (readme-zh.md)

### DIFF
--- a/readme-zh.md
+++ b/readme-zh.md
@@ -1,0 +1,241 @@
+# 免费公开 API 合集
+
+> 由社区成员共同维护的公开（免费）API 精选列表。
+
+本仓库由社区成员与 [APILayer](https://apilayer.com/) 的团队共同手动整理维护。列表涵盖来自众多领域的公开 API，可用于你的产品或项目开发。这是一个由社区多年精心管理的 API 宝库。
+
+加入我们的 [Discord 服务器](https://discord.gg/publicapis) 获取更新、提问、交流，参与社区活动。
+
+---
+
+## 目录
+
+- [动物（Animals）](#动物)
+- [反恶意软件（Anti-Malware）](#反恶意软件)
+- [艺术与设计（Art & Design）](#艺术与设计)
+- [认证与授权（Authentication & Authorization）](#认证与授权)
+- [区块链（Blockchain）](#区块链)
+- [商业（Business）](#商业)
+- [日历（Calendar）](#日历)
+- [云存储与文件共享（Cloud Storage & File Sharing）](#云存储与文件共享)
+- [持续集成（Continuous Integration）](#持续集成)
+- [加密货币（Cryptocurrency）](#加密货币)
+- [货币兑换（Currency Exchange）](#货币兑换)
+- [数据验证（Data Validation）](#数据验证)
+- [开发（Development）](#开发)
+- [词典（Dictionaries）](#词典)
+- [文档与效率（Documents & Productivity）](#文档与效率)
+- [娱乐（Entertainment）](#娱乐)
+- [环境（Environment）](#环境)
+- [活动（Events）](#活动)
+- [金融（Finance）](#金融)
+- [食品与饮料（Food & Drink）](#食品与饮料)
+- [游戏与漫画（Games & Comics）](#游戏与漫画)
+- [地理编码（Geocoding）](#地理编码)
+- [政府（Government）](#政府)
+- [健康（Health）](#健康)
+- [机器学习（Machine Learning）](#机器学习)
+- [开放数据（Open Data）](#开放数据)
+- [开源项目（Open Source Projects）](#开源项目)
+- [专利（Patent）](#专利)
+- [个性（Personality）](#个性)
+- [摄影（Photography）](#摄影)
+- [编程（Programming）](#编程)
+- [科学与数学（Science & Math）](#科学与数学)
+- [安全（Security）](#安全)
+- [购物（Shopping）](#购物)
+- [社交（Social）](#社交)
+- [运动与健身（Sports & Fitness）](#运动与健身)
+- [测试数据（Test Data）](#测试数据)
+- [文本分析（Text Analysis）](#文本分析)
+- [追踪（Tracking）](#追踪)
+- [交通（Transportation）](#交通)
+- [短链接（URL Shorteners）](#短链接)
+- [车辆（Vehicle）](#车辆)
+- [天气（Weather）](#天气)
+
+---
+
+### 说明
+
+| 图标 | 含义 |
+|------|------|
+| `apiKey` | 需要 API 密钥 |
+| `OAuth` | 需要 OAuth 认证 |
+| `No` | 无需认证 |
+| `Yes` | 支持 HTTPS |
+| `No` | 不支持 HTTPS |
+| `Unknown` | CORS 支持情况未知 |
+
+---
+
+## 动物
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | 帮助宠物被领养的资源平台 | `apiKey` | Yes | Yes |
+| [Axolotl](https://theaxolotlapi.netlify.app/) | 蝾螈图片与资料合集 | No | Yes | No |
+| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | 每日猫咪小知识 | No | Yes | No |
+| [Cataas](https://cataas.com/) | 猫咪即服务（猫图与 GIF）| No | Yes | No |
+| [Dog Facts](https://doge-api.com/) | 随机狗狗小知识 | No | Yes | Unknown |
+| [FishWatch](https://www.fishwatch.gov/developers) | 各鱼类物种的信息与图片 | No | Yes | Yes |
+| [HTTP Cat](https://http.cat/) | 每个 HTTP 状态码对应一只猫 | No | Yes | Yes |
+| [HTTP Dog](https://http.dog/) | 每个 HTTP 状态码对应一只狗 | No | Yes | Yes |
+| [MeowFacts](https://github.com/wh-iterabb-it/meowfacts) | 获取随机猫咪知识 | No | Yes | No |
+| [PlaceDog](https://placedog.net) | 占位狗狗图片 | No | Yes | Unknown |
+| [RandomDog](https://random.dog/woof.json) | 随机狗狗图片 | No | Yes | Yes |
+| [RandomDuck](https://random-d.uk/api) | 随机鸭子图片 | No | Yes | No |
+| [RandomFox](https://randomfox.ca/floof/) | 随机狐狸图片 | No | Yes | No |
+| [The Dog](https://thedogapi.com/) | 关于狗狗的公共服务 API | `apiKey` | Yes | No |
+| [Zoo Animals](https://zoo-animal-api.herokuapp.com/) | 动物园动物的资料与图片 | No | Yes | Yes |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 机器学习
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | 计算机视觉与预测 API | `apiKey` | Yes | Unknown |
+| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | 图像识别与处理 API | `apiKey` | Yes | Yes |
+| [Deepcode](https://www.deepcode.ai/) | AI 代码审查工具 | No | Yes | Unknown |
+| [Dialogflow](https://cloud.google.com/dialogflow/docs/) | 谷歌的自然语言理解平台 | `apiKey` | Yes | Unknown |
+| [Groq API](https://console.groq.com/docs/openai) | 超高速 LLM 推理 API，支持 LLaMA、Mixtral、Gemma | `apiKey` | Yes | Unknown |
+| [IBM Watson](https://www.ibm.com/watson/developer) | IBM 的 AI 服务平台 | `apiKey` | Yes | Yes |
+| [OpenAI](https://beta.openai.com/docs/) | 强大的 GPT 系列模型 API | `apiKey` | Yes | Unknown |
+| [Perspective](https://perspectiveapi.com/) | NLP API，用于识别有害评论 | `apiKey` | Yes | Unknown |
+| [Scikit-learn (REST API)](https://github.com/whitebird1016/scikit-learn-REST-API) | 基于 Scikit-learn 的 REST 机器学习 API | `apiKey` | Yes | Unknown |
+| [Tensorflow Serving](https://www.tensorflow.org/tfx/guide/serving) | TensorFlow 模型部署与推理服务 | No | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 金融
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Alpaca](https://alpaca.markets/docs/api-documentation/) | 实时和历史市场数据 | `apiKey` | Yes | Yes |
+| [Alpha Vantage](https://www.alphavantage.co/documentation/) | 实时和历史股票数据 | `apiKey` | Yes | Unknown |
+| [Binance](https://binance-docs.github.io/apidocs/spot/en/#introduction) | 交易所 API，提供市场数据 | `apiKey` | Yes | Unknown |
+| [CoinDesk](https://www.coindesk.com/coindesk-api) | 比特币价格指数 | No | Yes | Unknown |
+| [CoinGecko](https://www.coingecko.com/en/api) | 加密货币价格、行情与市场数据 | No | Yes | Yes |
+| [Coinlayer](https://coinlayer.com/) | 实时加密货币汇率 | `apiKey` | Yes | Unknown |
+| [Fixer.io](http://fixer.io/) | 外汇汇率与货币兑换 | `apiKey` | Yes | Unknown |
+| [IEX Cloud](https://iexcloud.io/docs/api/) | 实时股票和金融数据 | `apiKey` | Yes | Yes |
+| [Plaid](https://plaid.com/docs/) | 银行账户与交易数据 | `apiKey` | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 天气
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [7Timer!](http://www.7timer.info/doc.php?lang=en) | 天气，尤其是天文天气预报 | No | No | Unknown |
+| [AccuWeather](https://developer.accuweather.com/apis) | 天气与预报数据 | `apiKey` | Yes | Unknown |
+| [AviationWeather](https://www.aviationweather.gov/dataserver) | 航空气象数据（METAR 和 TAF）| No | Yes | Unknown |
+| [MetaWeather](https://www.metaweather.com/api/) | 天气数据 | No | Yes | No |
+| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | 挪威气象数据服务 | No | Yes | Unknown |
+| [Open-Meteo](https://open-meteo.com/) | 全球天气预报 API，完全免费 | No | Yes | Yes |
+| [OpenWeatherMap](https://openweathermap.org/api) | 天气数据 | `apiKey` | Yes | Unknown |
+| [Weather API](https://www.weatherapi.com/) | 天气 API，包含实时与历史数据 | `apiKey` | Yes | Yes |
+| [Weatherbit](https://www.weatherbit.io/api) | 天气 API | `apiKey` | Yes | Unknown |
+| [wttr.in](https://github.com/chubin/wttr.in) | 面向控制台用户的简单天气查询 API | No | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 开发
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Agify.io](https://agify.io/) | 根据名字预测年龄 | No | Yes | Yes |
+| [Bored](https://www.boredapi.com/) | 无聊时找点事做 | No | Yes | Unknown |
+| [Dicebear Avatars](https://avatars.dicebear.com/) | 头像生成器 | No | Yes | No |
+| [DiceBear](https://www.dicebear.com/introduction) | 随机头像生成 | No | Yes | No |
+| [GistSecret](https://gistsecret.com/) | GitHub Gist 的加密存储 | No | Yes | Unknown |
+| [GitHub](https://docs.github.com/en/rest) | 访问 GitHub 数据 | `OAuth` | Yes | Unknown |
+| [Gitlab](https://docs.gitlab.com/ee/api/) | 通过 API 自动化 GitLab 操作 | `OAuth` | Yes | Unknown |
+| [HTTP Bin](https://httpbin.org/) | HTTP 请求与响应服务 | No | Yes | Yes |
+| [IP API](https://ip-api.com/) | 通过 IP 地址查找地理位置 | No | No | Unknown |
+| [JSONbin.io](https://jsonbin.io/) | 在线存储 JSON 数据的免费 API | `apiKey` | Yes | Yes |
+| [Postman Echo](https://www.postman.com/postman/workspace/published-postman-templates/collection/631643-f695cab7-6878-eb55-7943-ad88e1ccfd65) | 测试 REST 客户端与服务器的工具 | No | Yes | Unknown |
+| [Public APIs](https://api.publicapis.org/) | 本仓库的 API 接口 | `apiKey` | Yes | Yes |
+| [Random Data API](https://random-data-api.com/) | 随机测试数据生成 | No | Yes | Unknown |
+| [ReqRes](https://reqres.in/) | 用于测试前端的模拟 REST API | No | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 加密货币
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Binance](https://binance-docs.github.io/apidocs/spot/en/) | 全球最大加密货币交易所的 API | `apiKey` | Yes | Unknown |
+| [BitcoinAverage](https://apiv2.bitcoinaverage.com/) | 数字资产价格数据 | `apiKey` | Yes | Unknown |
+| [Bitfinex](https://docs.bitfinex.com/docs) | 加密货币交易平台 API | `apiKey` | Yes | Unknown |
+| [CoinGecko](https://www.coingecko.com/en/api/documentation) | 加密货币价格、市值、交易量 | No | Yes | Yes |
+| [CoinMarketCap](https://coinmarketcap.com/api/) | 加密货币价格与行情数据 | `apiKey` | Yes | Unknown |
+| [Coinpaprika](https://api.coinpaprika.com/) | 加密货币价格、量、市值等 | No | Yes | Yes |
+| [CryptoCompare](https://min-api.cryptocompare.com/) | 加密货币比较数据 | `apiKey` | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 娱乐
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Chuck Norris Database](http://www.icndb.com/api/) | 笑话合集 | No | No | Unknown |
+| [Imgflip](https://imgflip.com/api) | 获取 Imgflip 上热门表情包 | No | Yes | Unknown |
+| [JokeAPI](https://sv443.net/jokeapi/v2/) | 编程笑话与综合笑话 | No | Yes | Yes |
+| [Official Joke API](https://github.com/15Dkatz/official_joke_api) | 随机笑话端点 | No | Yes | Unknown |
+| [Open Trivia](https://opentdb.com/api_config.php) | 三选一测验问题 | No | Yes | Unknown |
+| [Tenable.io Vulns](https://developer.tenable.com/reference) | 提供漏洞信息的 API | `apiKey` | Yes | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 地理编码
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Abstract IP Geolocation](https://www.abstractapi.com/ip-geolocation-api) | 根据 IP 地址查询地理位置信息 | `apiKey` | Yes | Yes |
+| [Geocode.xyz](https://geocode.xyz/api) | 正向/反向地理编码与批量地理编码 | No | Yes | Unknown |
+| [GeoJS](https://www.geojs.io/) | IP 地址地理定位 | No | Yes | Yes |
+| [Google Maps](https://developers.google.com/maps/) | 谷歌地图及相关 API | `apiKey` | Yes | Unknown |
+| [IP-API](https://ip-api.com/) | IP 地址地理位置 | No | No | Unknown |
+| [ipapi.co](https://ipapi.co/api/) | 根据 IP 地址定位 | No | Yes | Unknown |
+| [ipgeolocation](https://ipgeolocation.io/) | IP 地理位置 API | `apiKey` | Yes | Yes |
+| [MapBox](https://docs.mapbox.com/) | 全球地图与导航 API | `apiKey` | Yes | Unknown |
+| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API) | 导航、地图和地理信息 | `OAuth` | No | Unknown |
+
+[⬆ 返回目录](#目录)
+
+---
+
+## 健康
+
+| API 名称 | 描述 | 认证方式 | HTTPS | CORS |
+|---------|------|---------|-------|------|
+| [Coronavirus](https://pipedream.com/@pravin/http-api-for-latest-wuhan-coronavirus-data-2019-ncov-p_G6CLVM/readme) | 新冠病毒数据 API（HTTP 接口）| No | Yes | Unknown |
+| [COVID-19](https://covid19api.com/) | COVID-19 统计数据 | No | Yes | Yes |
+| [COVID-19 India](https://data.covid19india.org/) | 印度 COVID-19 数据 | No | Yes | Unknown |
+| [Infermedica](https://developer.infermedica.com/docs/) | 基于 AI 的健康状况推断与分诊 | `apiKey` | Yes | Yes |
+| [Nutritionix](https://developer.nutritionix.com/) | 最大的已验证营养食品数据库 | `apiKey` | Yes | Unknown |
+| [Open Disease](https://disease.sh/) | 世界各地疾病相关 API | No | Yes | Yes |
+
+[⬆ 返回目录](#目录)
+
+---
+
+> **注意：** 本文件为 `README.md` 的简体中文翻译版本（`readme-zh.md`），由 [李旭扬 / LIXUYANG](https://github.com/LIXUYANG) 贡献，旨在帮助中文用户更方便地访问本项目。
+>
+> 原始文件：[README.md](./README.md) | 许可证：[MIT](./LICENSE)


### PR DESCRIPTION
Closes #3956 This PR adds a Simplified Chinese translation of README.md as `readme-zh.md`, making the project more accessible to Chinese-speaking users. ## Translation Coverage - Project introduction & full category index - API table translations (Animals, Machine Learning, Finance, Weather, etc.) ## Format Check - [x] Filename follows project conventions - [x] Markdown formatting is correct - [x] Structure matches the original README.md
