### PR TITLE
Fix format.py crash on Python 3.13+

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]
@@ -43,6 +43,7 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
 
     categories = {}
     category_line_num = {}
+    category = None
 
     for line_num, line_content in enumerate(contents):
 
@@ -53,6 +54,11 @@ def get_categories_content(contents: List[str]) -> Tuple[Categories, CategoriesL
             continue
 
         if not line_content.startswith('|') or line_content.startswith('|---'):
+            continue
+
+        # Skip table rows that appear before any ### category header
+        # (e.g. promotional tables at the top of the README)
+        if category is None:
             continue
 
         raw_title = [


### PR DESCRIPTION
## Problem

format.py crashes on Python 3.10+ with `UnboundLocalError` when the README contains markdown table rows before the first `###` category header.

**Root cause:** `get_categories_content()` uses `category` without initializing it. When table rows with `[TITLE](LINK)` appear before any `###` anchor (like the APILayer ad table), the code tries `categories[category].append(title)` where `category` was never assigned.

**Secondary issue:** Three regex patterns use bare strings with backslash escapes instead of raw strings, producing `SyntaxWarning` on Python 3.12+ (will become `SyntaxError` in future Python).

## Fix

1. Initialize `category = None` and add guard `if category is None: continue`
2. Convert regex patterns to raw strings

## Testing

- All 31 existing unit tests pass unchanged
- format.py now runs successfully on the full README.md