### PR TITLE
Add Feedhook to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1936,6 +1936,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/) | TV programme of Czech TV | No | No | Unknown |
 | [Dailymotion](https://developer.dailymotion.com/) | Dailymotion Developer API | `OAuth` | Yes | Unknown |
 | [Dune](https://github.com/ywalia01/dune-api) | A simple API which provides you with book, character, movie and quotes JSON data | No | Yes | Yes |
+| [Feedhook](https://feedhook.walls.sh/docs) | Turn a YouTube channel into a webhook with a signed POST on every new video | `apiKey` | Yes | Unknown |
 | [Final Space](https://finalspaceapi.com/docs/) | Final Space API | No | Yes | Yes |
 | [Game of Thrones Quotes](https://gameofthronesquotes.xyz/) | Some Game of Thrones quotes | No | Yes | Unknown |
 | [Harry Potter Charactes](https://hp-api.herokuapp.com/) | Harry Potter Characters Data with with imagery | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Feedhook** to the Video section.

Feedhook turns a YouTube channel into a webhook: register a channel + a callback URL and your endpoint receives a signed HTTP POST within seconds of every new video (YouTube's WebSub/PubSubHubbub push underneath, a clean REST API on top — no polling, no Data API quota). Free for one channel.

- Added alphabetically between Dune and Final Space.
- Auth: `apiKey` · HTTPS: Yes · CORS: Unknown
- Docs: https://feedhook.walls.sh/docs · OpenAPI: https://feedhook.walls.sh/openapi.json