### PR TITLE
Add ComplianceWatch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
+| [ComplianceWatch](https://compliancewatch.stackmint.cloud/) | AML/KYC sanctions screening against OFAC, EU, UN, UK, INTERPOL and FBI watchlists | `apiKey` | Yes | Unknown | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |


### PR DESCRIPTION
## Summary

Adds [ComplianceWatch](https://compliancewatch.stackmint.cloud/) to the Finance section.

- **Free tier**: 100 sanctions screenings/month via RapidAPI
- **Auth**: API key (`X-RapidAPI-Key`)
- **HTTPS**: Yes
- **Docs**: https://compliancewatch.stackmint.cloud/
- **OpenAPI spec**: https://compliancewatch.stackmint.cloud/openapi.yaml

ComplianceWatch screens names against OFAC, EU, UN, UK, INTERPOL and FBI sanctions lists with fuzzy matching and confidence scores. Suitable for KYC/AML compliance workflows in fintech applications.
