### PR TITLE
Add Pesa Rates — Real-time Tanzanian Shilling forex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,8 @@ API | Description | Auth | HTTPS | CORS |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
-| [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
+|| [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
+|| [Pesa Rates](https://appow-22hv3j.web.app) | Real-time Tanzanian Shilling (TZS) exchange rates from BoT, NMB & CRDB | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Description

Adds [Pesa Rates](https://appow-22hv3j.web.app) to the Currency Exchange section.

Pesa Rates provides **real-time Tanzanian Shilling (TZS) exchange rates** from multiple sources:
- Bank of Tanzania (BoT) — official daily rates
- NMB Bank — commercial bank rates
- CRDB Bank — commercial bank rates
- OpenExchangeRates — global reference

**Features:**
- 9 currencies tracked (USD, EUR, GBP, KES, UGX, ZAR, CNY, INR, AED)
- Free tier: 1,000 requests/day
- REST API with API key auth
- Arbitrage detection endpoint
- 15-minute refresh interval

**Why this belongs here:** Tanzania's forex data is fragmented across multiple sources with no unified API. This fills a gap for developers building fintech, e-commerce, and trading tools in East Africa.