### PR TITLE
Add DeepSeek API to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [DeepAI](https://deepai.org/) | Provides AI-powered APIs for text generation, image processing, and more | `apiKey` | Yes | Yes |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |
+| [DeepSeek](https://platform.deepseek.com/api-docs) | Free tier AI inference with reasoning and chat models | `apiKey` | Yes | Unknown |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [GoldBean](https://goldbean-api.xyz/docs) | OCR, Translation, NLP & ERNIE LLM via Baidu AI (free tier available) | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **DeepSeek** to the Machine Learning section.

DeepSeek provides free tier AI inference with reasoning (DeepSeek-R1) and chat models via an OpenAI-compatible API.

- Docs: https://platform.deepseek.com/api-docs
- Free tier: Yes (limited credits on signup)
- Auth: apiKey
- HTTPS: Yes
- CORS: Unknown