### PR TITLE
Add AstroWay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Advice Slip](http://api.adviceslip.com/) | Generate random advice slips | No | Yes | Unknown |
+| [AstroWay](https://api.astroway.info/docs/) | Astrology, natal charts, Human Design, Vedic and horoscopes on the Swiss Ephemeris | `apiKey` | Yes | Yes |
 | [Biriyani As A Service](https://biriyani.anoram.com/) | Biriyani images placeholder | No | Yes | No |
 | [Dev.to](https://developers.forem.com/api) | Access Forem articles, users and other resources via API | `apiKey` | Yes | Unknown |
 | [Dictum](https://github.com/fisenkodv/dictum) | API to get access to the collection of the most inspiring expressions of mankind | No | Yes | Unknown |


### PR DESCRIPTION
Adding AstroWay to the Personality category.

- **API**: AstroWay
- **Description**: Astrology, natal charts, Human Design, Vedic and horoscopes on the Swiss Ephemeris
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **URL**: https://api.astroway.info/docs/

Free tier: 10,000 credits/month, no card. Entry placed alphabetically after Advice Slip.