### PR TITLE
Add Quantum Surety Bond Watch API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
+| [Quantum Surety Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Real-time Texas contractor and notary bond compliance data (775K+ TDLR records, 558K+ notaries) | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |


### PR DESCRIPTION
## Description

Adds the Quantum Surety Bond Watch API to the Government section.

**Entry:**
| [Quantum Surety Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Real-time Texas contractor and notary bond compliance data (775K+ TDLR records, 558K+ notaries) | No | Yes | Yes |

## About the API

- **Base URL:** https://verify.quantumsurety.bond
- **Auth:** None required for public endpoints
- **HTTPS:** Yes (Caddy/Let's Encrypt)
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)

The Bond Watch API provides real-time compliance data sourced from the Texas Department of Licensing and Regulation (TDLR) and Texas Secretary of State public records. Data is refreshed monthly.

**Public endpoints:**
- `GET /api/search?q=&city=` — Texas notary bond lookup (558K+ records)
- `GET /api/contractor-search?q=&county=&type=` — TDLR contractor bond status (775K+ records)
- `GET /api/v1/status` — dataset stats

Full API docs: https://verify.quantumsurety.bond/api-docs.html