### PR TITLE
Add SkinAPI to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,7 @@ API | Description | Auth | HTTPS | CORS |
 | [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
 | [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
 | [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
+| [SkinAPI](https://skinapi.skinvaults.online/docs) | Real-time CS2/Steam skin prices, float values and inventories | `apiKey` | Yes | Unknown |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey` | Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |


### PR DESCRIPTION
Adds **SkinAPI** - a REST API for CS2/Steam skin prices, float values, Steam inventories/profiles and multi-marketplace data (free tier).

- Entry placed alphabetically in **Games & Comics** (after Scryfall).
- Auth: `apiKey` (x-api-key header) - HTTPS: Yes - CORS: Unknown
- Docs: https://skinapi.skinvaults.online/docs
- OpenAPI: https://skinapi.skinvaults.online/api/v1/openapi.json

Checklist:
- [x] My addition is on one line in the correct alphabetical position
- [x] Description is clear, concise, and free of buzzwords
- [x] HTTPS and Auth columns are accurate
- [x] The API is publicly accessible and documented