### PR TITLE
Remove duplicate isitdownstatus link from Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,6 @@ API | Description | Auth | HTTPS | CORS |
 | [ipfind.io](https://ipfind.io) | Geographic location of an IP address or any domain name along with some other useful information | `apiKey` | Yes | Yes |
 | [IPify](https://www.ipify.org/) | A simple IP Address API | No | Yes | Unknown |
 | [IPinfo](https://ipinfo.io/developers) | Another simple IP Address API | No | Yes | Unknown |
-| [isitdownstatus](https://isitdownstatus.com) | Check if websites and online services are currently down | No | Yes | Unknown |
 | [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com) | Package info and download stats on jsDelivr CDN | No | Yes | Yes |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Removes the duplicate `isitdownstatus` entry from the Development section.

The same URL (`https://isitdownstatus.com`) is already listed earlier in the same section as `DownStatus`. I verified this with the repository duplicate-link checker.

I left the other currently-reported duplicate (`TasteDive`) untouched because there are already open PRs addressing it (#6222 and #6228), so this PR only changes one unrelated duplicate entry.

Checklist:
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically or this change does not add a new entry
- [x] My submission has a useful description or this change removes a duplicate entry
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items or this change does not create a category
- [x] All changes have been squashed into a single commit