### PR TITLE
Add Conversor IAE CNAE API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
+| [Conversor IAE CNAE](https://www.conversoriaecnae.es/api/v1/docs) | Spanish IAE/CNAE tax activity codes, 2009→2025 crosswalk and AEAT obligations | `apiKey` | Yes | No |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
 | [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |
 | [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members) | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No | No | Unknown |


### PR DESCRIPTION
Adds Conversor IAE CNAE to the Government section: Spain's official business-activity tax codes (1,187 IAE, 1,060 CNAE 2025, 1,010 CNAE 2009→2025 correspondences) with the AEAT filing obligations each code triggers. Free tier (250 req/day, no card). OpenAPI 3.0 spec: https://www.conversoriaecnae.es/openapi.json