### PR TITLE
feat: add Flutterwave and Paystack Nigerian fintech APIs to Finance s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
+| [Flutterwave](https://developer.flutterwave.com/docs) | African payment gateway for accepting and sending payments across Africa | `apiKey` | Yes | Unknown |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 75+ countries with 121K+ bank entries | No | Yes | Yes |
@@ -813,6 +814,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [Paystack](https://paystack.com/docs/api) | Nigerian payment gateway for accepting online payments across Africa | `apiKey` | Yes | Unknown |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
What does this PR do?
Adds two widely-used African/Nigerian fintech APIs. 
to the Finance section:

1. **Flutterwave** - African payment gateway for 
   accepting and sending payments across Africa
   URL: https://developer.flutterwave.com/docs
   Auth: apiKey
   HTTPS: Yes

2. **Paystack** - Nigerian payment gateway for 
   accepting online payments across Africa
   URL: https://paystack.com/docs/api
   Auth: apiKey
   HTTPS: Yes

Both APIs are widely used across Africa and Nigeria, yet they are missing from the current list, serving millions of users, but are underrepresented in most global API directories. This PR helps close that gap for African developers worldwide."