### PR TITLE
Add Almanac.tools API

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Data Validation
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [Almanac.tools](https://almanac.tools) | Deterministic reference & validation APIs: VAT/IBAN, business days, currencies, country/industry codes, checksums | `apiKey` | Yes | No | |
 | [VATlayer](https://vatlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | VAT number validation | `apiKey` | Yes | Unknown | |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |


### PR DESCRIPTION
Adds **Almanac.tools** to the **Data Validation** category.

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [Almanac.tools](https://almanac.tools) | Deterministic reference & validation APIs: VAT/IBAN, business days, currencies, country/industry codes, checksums | `apiKey` | Yes | No |

- A platform of free-tier reference & validation APIs (VAT/GST, IBAN/BIC, business-day & holiday calendars, ISO 4217 currencies, country/industry/tariff codes, identifier checksums) behind one key.
- Public, HTTPS, documented at https://almanac.tools/docs with an OpenAPI 3.1 spec at https://almanac.tools/api/openapi.
- Entry added as a single row, placed alphabetically, matching the existing column format.