### PR TITLE
Add World Cup 2026 Tour API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1719,6 +1719,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |
+| [World Cup 2026 Tour](https://ay-worldcup2026.zeabur.app/developers) | World Cup 2026 fixtures with optional local-time conversion | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary

Adds World Cup 2026 Tour to the Sports & Fitness category.

## API details

- Free public API for World Cup 2026 fixtures
- No authentication required
- HTTPS supported
- CORS supported (`Access-Control-Allow-Origin: *`)
- Documentation: https://ay-worldcup2026.zeabur.app/developers
- Metadata endpoint: https://ay-worldcup2026.zeabur.app/api/public/v1/metadata

## Local validation

- Verified documentation URL returns HTTP 200
- Verified metadata endpoint returns HTTP 200
- Verified CORS response header on metadata endpoint
- Attempted `python3 scripts/validate/format.py README.md`; it failed before validating entries due to an upstream script error: `UnboundLocalError: cannot access local variable category where it is not associated with a value`