### PR TITLE
Add CryptoWhaleInsights to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ API | Description | Auth | HTTPS | CORS |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
+| [CryptoWhaleInsights](https://cryptowhaleinsights.com/api-for-ai-agents) | Crypto whale tracking & market data across 14 chains (BTC, ETH, SOL +) | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Add CryptoWhaleInsights to Cryptocurrency section

Crypto whale tracking & market data across 14 chains. No auth required for public endpoints.

- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically  
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been squashed into a single commit