### PR TITLE
Add Atheris IP to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ API | Description | Auth | HTTPS | CORS |
 | [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | Address database of France, geocoding and reverse | No | Yes | Unknown |
 | [Airtel IP](https://sys.airtel.lv/ip2country/1.1.1.1/?full=true) | IP Geolocation API. Collecting data from multiple sources | No | Yes | Unknown |
 | [Apiip](https://apiip.net/) | Get location information by IP address | `apiKey` | Yes | Yes |
+| [Atheris IP](https://atheris.ee/tools/ip) | Returns the caller's public IP and country code as plain text or JSON, CORS-open and key-free | No | Yes | Yes |
 | [Battuta](http://battuta.medunes.net) | A (country/region/city) in-cascade location API | `apiKey` | No | Unknown |
 | [BdAPIs](https://bdapis.com/) | Get divisions, districts, and upazzilas of Bangladesh | No | Yes | Unknown |
 | [BigDataCloud](https://www.bigdatacloud.com/ip-geolocation-apis) | Provides fast and accurate IP geolocation APIs along with security checks and confidence area | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Atheris IP** to the Geocoding section.

- **Endpoint:** https://atheris.ee/tools/ip (docs) — `https://atheris.ee/ip` (plain text) and `https://atheris.ee/ip.json` (JSON `{ip, country}`)
- **What it does:** returns the caller's public IP and ISO country code, as plain text or JSON. The ipify/icanhazip pattern, with the country code added.
- **Auth:** No — fully open, no key, no sign-up.
- **HTTPS:** Yes.
- **CORS:** Yes — both endpoints send `Access-Control-Allow-Origin: *`.

Not a paid product or trial; the endpoint is free and unmetered. Documentation page lists usage and a stability commitment (the URL will not change or break).

My addition

- [x] Added one entry per PR.
- [x] Entry is formatted per the contributing guidelines (5 columns, link title, valid Auth/HTTPS/CORS values).
- [x] Searched for existing entries to avoid duplicates.
- [x] Added in the appropriate category (Geocoding).