### PR TITLE
Add PDFPipe to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [OCR.Space](https://ocr.space/ocrapi) | OCR text extraction from images and PDFs with a free tier | `apiKey` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PDFPipe](https://pdfpipe.xyz/docs) | HTML/URL to PDF with a free tier of 500 documents/month | `apiKey` | Yes | No |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PDFPipe, an HTML/URL to PDF API with a free tier of 500 documents per month.

Checklist per CONTRIBUTING:
- Alphabetical order within the section (between PandaDoc and Pocket)
- Auth: apiKey (Bearer). HTTPS: yes. CORS: no on the render endpoint.
- Docs: https://pdfpipe.xyz/docs, OpenAPI: https://pdfpipe.xyz/openapi.yaml