### PR TITLE
Add ProteinBenchmark API to Food & Drink

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
+| [ProteinBenchmark](https://proteinbenchmark.com/api) | Protein density, tiers, DIAAS and cost-efficiency for 190+ foods and supplements | No | Yes | Yes |
 | [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
 | [RecipeAPI](https://recipeapi.io) | Recipes, ingredients, nutrition data and cooking instructions | `apiKey` | Yes | Yes |
 | [Rustybeer](https://rustybeer.herokuapp.com/) | Beer brewing tools | No | Yes | No |


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not start with `The` or `A` (unless it is the name of the API)
- [x] My addition has a relevant `Auth`, `HTTPS`, and `CORS` value
- [x] The README is automatically validated when I open a Pull Request — i.e. the `Validate` action passes

## What

Adds **ProteinBenchmark** to the **Food & Drink** category.

```
| [ProteinBenchmark](https://proteinbenchmark.com/api) | Protein density, tiers, DIAAS and cost-efficiency for 190+ foods and supplements | No | Yes | Yes |
```

## Why it qualifies

- **Free & no auth** — fully open, no API key or account required.
- **HTTPS: Yes**, **CORS: Yes** — responds with `Access-Control-Allow-Origin: *`.
- **OpenAPI 3.1 description**: https://proteinbenchmark.com/openapi.yaml
- Read-only JSON over 190+ foods, snacks, restaurant items and protein supplements, with computed metrics (Protein Density, tier, DIAAS-adjusted yield, protein cost-efficiency) embedded in each record.

Endpoints: `/api/v1/products`, `/api/v1/products/{id}`, `/api/v1/coefficients`, `/api/v1/methodology`. Docs: https://proteinbenchmark.com/api