### PR TITLE
Add Lineage2 API to Games & Comics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes | Yes |
 | [Jservice](http://jservice.io) | Jeopardy Question Database | No | No | Unknown |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
+| [Lineage2](https://l2api.dev) | Access to game data, npc's, items, drops, etc | No | Yes | Yes |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |
 | [Marvel](https://developer.marvel.com) | Marvel Comics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Ads Lineage2 API

1. Interlude chronicle only (npc, items, sets, drop, spoil, classes, hennas, locations, spawns).
2. No auth, https, CORS.
3. Rate limit, 60 requests 1 min.
4. Available OpenAPI
5. Docs: [docs link](https://docs.l2api.dev/)
6. API fully free.

