### PR TITLE
Add Prismix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [Prismix](https://prismix.dev/api-docs) | Live status of 75+ AI services (OpenAI, Anthropic, etc.) with uptime and incidents | No | Yes | No |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |
 | [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Prismix API to the Development section.

- **API**: https://prismix.dev/api-docs
- Returns the live operational status (indicator, uptime, incidents) of 75+ AI services (OpenAI, Anthropic, Cursor, Mistral, etc.) as JSON
- Auth: No · HTTPS: Yes · CORS: No
- Inserted alphabetically between Postman and ProxyCrawl

<!-- Checklist -->
- [x] My submission follows the entry format
- [x] My addition is in alphabetical order within its category
- [x] The API is publicly accessible and returns 200 without auth