### PR TITLE
Add ClassiFinder to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Botd](https://github.com/fingerprintjs/botd) | Botd is a browser library for JavaScript bot detection | `apiKey` | Yes | Yes |
 | [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | Bugcrowd API for interacting and tracking the reported issues programmatically | `apiKey` | Yes | Unknown |
 | [Censys](https://search.censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
+| [ClassiFinder](https://classifinder.ai) | Detect leaked secrets and prompt-injection in text and return redacted output | `apiKey` | Yes | Yes |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **ClassiFinder** to the Security category (alphabetically, between Censys and Classify).

ClassiFinder is a stateless REST API that detects leaked secrets and prompt-injection markers in text and returns redacted output — built for AI pipelines (LLM input/output, RAG, agent-generated code) rather than Git repos. Fits alongside the existing GitGuardian entry.

- **Auth:** `apiKey` — free key at https://classifinder.ai (no card)
- **HTTPS:** Yes · **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **Docs:** https://api.classifinder.ai/docs · **OpenAPI:** https://api.classifinder.ai/v1/openapi.json

Single-line addition, alphabetical order preserved, format matches surrounding entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)