### PR TITLE
Add xfetch to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -1662,6 +1662,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth` | Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
+| [xfetch](https://xfetch.io) | Read API for X/Twitter search, profiles, tweets, and social graph | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds **xfetch** ([xfetch.io](https://xfetch.io)) to the **Social** category.

- **What it is:** Developer API for X/Twitter read workflows — search, profiles, tweets, and social graph — via stable REST endpoints.
- **Auth:** `apiKey` · **HTTPS:** Yes · **CORS:** Yes
- Entry placed in alphabetical order (after `vk`) and follows the existing table format.
- Link returns HTTP 200.