### PR TITLE
Add Eulerpool to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
+| [Eulerpool](https://eulerpool.com/financial-data-api) | Stocks, ETFs, funds, crypto, forex, bonds & macro with fundamentals, estimates & screeners | `apiKey` | Yes | Unknown |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds **Eulerpool** to the Finance section (alphabetical, after EconPulse). A financial-data API covering equities, ETFs, funds, crypto, forex, bonds and macro with fundamentals, analyst estimates and screeners. Free tier, HTTPS, apiKey auth. Docs: https://eulerpool.com/financial-data-api