### PR TITLE
Add TaxVett API

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |
 | [Sugra](https://sugra.ai) | One API for market data, economics, commodities, climate, and global news. LLM-ready JSON | `apiKey` | Yes | Yes | |
 | [Tax Data](https://apilayer.com/marketplace/tax_data-api) | Instant VAT number and tax validation across the globe | `apiKey` | Yes | Unknown | |
+| [TaxVett](https://api.taxvett.com/docs) | Validate VAT, ABN and GST tax numbers against live government registries in 30+ countries | `apiKey` | Yes | Yes | |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes | |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adds TaxVett to the Finance section.

- **API:** [TaxVett](https://api.taxvett.com/docs)
- **Description:** Validate VAT, ABN and GST tax numbers against live government registries in 30+ countries
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** Yes (500 req/month, no credit card required)