### PR TITLE
Add Exchange-Rate currency exchange API

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CurrencyScoop](https://currencyscoop.com/api-documentation) | Real-time and historical currency rates JSON API | `apiKey` | Yes | Yes |
 | [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates | No | Yes | Unknown |
 | [Economia.Awesome](https://docs.awesomeapi.com.br/api-de-moedas) | Portuguese free currency prices and conversion with no rate limits | No | Yes | Unknown |
+| [Exchange-Rate](https://exchange-rateapi.com) | Live currency exchange rates and conversion for 160+ currencies | `apiKey` | Yes | Yes |
 | [ExchangeRate-API](https://www.exchangerate-api.com) | Free currency conversion | `apiKey` | Yes | Yes |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |


### PR DESCRIPTION
Adds **Exchange-Rate** to the Currency Exchange section.

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| [Exchange-Rate](https://exchange-rateapi.com) | Live currency exchange rates and conversion for 160+ currencies | `apiKey` | Yes | Yes |

- Live + historical exchange rates and conversion for 160+ currencies
- HTTPS only, CORS enabled, bearer-token (`apiKey`) auth
- Free tier available

Checklist:
- [x] Alphabetical order within Currency Exchange
- [x] Description under 100 characters
- [x] Only README.md changed
- [x] HTTPS link that resolves