### PR TITLE
Add TimeZoneMeet to Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Public Holidays](https://www.abstractapi.com/holidays-api) | Data on national, regional, and religious holidays via API | `apiKey` | Yes | Yes |
 | [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | Yes | No |
 | [The Calendar](https://the-calendar.net/api/) | Public holidays for US states and 30 countries plus sports and finance calendars as static JSON | No | Yes | Yes |
+| [TimeZoneMeet](https://timezonemeet.app/api.html) | Convert a UTC instant to any IANA time zone (DST-aware); free key, embed widget | `apiKey` | Yes | Yes |
 | [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | Bank holidays in England and Wales, Scotland and Northern Ireland | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds the TimeZoneMeet API to the **Calendar** section (where time-related entries live).

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [TimeZoneMeet](https://timezonemeet.app/api.html) | Convert a UTC instant to any IANA time zone (DST-aware); free key, embed widget | `apiKey` | Yes | Yes |

- Docs: https://timezonemeet.app/api.html
- Free key (1,000 req/day): https://timezonemeet.app/developers.html
- OpenAPI 3.1 spec: https://timezonemeet.app/openapi.json

Checklist:
- [x] My addition is on **one** line in the correct alphabetical position (after "The Calendar", before "UK Bank Holidays").
- [x] Entry format `| [Name](link) | Description | Auth | HTTPS | CORS |` followed; description has no trailing period.
- [x] Link is HTTPS and returns 200.
- [x] Auth is `apiKey`; CORS is supported (Yes).