### PR TITLE
Add defend.network API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,6 +1577,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
+| [defend.network](https://defend.network/api/) | Daily CVE feed with CVSS, EPSS, CISA KEV status and exploitation state | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |


### PR DESCRIPTION
Adds defend.network to the Security category. It is a free, no-auth JSON API of CVEs with CVSS, EPSS, CISA KEV status and exploitation state, regenerated daily and licensed CC BY 4.0. Documentation: https://defend.network/api/

Follows the contributing rules: one link, placed alphabetically in Security (between dead-drop and Dehash.lt), description under 100 chars with no trailing period, Auth No, HTTPS Yes, CORS Yes (verified: Access-Control-Allow-Origin: *).