### PR TITLE
Add IPGeo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,6 +1021,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IP Vigilante](https://www.ipvigilante.com/) | Free IP Geolocation API | No | Yes | Unknown |
 | [ip-api](https://ip-api.com/docs) | Find location with IP address or domain | No | No | Unknown |
 | [IP-API.io](https://ip-api.io) | IP geolocation with VPN/proxy/Tor detection, reputation and risk score | `apiKey` | Yes | Yes |
+| [IPGeo](https://getipgeo.com/docs) | IP geolocation with VPN, proxy, Tor & hosting detection, 10K free/mo | `apiKey` | Yes | Yes |
 | [IP Geolocation](https://www.abstractapi.com/ip-geolocation-api) | Geolocate website visitors from their IPs | `apiKey` | Yes | Yes |
 | [IP2Location](https://www.ip2location.com/web-service/ip2location) | IP geolocation web service to get more than 55 parameters | `apiKey` | Yes | Unknown |
 | [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy) | Detect proxy and VPN using IP address | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds IPGeo (https://getipgeo.com) — IP geolocation API with VPN, proxy, Tor & hosting detection included on every plan. 10K free lookups/month. apiKey auth, HTTPS, CORS supported.