### PR TITLE
Add Warp Freight API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tripadvisor](https://developer-tripadvisor.com/home/) | Rating content for a hotel, restaurant, attraction or destination | `apiKey` | Yes | Unknown |
 | [Uber](https://developer.uber.com/products) | Uber ride requests and price estimation | `OAuth` | Yes | Yes |
 | [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole) | Velib Open Data API | No | Yes | No |
+| [Warp Freight](https://www.wearewarp.com/freight-api) | Quote, book, and track real LTL, FTL, cargo van, and box truck freight | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds the Warp Freight API under Transportation. Quoting is keyless and free (no account required); booking uses an API key. Supports LTL, FTL, cargo van, and box truck. HTTPS and CORS both supported.