### PR TITLE
Add SCALA Score API

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
 | [Pick an Agency](https://www.pickanagency.com/developers) | Search 47,000+ marketing agencies by service, location and rating | No | Yes | Yes |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
+| [SCALA Score](https://score.get-scala.com/api) | Search 250M+ company records with revenue, employees, and credit scores | No | Yes | Yes |
 | [Signaliz](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction) | GTM enrichment, lead generation, email verification, and company signals | `apiKey` | Yes | Unknown |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adding [SCALA Score](https://score.get-scala.com/api) to the **Business** category.

SCALA Score provides free access to 250M+ company records across 265 countries, including revenue, employee count, and credit score data. The API works without authentication (free tier), with an optional API key available for higher rate limits.

- **Auth**: No (free tier, no sign-up required)
- **HTTPS**: Yes
- **CORS**: Yes
- **Category**: Business

The entry is placed in alphabetical order within the Business section (between Redash and Signaliz).