### PR TITLE
Add RealMarketAPI to Currency Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ API | Description | Auth | HTTPS | CORS |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
+| [RealMarketAPI](https://realmarketapi.com/docs) | Real-time and historical of gold, forex, crypto, and stock prices with free plan 5K requests/month | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ API | Description | Auth | HTTPS | CORS |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
-| [RealMarketAPI](https://realmarketapi.com/docs) | Real-time and historical of gold, forex, crypto, and stock prices with free plan 5K requests/month | `apiKey` | Yes | Unknown |
+| [RealMarketAPI](https://realmarketapi.com/docs) | Real-time and historical prices for gold, forex, crypto, and stocks. Free plan includes 5K requests/month | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adding RealMarketAPI to Currency Exchange

- **API**: RealMarketAPI 
- **Description**: Real-time and historical of gold, forex, crypto, and stock prices with free plan 5K requests/month
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Unknown
- **URL**: https://realmarketapi.com/docs

Free tier: 5,000 requests/month, no card.