### PR TITLE
Add TWZRD Agent Intel to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No | Yes | Unknown |
 | [Nownodes](https://nownodes.io/) | Blockchain-as-a-service solution that provides high-quality connection via API | `apiKey` | Yes | Unknown |
 | [Steem](https://developers.steem.io/) | Blockchain-based blogging and social media website | No | No | No |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana on-chain agent trust scoring via MCP; 4 free tools to score, resolve and verify AI agent wallets | No | Yes | Yes |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What is being added?

**TWZRD Agent Intel** — Solana on-chain agent trust scoring API, accessible as a zero-install MCP server.

| Field | Value |
|-------|-------|
| API URL | `https://intel.twzrd.xyz` |
| Auth | No API key required (4 free tools) |
| HTTPS | Yes |
| CORS | Yes |

### Free Tools (no auth required)

- `resolve_agent` — Resolve a Solana wallet to agent identity metadata
- `score_agent` — Compute on-chain trust score (0–100) for any Solana wallet  
- `preflight_check` — Pre-dispatch trust gate for agent interactions
- `verify_trust_receipt` — Verify a signed V5 trust receipt against chain state

The API also has a paid tool (`get_trust_receipt`) using the x402 HTTP payment protocol, but the 4 free tools fully qualify this as a "No auth" free API.

### Why Blockchain section?

This API reads on-chain state from the Solana blockchain to compute trust scores for agent wallets. It fits the Blockchain section alongside other chain-data APIs like The Graph and Covalent.

### Entry added

```
| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana on-chain agent trust scoring via MCP; 4 free tools to score, resolve and verify AI agent wallets | No | Yes | Yes |
```

Placed alphabetically (T) between Steem and The Graph.
