### PR TITLE
Add Kiprio MCP Registry to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
 | [Keyvalue](https://keyvalue.immanuel.co/) | Simple key-value storage REST API for quick prototyping | No | Yes | Unknown |
+| [Kiprio MCP Registry](https://kiprio.com/v1/mcp-registry/) | Searchable index of 700+ Model Context Protocol servers from GitHub | No | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds [Kiprio MCP Registry](https://kiprio.com/v1/mcp-registry/) to the **Development** category.

## Verification

- API is publicly accessible: `curl https://kiprio.com/v1/mcp-registry/` returns JSON with 700+ MCP servers
- HTTPS: ✅
- CORS: ✅ (`access-control-allow-origin: *`)
- Free tier: 50 results/call, no API key required
- Documentation/endpoint: https://kiprio.com/v1/mcp-registry/

## Checklist

- [x] Entry added in alphabetical order (between Keyvalue and Kroki)
- [x] API name has no 'API' suffix
- [x] Description is under 100 characters
- [x] All columns have proper spacing
- [x] HTTPS Yes, CORS Yes, Auth No (free tier requires no key)