### PR TITLE
Add Pulse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1656,6 +1656,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
 | [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth` | Yes | Unknown |
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Yes | Unknown |
+| [Pulse](https://pulse.walls.sh/docs) | Social post metrics (views, likes, comments) for YouTube, X, TikTok, Bluesky, Mastodon, Instagram | No | Yes | Yes |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds **Pulse** to the Social section.

Pulse is a free, no-auth social post metrics API: give it any public post URL and get normalized views, likes, and comments back as JSON — no signup, no API key required.

- **URL:** https://pulse.walls.sh/docs
- **Platforms:** YouTube, X/Twitter, TikTok, Bluesky, Mastodon, Instagram
- **Auth:** None required for free tier (optional API key for higher rate limits)
- **HTTPS:** Yes
- **CORS:** Yes (explicitly configured)
- **Free access:** Fully free at 120 calls/min with no account; a free API key is available at /account

Entry placed alphabetically after "Product Hunt" in the Social section.