### PR TITLE
Add Superhighway to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
 | [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
+| [Superhighway](https://superhighway.walls.sh) | Web search for AI agents: live web search, news and read-any-page-as-markdown — free tier, or USDC pay-per-call via x402 | `apiKey` | Yes | No |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |
 | [Suprsonic](https://suprsonic.ai) | Unified agent API: search, scrape, enrich, image gen, TTS, STT, messaging. One key, 20+ capabilities | `apiKey` | Yes | Yes |
 | [Talordata](https://docs.talordata.com/) | SERP data from major search engines with a free trial | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**What does this PR do?**
Adds Superhighway under **Development**, alphabetically (between Statically and Supportivekoala).

| Field | Value |
| --- | --- |
| API | [Superhighway](https://superhighway.walls.sh) |
| Description | Web search for AI agents: live web search, news and read-any-page-as-markdown — free tier, or USDC pay-per-call via x402 |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No |

**Free access:** genuinely free tier — email signup issues an API key instantly (1,000 calls/month, no card), plus a no-signup trial endpoint (`/try?q=`). Agents can alternatively pay per call in USDC over the open [x402](https://x402.org) protocol with no account at all. OpenAPI spec: https://superhighway.walls.sh/openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)