### PR TITLE
Add Hlido API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [Groq](https://console.groq.com/docs/quickstart) | Fast AI inference API with free tier, supports Llama, Mixtral, Gemma models | `apiKey` | Yes | Yes |
 | [Hirak FaceAPI](https://faceapi.hirak.site/) | Face detection, face recognition with age estimation/gender estimation, accurate, no quota limits | `apiKey` | Yes | Unknown |    
+| [Hlido](https://hlido.eu/api/) | Independent AI agent reviews: ranked recommendations, scores and evidence as JSON | No | Yes | Yes |
 | [Hugging Face](https://huggingface.co) | AI model hub with inference API for NLP, computer vision, and audio | `apiKey` | Yes | Yes |
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Hlido API to the Machine Learning section. The free tier requires no auth: `POST /v1/recommend` takes a free-text need and returns a ranked shortlist of independently reviewed AI agents with scores and evidence URLs. Docs: https://hlido.eu/api/ — OpenAPI 3.1 spec: https://hlido.eu/openapi.json. HTTPS-only, CORS enabled (`Access-Control-Allow-Origin: *`), all verified today.

Disclosure: submitted by Hlido's founder.
