### PR TITLE
Add Daanyam Vedic Astrology API to Personality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,6 +1424,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Advice Slip](http://api.adviceslip.com/) | Generate random advice slips | No | Yes | Unknown |
 | [AstroWay](https://api.astroway.info/docs/) | Astrology, natal charts, Human Design, Vedic and horoscopes on the Swiss Ephemeris | `apiKey` | Yes | Yes |
 | [Biriyani As A Service](https://biriyani.anoram.com/) | Biriyani images placeholder | No | Yes | No |
+| [Daanyam Vedic Astrology](https://rapidapi.com/sanjeet-ZpaYHNfRD/api/daanyam-vedic-astrology-api) | Vedic astrology calculations - kundli, Vimshottari dasha and panchang | `apiKey` | Yes | Unknown |
 | [Dev.to](https://developers.forem.com/api) | Access Forem articles, users and other resources via API | `apiKey` | Yes | Unknown |
 | [Dictum](https://github.com/fisenkodv/dictum) | API to get access to the collection of the most inspiring expressions of mankind | No | Yes | Unknown |
 | [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] - [x] My addition is ordered alphabetically
- [ ] - [x] My submission has a useful description
- [ ] - [x] The description does not have more than 100 characters
- [ ] - [x] The description does not end with punctuation
- [ ] - [x] Each table column is padded with one space on either side
- [ ] - [x] I have searched the repository for any relevant issues or pull requests
- [ ] - [x] Any category I am creating has the minimum requirement of 3 items
- [ ] - [x] All changes have been squashed into a single commit
Adds the Daanyam Vedic Astrology API under Personality (alongside AstroWay): kundli (birth chart), Vimshottari dasha and panchang calculations.