### PR TITLE
Add DomainIntel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |
+| [DomainIntel](https://domainintel.onrender.com) | Real-time domain intelligence: RDAP, DNS-over-HTTPS, Certificate Transparency and bulk lookups | `apiKey` | Yes | Yes |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Add [DomainIntel](https://domainintel.onrender.com) to the Security section. DomainIntel is a real-time domain intelligence API providing RDAP, DNS-over-HTTPS, Certificate Transparency, and bulk lookups. Free tier available.

## Checklist

- [x] Alphabetical ordering per section
- [x] Description under 100 characters (99)
- [x] Proper formatting with one space padding on either side
- [x] API has free tier (500 req/month)
- [x] Proper documentation available (link points to API docs)