### PR TITLE
Add DPX Oracle & Intelligence API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,8 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
+| [DPX Intelligence API](https://intelligence.untitledfinancial.com) | 15 paid intelligence endpoints — macro stress, climate, G10/EM currency stress, supply chain, energy, ESG, sovereign debt, water risk, network topology, nature risk, financial shock cascades | `apiKey` | Yes | Yes |
+| [DPX Stability Oracle](https://stability.untitledfinancial.com) | Real-time stablecoin stability scoring across macro, climate, FX, geopolitical, on-chain, and basket signals | No | Yes | Yes |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |


### PR DESCRIPTION
## New entries: DPX Oracle & Intelligence API

**Provider:** Untitled_ LuxPerpetua Technologies, Inc. — [untitledfinancial.com](https://untitledfinancial.com)

### DPX Intelligence API
- **URL:** https://intelligence.untitledfinancial.com
- **Auth:** API key (`X-API-Key`) or x402 micropayments (USDC on Base)
- **HTTPS:** Yes (Cloudflare edge)
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **Description:** 15 paid endpoints covering macro stress, climate, G10/EM currency stress, supply chain, energy transition, entity ESG, sovereign debt, water risk, financial network topology, nature risk (TNFD-aligned), and financial shock cascade propagation. Per-call pricing via x402 or API key. OpenAPI spec at https://intelligence.untitledfinancial.com/openapi.yaml

### DPX Stability Oracle
- **URL:** https://stability.untitledfinancial.com
- **Auth:** None (public endpoints)
- **HTTPS:** Yes
- **CORS:** Yes
- **Description:** Real-time stablecoin stability scoring across macro, climate, FX, geopolitical, on-chain, and basket signals. Free public endpoints for score, quote, and reliability.

Both APIs are live in production on Cloudflare Workers. No mocks.