### PR TITLE
Add K-Data Gate API to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,6 +1358,7 @@ API | Description | Auth | HTTPS | CORS |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
+| [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |
 | [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
 | [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |


### PR DESCRIPTION
Adds K-Data Gate under Open Data.

- API: https://kdata-gate.vercel.app/docs (OpenAPI: /openapi.json, llms.txt available)
- Korean market data normalized to English JSON: K-beauty/K-food product search, Naver search trends, Korean stocks with English DART summaries, apartment transactions, tourism, weather
- Auth: apiKey (free self-serve key, 100 calls/month; preview mode works without key)
- HTTPS: Yes / CORS: Unknown