### PR TITLE
Add DomainIntel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |
+| [DomainIntel](https://rapidapi.com/domainintel-domainintel-default/api/domainintel) | RDAP, DNS, certificate transparency & bulk domain lookups — free tier | `apiKey` | Yes | Unknown |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds DomainIntel — a domain intelligence API providing RDAP, DNS, certificate transparency, and bulk domain lookups. Has a free tier (500 requests/month), supports HTTPS, requires an API key.

- RapidAPI listing: https://rapidapi.com/domainintel-domainintel-default/api/domainintel
- OpenAPI spec available