### PR TITLE
Add FateStar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1439,6 +1439,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Biriyani As A Service](https://biriyani.anoram.com/) | Biriyani images placeholder | No | Yes | No |
 | [Dev.to](https://developers.forem.com/api) | Access Forem articles, users and other resources via API | `apiKey` | Yes | Unknown |
 | [Dictum](https://github.com/fisenkodv/dictum) | API to get access to the collection of the most inspiring expressions of mankind | No | Yes | Unknown |
+| [FateStar](https://www.fatestar.top/api/ziwei) | Chinese Zi Wei Dou Shu (Purple Star) natal charts and multi-level transits | No | Yes | No |
 | [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Yes | Unknown |
 | [FOAAS](http://www.foaas.com/) | Fuck Off As A Service | No | No | Unknown |
 | [Forismatic](http://forismatic.com/en/api/) | Inspirational Quotes | No | No | Unknown |


### PR DESCRIPTION
Adds **FateStar** to the **Personality** category — a free, no-key REST endpoint that returns Chinese Zi Wei Dou Shu (Purple Star astrology) natal charts and multi-level transits as JSON.

Tested live (HTTP 200):
`GET https://www.fatestar.top/api/ziwei?year=1990&month=7&day=23&hour=8&gender=male`

- [x] Addition placed in the correct category (Personality, alongside AstroWay)
- [x] Ordered alphabetically within the category
- [x] Useful, non-promotional description, no trailing punctuation
- [x] Columns padded with one space on either side
- [x] Auth: No · HTTPS: Yes · CORS: No (filled accurately)
- [x] Searched repo for duplicates — none