### PR TITLE
Add ReceiptEdit US Sales Tax API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,6 +1382,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
+| [ReceiptEdit US Sales Tax](https://receiptedit.com/api/sales-tax) | Free 2026 US state sales tax rates and lodging taxes for all 50 states | No | Yes | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |


### PR DESCRIPTION
Adding the ReceiptEdit US Sales Tax API to the Open Data section.

This is a free public REST API providing 2026 US state sales tax rates, lodging taxes, and grocery taxation rules for all 50 states.

- API endpoint: https://receiptedit.com/api/sales-tax
- API documentation: https://receiptedit.com/developers
- Open data repo (MIT licensed): https://github.com/receiptedit/us-sales-tax-2026

Checklist:
- [x] No authentication required
- [x] HTTPS supported
- [x] CORS enabled
- [x] Description under 100 characters
- [x] Inserted in alphabetical order (between PeakMetrics and Recreation Information Database)
- [x] Single link added per PR
- [x] PR title follows `Add Api-name API` format