### PR TITLE
Add Noozra News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,6 +1332,7 @@ API | Description | Auth | HTTPS | CORS |
 | [News](https://newsapi.org/) | Headlines currently published on a range of news sources and blogs | `apiKey` | Yes | Unknown |
 | [NewsData](https://newsdata.io/docs) | News data API for live-breaking news and headlines from reputed  news sources | `apiKey` | Yes | Unknown |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖 | `apiKey` | Yes | Unknown |
+| [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |
 | [NPR One](http://dev.npr.org/api/) | Personalized news listening experience from NPR | `OAuth` | Yes | Unknown |
 | [Spaceflight News](https://spaceflightnewsapi.net) | Spaceflight related news 🚀 | No | Yes | Yes |
 | [The Guardian](http://open-platform.theguardian.com/) | Access all the content the Guardian creates, categorised by tags and section | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What does this PR do?

Adds [Noozra](https://noozra.com/api) to the News category.

**Entry:**
`| [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |`

## Verification

- Endpoint: `GET https://noozra.com/api/articles?limit=2` returns HTTP 200 with JSON news headlines
- Auth: No API key required (100 requests/day free, per IP, no signup)
- HTTPS: Yes
- CORS: Yes — response includes `Access-Control-Allow-Origin: *`
- Documentation: https://noozra.com/api

## Checklist

- [x] API is publicly accessible
- [x] API has free access (no key required for the free tier)
- [x] HTTPS is supported
- [x] Entry follows the correct format
- [x] Entry is placed alphabetically in the News section
- [x] Description is under 100 characters
- [x] PR title follows the required format `Add Api-name API`
- [x] One link per PR