### PR TITLE
Add Rotate Pilot API to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1845,6 +1845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | Yes |
+| [Rotate Pilot](https://rotatepilot.com/developers) | Free aviation data: airport info by ICAO, live METAR weather, and aircraft specs | No | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |


### PR DESCRIPTION
**Adding:** Rotate Pilot — a free aviation data API.

| Field | Value |
|---|---|
| Endpoint docs | https://rotatepilot.com/developers |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes (`Access-Control-Allow-Origin: *`) |

It exposes free, no-key JSON endpoints for aviation data: airport info by ICAO (`/api/v1/airport/KJFK`), live METAR weather (`/api/v1/metar?icao=KJFK`), aircraft specs (`/api/v1/aircraft/{slug}`), glossary terms, a daily quiz, and platform stats. All return JSON over HTTPS with open CORS.

Checklist:
- [x] Added in the **Transportation** section in alphabetical order (after Road511, before Sabre for Developers)
- [x] Entry format: `| [Title](link) | Description | Auth | HTTPS | CORS |`
- [x] Description is concise, capitalized, and has no trailing period
- [x] Link uses HTTPS and resolves
- [x] One addition in this PR