### PR TITLE
Add OpenChainBench API

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
+| [OpenChainBench](https://openchainbench.com/api/openapi.json) | Live crypto infrastructure benchmarks (L1 finality, RPC latency, bridge fees) as JSON | No | Yes | Yes |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [PumpFunData](https://pumpfundata.com/docs) | Historical Pump.fun and PumpSwap AMM swap data as hourly Parquet files | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |


### PR DESCRIPTION
Adds OpenChainBench to the Cryptocurrency section.

- Live, reproducible benchmarks for crypto infrastructure: L1 finality times, free public RPC latency (10 EVM chains), bridge fees and latency, gas estimation accuracy, stablecoin pegs, oracle deviation.
- OpenAPI spec: https://openchainbench.com/api/openapi.json
- Example endpoint: https://openchainbench.com/api/stat/l1-finality
- Auth: none. HTTPS: yes. CORS: `access-control-allow-origin: *`
- Data CC-BY 4.0, methodology + harnesses open source.

Checklist:
- [x] Alphabetical order maintained (after OKEx, before Poloniex)
- [x] Entry format respected
- [x] API is free, stable and documented