### PR TITLE
Add Extracto API

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
+| [Extracto](https://getextracto.dev) | Extract typed, schema-validated JSON from any URL with a headless browser, no CSS selectors | `apiKey` | Yes | Unknown |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |
 | [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |
 | [GETPing](https://www.getping.info) | Trigger an email notification with a simple GET request | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Extracto** to the **Development** section.

- Web data extraction API: send a URL plus a JSON schema, get typed, schema-validated JSON back.
- Free tier: 100 pages, no credit card required.
- Auth: `apiKey` · HTTPS: Yes · CORS: Unknown

Checklist per CONTRIBUTING:
- [x] Inserted alphabetically in Development
- [x] One link in this PR
- [x] Description under 100 characters
- [x] Name has no "API" suffix and no TLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)