### PR TITLE
Add pinnapi to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
+| [pinnapi](https://pinnapi.com/docs) | Real-time Pinnacle sports odds with dropping-odds alerts over REST and SSE | `apiKey` | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |


### PR DESCRIPTION
**What does this PR do?**

Adds **[pinnapi](https://pinnapi.com/docs)** to **Sports & Fitness** — a real-time Pinnacle sports odds API with dropping-odds alerts over REST and Server-Sent Events (live + prematch, 10+ sports).

**Entry:**

`| [pinnapi](https://pinnapi.com/docs) | Real-time Pinnacle sports odds with dropping-odds alerts over REST and SSE | apiKey | Yes | Yes |`

**Checklist**
- [x] One API addition, one commit
- [x] Alphabetical order within the section (between Padel Snipe and Premier League Standings)
- [x] Description is < 100 characters, starts with a capital letter, no trailing punctuation
- [x] Link points at the API documentation
- [x] HTTPS: Yes · CORS: Yes (Access-Control-Allow-Origin: *) · Auth: apiKey
- [x] Free tier available: trial key without a card (100 requests/day); official clients on PyPI and npm (`pip install pinnapi` / `npm install pinnapi`)