### PR TITLE
Add NetLoc8 to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
 | [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No | Yes
 | [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |
+| [NetLoc8](https://netloc8.com/docs/api) | IP geolocation with city, region, timezone, and coordinates — SDKs for Next.js, React, and Go | `apiKey` | Yes | Yes |
 | [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/) | Provides worldwide forward / reverse geocoding | No | Yes | Yes |
 | [One Map, Singapore](https://www.onemap.gov.sg/docs/) | Singapore Land Authority REST API services for Singapore addresses | `apiKey` | Yes | Unknown |
 | [OnWater](https://onwater.io/) | Determine if a lat/lon is on water or land | No | Yes | Unknown |


### PR DESCRIPTION
Added [NetLoc8](https://netloc8.com) to the **Geocoding** section.

NetLoc8 is an IP geolocation REST API that resolves IP addresses to city, region, country, coordinates, and timezone data. It runs on 300+ edge locations worldwide and provides the tightest tail latency of any provider benchmarked (sub-55ms worst-case).

- **Docs:** https://netloc8.com/docs/api
- **OpenAPI spec:** https://api.netloc8.com/.well-known/openapi.json
- **Auth:** API key via `X-API-Key` header
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** 5,000 requests/month, no credit card required
- **SDKs:** Next.js, React, Node.js, Go