### PR TITLE
Correct InfraNode entry: keyless auth and CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
-| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
+| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | No | Yes | Yes |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
 | [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
The existing InfraNode entry (Open Data) lists `apiKey`, but InfraNode requires no API key and no account: every endpoint is callable with a plain unauthenticated GET. This corrects the Auth column to `No`.

CORS is also enabled (responses send `Access-Control-Allow-Origin: *`), so the CORS column is updated from `Unknown` to `Yes`.

No new entry, only the two columns of the existing row are corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)