### PR TITLE
Update InfraNode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,7 +1365,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
-| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
+| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | No | Yes | Unknown |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
 | [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Corrects the Auth field for the existing **InfraNode** entry in the Open Data section.

InfraNode is fully **keyless** (no API key, no signup), so the Auth column should be `No`, not `apiKey`. This can be verified by calling any endpoint without credentials, e.g. `https://infranode.dev/api/v1/cities/koeln/weather`.

Only the Auth field of the single existing line is changed; formatting and alphabetical order are untouched.