### PR TITLE
Add API-Sports API to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1734,6 +1734,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |
+| [API-Sports](https://api-sports.io/documentation) | Real-time sports data for football, basketball, baseball, and more | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Added API-Sports - a free real-time sports data API. It provides endpoints for football, basketball, baseball, and more with free tier access.