### PR TITLE
Add VeriRoute Intel to Phone section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,6 +1465,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |
+| [VeriRoute Intel](https://verirouteintel.com) | CNAM caller ID, carrier/LRN lookup and spam scoring for North American phone numbers | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds [VeriRoute Intel](https://verirouteintel.com) — CNAM caller ID, carrier/LRN lookup, and spam/trust scoring API for North American (NANP) phone numbers.

- Auth: `apiKey` (Bearer)
- HTTPS: yes
- Free tier: yes (LRN lookups free for unfunded accounts)
- Docs: https://verirouteintel.com/api-docs
- OpenAPI spec available; official Python and Node SDKs

Disclosure: I operate this API.

Thank you for maintaining this list!