### PR TITLE
Add Pick an Agency API

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ API | Description | Auth | HTTPS | CORS |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
+| [Pick an Agency](https://www.pickanagency.com/developers) | Search 47,000+ marketing agencies by service, location and rating | No | Yes | Yes |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Signaliz](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction) | GTM enrichment, lead generation, email verification, and company signals | `apiKey` | Yes | Unknown |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |


### PR DESCRIPTION
Adds the Pick an Agency API to the **Business** category (alphabetical order kept, one link, description under 100 characters).

- **What it is:** free, read-only REST API over a directory of 47,000+ verified marketing agencies (129,000+ indexed) — search by service, location, industry and rating, fetch single profiles with reviews, or get a ranked shortlist from a brief.
- **Auth:** none (no key, no signup)
- **HTTPS:** yes
- **CORS:** yes (`Access-Control-Allow-Origin: *`)
- **Docs:** https://www.pickanagency.com/developers · OpenAPI 3.1: https://www.pickanagency.com/api/v1/openapi.json
- **Try it:** `curl "https://www.pickanagency.com/api/v1/search?service=SEO&city=Berlin&limit=3"`

Disclosure: I'm the founder of Pick an Agency.