### PR TITLE
Add rftools.io to Science & Math

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,6 +1539,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
+| [rftools.io](https://rftools.io/docs/api/) | REST API for 200+ RF, antenna and electronics engineering calculations; OpenAPI docs and free tier | `apiKey` | Yes | No |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
 | [SpaceX](https://api.spacex.land/graphql/) | GraphQL, Company, Ships, launchpad and launch data | No | Yes | Unknown |


### PR DESCRIPTION
Adds **rftools.io** to the **Science & Math** category.

rftools.io is a REST API for RF, antenna, and electronics engineering calculations (free-space path loss, link budget, impedance matching, filter design, etc.) with interactive OpenAPI/Swagger docs and a free tier (free API key, 5 calculations/month).

- API docs: https://rftools.io/docs/api/
- Swagger playground: https://rftools.io/api/py/docs

### Checklist
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically (between Remote Calc and SHARE)
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (98)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (adding to an existing category)
- [x] All changes have been squashed into a single commit
