### PR TITLE
Add ipok API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,6 +1594,7 @@ API | Description | Auth | HTTPS | CORS |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
+| [ipok](https://ipok.io/developers) | IP reputation, risk scoring, Tor/proxy/VPN and datacenter vs residential detection, DNSBL checks | No | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |


### PR DESCRIPTION
Adds `ipok` to the Security section.

- Free, no-auth, CORS-enabled public API for IP reputation / risk scoring (Tor/proxy/VPN and datacenter-vs-residential detection, DNSBL checks).
- Docs: https://ipok.io/developers
- Auth: No · HTTPS: Yes · CORS: Yes
- Placed alphabetically in Security, directly after IPLogs.
- Single link, single squashed commit, description under 100 chars.