### PR TITLE
Add PuntersEdge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1718,6 +1718,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
+| [PuntersEdge](https://api.puntersedge.online/docs) | Australian racing and sports odds from 11 bookmakers plus the Betfair exchange | `apiKey` | Yes | Yes |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |


### PR DESCRIPTION
Adds **PuntersEdge** to **Sports & Fitness**.

Australian racing (horse, greyhound, harness) and sports odds from 11 bookmakers plus the Betfair exchange, in one REST API. The free tier is 1,500 credits/month and does not require a credit card.

Row added:

```
| [PuntersEdge](https://api.puntersedge.online/docs) | Australian racing and sports odds from 11 bookmakers plus the Betfair exchange | `apiKey` | Yes | Yes |
```

- [x] One line, one link, in `Sports & Fitness`
- [x] Alphabetical — sits between `PropLine` and `RacingHub`
- [x] Description is 78 characters, capitalised, no trailing punctuation
- [x] `Auth` is `apiKey`; `HTTPS` is `Yes`; `CORS` is `Yes` — a request carrying an `Origin` header gets `Access-Control-Allow-Origin: *` back, and preflight allows `X-API-Key`
- [x] Documentation link returns HTTP 200
- [x] Free tier — no purchase, subscription or hardware required
- [x] Not already listed; title carries no TLD and does not end in "API"

If you want to check it without signing up, there is a keyless demo endpoint:

```
curl https://api.puntersedge.online/v1/demo/racing/next-to-go
```

On validation: `scripts/validate/format.py` currently reports 557 errors on `master` for pre-existing reasons. This row adds none — the count is 557 with and without it.

---

Amended since opening: the description was 108 characters, over the 100 limit, and the body previously stated the free tier as 2,500 credits/month. Both corrected, and the commits squashed into one.
