### PR TITLE
Add Is It Safe to Travel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1385,6 +1385,7 @@ API | Description | Auth | HTTPS | CORS |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
 | [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
+| [Is It Safe to Travel](https://isitsafetotravel.org/en/api/) | Daily travel-safety scores and 5 risk pillars for 248 countries, from gov advisories and indices | No | Yes | Yes |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
 | [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Is It Safe to Travel** to **Open Data**.

- Docs: https://isitsafetotravel.org/en/api/ · Data: https://isitsafetotravel.org/scores.json
- Free, no auth, HTTPS, CORS enabled (`access-control-allow-origin: *` verified)
- Daily composite travel-safety scores + 5 risk pillars (conflict, crime, health, governance, environment) for 248 countries, from GPI, INFORM, ReliefWeb, GDACS and US/UK/CA/AU government advisories
- Open source: https://github.com/RiccardoDominici/IsItSafeToTravel

Checklist: entry added alphabetically in Open Data, description under 100 chars, no trailing period, Auth=No / HTTPS=Yes / CORS=Yes.