### PR TITLE
Add slot.report — free slot machine data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ API | Description | Auth | HTTPS | CORS |
 | [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
 | [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
 | [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
+| [slot.report](https://slot.report/api/) | Online slot game data with RTP, volatility, max win for 2600+ slots | No | Yes | Yes |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey` | Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |

--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ API | Description | Auth | HTTPS | CORS |
 | [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
 | [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
 | [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
-| [slot.report](https://slot.report/api/) | Online slot game data with RTP, volatility, max win for 2600+ slots | No | Yes | Yes |
+| [slot.report](https://slot.report/api/) | Online slot machine data: RTP, volatility, max win and features for 6,000+ games | No | Yes | Yes |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey` | Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |


### PR DESCRIPTION
## What does this PR do?

Adds **slot.report** to the *Games & Comics* category.

- **API:** https://slot.report/api/ (docs) — endpoints under https://slot.report/api/v1/
- **What it provides:** Structured data for 6,000+ online slot machine games from 80+ providers: RTP, volatility, max win, grid layout, features, mechanics, themes, release dates. Updated daily.
- **Auth:** No (no key, no signup)
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **OpenAPI 3.1 spec:** https://slot.report/api/openapi.json
- Free forever, no paid tier, no device/service purchase required. Static JSON, no rate limits for reasonable use.

Checked the entry is alphabetically ordered and follows the table format.