### PR TITLE
Add ClearTrace API (cross-frontend DEX attribution & execution quality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ API | Description | Auth | HTTPS | CORS |
 | [btcnode.uk](https://btcnode.uk) | Bitcoin blockchain data, fees, mempool, SEC insider trades, Reddit sentiment. x402 micropayments for paid endpoints. | No | Yes | Unknown |
 | [BtcTurk](https://docs.btcturk.com/) | Real-time cryptocurrency data, graphs and API that allows buy&sell | `apiKey` | Yes | Yes |
 | [Bybit](https://bybit-exchange.github.io/docs/linear/#t-introduction) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |
+| [ClearTrace](https://cleartracedata.com/docs) | Cross-frontend DEX attribution and execution quality (slippage, MEV, reverts) across 4 EVM chains | No | Yes | Yes |
 | [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
 | [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
 | [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **ClearTrace** to the Cryptocurrency section — a free, no-auth REST API for cross-frontend DEX trade attribution and execution-quality benchmarks (slippage, MEV/sandwich detection, revert rates) across Ethereum, Base, Arbitrum, and Optimism.

Docs: https://cleartracedata.com/docs

<!-- Contribution checklist -->
- [x] My addition is on the **Cryptocurrency** section, in **alphabetical order** (placed before `CoinAPI`).
- [x] Entry format matches `| API | Description | Auth | HTTPS | CORS |`.
- [x] Description is useful and **≤ 100 characters**, and does **not** end with a period.
- [x] `Auth` is `No` (no key required), `HTTPS` is `Yes`, `CORS` is `Yes`.
- [x] The link points to the **API documentation** and returns `200` with no redirect.
- [x] Only **one** API added in this PR.