### PR TITLE
Add Sonto API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖 | `apiKey` | Yes | Unknown |
 | [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |
 | [NPR One](http://dev.npr.org/api/) | Personalized news listening experience from NPR | `OAuth` | Yes | Unknown |
+| [Sonto](https://sonto.tech/api/) | Tech and AI news as JSON or RSS, with translated feeds in EN, DE, ES, FR, JA | No | Yes | Yes |
 | [Spaceflight News](https://spaceflightnewsapi.net) | Spaceflight related news 🚀 | No | Yes | Yes |
 | [The Guardian](http://open-platform.theguardian.com/) | Access all the content the Guardian creates, categorised by tags and section | `apiKey` | Yes | Unknown |
 | [The Old Reader](https://github.com/theoldreader/api) | RSS reader | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Sonto to News. Tech and AI news as JSON (`/api/news`, plus a slim variant) and RSS. Five languages (EN, DE, ES, FR, JA) via per-subdomain feeds, each carrying a `lang` field. No key, no signup, HTTPS, CORS open. Docs: https://sonto.tech/api/