### PR TITLE
Add World Cup 2026 Tour API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1725,6 +1725,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |
+| [World Cup 2026 Tour](https://ay-worldcup2026.zeabur.app/developers) | World Cup 2026 fixtures with local kickoff times and share links | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the contributing guide\n- [x] My addition is ordered alphabetically\n- [x] My submission has a useful description\n- [x] The description does not have more than 100 characters\n- [x] The description does not end with punctuation\n- [x] Each table column is padded with one space on either side\n- [x] I have searched the repository for any relevant issues or pull requests\n- [x] Any category I am creating has the minimum requirement of 3 items\n- [x] All changes have been squashed into a single commit\n\nAdds the free World Cup 2026 Tour fixtures API under Sports & Fitness.