### PR TITLE
Add GeneTech Knowledge Engine - 12 domain science API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Open Data
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [GeneTech KB Ecosystem](https://genetech.tools) | 12-domain structured knowledge base: genes, quantum, nuclear, brain science, exoplanets, deep-sea tech | No | Yes | Yes |
 | [18F](http://18f.github.io/API-All-the-X/) | Unofficial US Federal Government API Development | No | No | Unknown |
 | [AcreLens](https://www.acrelens.com) | Land suitability scoring API for any US property: off-grid, rural, recreational, investment | `apiKey` | Yes | Unknown |
 | [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
@@ -1528,6 +1529,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Science & Math
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [GeneTech Knowledge Engine](https://genetech.tools) | 4,000+ structured entities across 12 frontier science domains (genes, quantum, nuclear, brain, deep sea) | No | Yes | Yes |
 | [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |


### PR DESCRIPTION
## GeneTech Knowledge Engine

12 specialized knowledge bases covering frontier science & technology domains with 4,000+ structured JSON entities.

**Domains:** Gene Technology, Quantum Computing, Nuclear Energy, Brain Science, Exoplanets, Alien Minerals, Deep-Sea Technology, New Energy, Life Science, AI Agent Ecosystem, Robot Parts, Traditional Chinese Medicine

**Features:**
- Free REST API (no signup for basic tier)
- OpenAPI 3.1 spec
- llms.txt for AI agent discovery
- Cross-domain entity references
- MCP-compatible

**Try it:**
```bash
curl https://genetech-tools.pages.dev/api/entities.json | jq .total
```

Added to Science & Math and Open Data sections.