### PR TITLE
Add x402 Crypto Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+| [x402 Crypto API](http://43.157.206.248:4020) | AI agent crypto data API — pay per request in USDC on Base. 30+ endpoints. No API keys needed. | No | Yes | Yes |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Description
Add x402 Crypto Intelligence API to the Cryptocurrency section.

## API Details
- **URL:** http://43.157.206.248:4020
- **Description:** AI agent crypto data API — pay per request in USDC on Base via x402 protocol
- **Auth:** No (x402 protocol handles payment)
- **HTTPS:** Yes (via proxy)
- **CORS:** Yes

## What it does
30+ endpoints covering crypto market data, DEX pairs, DeFi analytics, wallet tracking, and whale alerts. Built specifically for AI agents that need crypto data — pays per request in USDC micropayments instead of using API keys.

Free tier available with 3 endpoints (health, Fear & Greed Index, gas prices).

## Source
- GitHub: https://github.com/faisalnugroho/x402-crypto-api
- Docs: http://43.157.206.248:4020/docs