### PR TITLE
Add Social Fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
+| [Social Fetch](https://www.socialfetch.dev/docs) | Unified REST API for social media profiles, posts, metrics, and search | `apiKey` | Yes | No |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What does this API do?

[Social Fetch](https://www.socialfetch.dev/docs) is a REST API for normalized social media data across TikTok, Instagram, X/Twitter, YouTube, Facebook, LinkedIn, Reddit, Threads, and more — profiles, posts, comments, metrics, transcripts, and search via a unified JSON envelope.

## Checklist

- [x] API has a free tier (100 free credits on signup, no credit card required)
- [x] Auth: `apiKey` (`x-api-key` header)
- [x] HTTPS: Yes
- [x] CORS: No
- [x] Alphabetical placement in Social section (between Slack and TamTam)
- [x] Description under 100 characters (68 chars)
- [x] No TLD in name
- [x] Name does not end with 'API'
- [x] Documentation: https://www.socialfetch.dev/docs
- [x] All commits squashed
