### PR TITLE
Add Starveri API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
+| [Starveri](https://api.starveri.net/docs) | OpenAI-compatible chat completions with free demo credits | `apiKey` | Yes | Yes |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Starveri to the Machine Learning section. Starveri provides OpenAI-compatible chat completions with API-key auth, HTTPS, CORS support, public documentation, and free demo credits.\n\nLocal checks attempted:\n- git diff --check passed\n- py -3 scripts/validate/format.py README.md hit a local validator/runtime crash before checking this row\n- py -3 scripts/validate/links.py README.md --only_duplicate_links_checker reported pre-existing duplicate links