### PR TITLE
Add btcnode.uk - Bitcoin blockchain data, fees, mempool, SEC trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blockchain](https://www.blockchain.com/api) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Yes | Unknown |
 | [blockfrost Cardano](https://blockfrost.io/) | Interaction with the Cardano mainnet and several testnets | `apiKey` | Yes | Unknown |
 | [Brave NewCoin](https://bravenewcoin.com/developers) | Real-time and historic crypto data from more than 200+ exchanges | `apiKey` | Yes | Unknown |
+| [btcnode.uk](https://btcnode.uk) | Bitcoin blockchain data, fees, mempool, SEC insider trades, Reddit sentiment. x402 micropayments for paid endpoints. | No | Yes | Unknown |
 | [BtcTurk](https://docs.btcturk.com/) | Real-time cryptocurrency data, graphs and API that allows buy&sell | `apiKey` | Yes | Yes |
 | [Bybit](https://bybit-exchange.github.io/docs/linear/#t-introduction) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |
 | [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds [btcnode.uk](https://btcnode.uk) to the Cryptocurrency section - a real Bitcoin full node API with free endpoints for fees, mempool, and blockchain info. No API key required.

- Free: fees, mempool, blockchain info
- Paid: SEC insider trades, transaction forensics, wallet data, Reddit sentiment (via x402)