### PR TITLE
Add cv.cm API

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
+| [cv.cm](https://cv.cm/api) | AI video and image generation (Seedance, gpt-image-2, Seedream) with a free credit tier | `apiKey` | Yes | Unknown |
 | [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth` | Yes | Unknown |
 | [DummyImage](https://dummyimage.com/) | Generate placeholder images with custom size, colors and text | No | Yes | Unknown |
 | [EmojiHub](https://github.com/cheatsnake/emojihub) | Get emojis by categories and groups | No | Yes | Yes |


### PR DESCRIPTION
Adds the **cv.cm** API to Art & Design (alphabetical placement).

cv.cm is an HTTP API for AI video and image generation (Seedance, gpt-image-2, Seedream). It has a free tier — new accounts receive free credits — and uses API-key auth, so it meets the "free, public access or at least a free tier" requirement and does not depend on buying any device or service.

- One link, placed alphabetically in Art & Design.
- Auth: `apiKey`; HTTPS: Yes; CORS: Unknown.