### PR TITLE
Add GPU Cloud Compare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Sheets](https://developers.google.com/sheets/api/reference/rest) | API to read, write, and format Google Sheets data | `OAuth` | Yes | Unknown |
 | [Google Slides](https://developers.google.com/slides/api/reference/rest) | API to read, write, and format Google Slides presentations | `OAuth` | Yes | Unknown |
 | [Gorest](https://gorest.co.in/) | Online REST API for Testing and Prototyping | `OAuth` | Yes | Unknown |
+| [GPU Cloud Compare](https://gpucloudcompare.com/data/) | Daily price index for cloud GPU instances (H100, A100, L40S, etc.) across providers, as JSON and CSV | No | Yes | Yes |
 | [Hasura](https://hasura.io/opensource/) | GraphQL and REST API Engine with built in Authorization | `apiKey` | Yes | Yes |
 | [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/) | REST API to programmatically create apps, provision add-ons and perform other task on Heroku | `OAuth` | Yes | Yes |
 | [host-t.com](https://host-t.com) | Basic DNS query via HTTP GET request | No | Yes | No |


### PR DESCRIPTION
## Add API

`GPU Cloud Compare` — a free, no-auth public API exposing a daily price index for cloud GPU instances (H100, A100, L40S, RTX, B200, etc.) across major providers, served as JSON and CSV.

- **Category:** Development (inserted alphabetically between Gorest and Hasura)
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes (responses send `Access-Control-Allow-Origin: *`)
- **Docs / endpoint:** https://gpucloudcompare.com/data/ (e.g. `GET https://gpucloudcompare.com/data/current.json`)
- Data is released under CC-BY-4.0, fully free, no device/service purchase required.

### My submission
- [x] Entry added to the correct category, in alphabetical order
- [x] Format matches `| API | Description | Auth | HTTPS | CORS |`
- [x] Description is clear and free of grammatical errors
- [x] API is free / has free access and requires no purchase
- [x] HTTPS and CORS fields are accurate