### PR TITLE
Add ReefAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |
+| [ReefAPI](https://reefapi.com) | Live web data from 160+ sources (search, social, e-commerce, real estate, jobs, finance) returned as clean JSON | `apiKey` | Yes | Unknown |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey` | Yes | No |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |


### PR DESCRIPTION
Adds **ReefAPI** to the Development category (alphabetical, between Random Stuff and Rejax).

ReefAPI returns live web data from 160+ sources (search, social, e-commerce, real estate, jobs, travel, news, finance, company/domain/people intelligence) as clean JSON over one endpoint group. It has a free tier (1,000 credits, no card required), same class as the existing ScraperApi / ScrapeNinja entries in this section.

- API: `apiKey` · HTTPS: Yes · CORS: Unknown
- Site: https://reefapi.com · Docs: https://reefapi.com/docs

Single-line addition, alphabetical placement, follows the table format.