### PR TITLE
Add Texas Bond Watch API to Government section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Quantum Surety Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Real-time Texas contractor and notary bond compliance data (775K+ TDLR records, 558K+ notaries) | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Texas Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Texas TDLR contractor & notary bond compliance data (816K+ licensees) | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
+| [Quantum Surety Bond Watch](https://verify.quantumsurety.bond/api-docs.html) | Real-time Texas contractor and notary bond compliance data (775K+ TDLR records, 558K+ notaries) | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |


### PR DESCRIPTION
## What is Texas Bond Watch?

**Texas Bond Watch** is a free, no-auth public API providing Texas contractor and notary bond compliance data sourced from TDLR (Texas Department of Licensing and Regulation) and Texas Secretary of State public records.

- **Base URL:** https://verify.quantumsurety.bond
- **Documentation:** https://verify.quantumsurety.bond/api-docs.html
- **Auth:** None required for public endpoints
- **HTTPS:** Yes
- **CORS:** Yes (open)

## Key endpoints

- `GET /api/contractor-search?q=name&county=harris` — search 816K+ TDLR-licensed contractors
- `GET /api/search?q=name&city=dallas` — search 66K+ Texas notary bonds
- `GET /api/v1/status` — dataset stats (notary count, contractor count, last updated)
- `GET /api/v1/contractor/lookup/:license_number` — lookup by license number (requires API key)
- `GET /api/v1/lookup/:notary_id` — lookup by notary ID (requires API key)

## Why it's useful

The API enables developers and researchers to:
- Verify that any TDLR-licensed contractor has an active, non-expired surety bond
- Build consumer protection tools (29.3% of TX TDLR licensees currently have expired bonds)
- Access real-time compliance data without needing to scrape TDLR's website

Data is updated monthly from TDLR public records (Texas Open Data Portal dataset ID: 7358-krk7).

**Checklist:**
- [ ] API is accessible without authentication (public endpoints)
- [ ] HTTPS is supported
- [ ] CORS is enabled
- [ ] Documentation is available and complete
- [ ] Entry is in alphabetical order within the Government section