### PR TITLE
Add PokéAPI to Games & Comics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Humble Bundle](https://rapidapi.com/Ziggoto/api/humble-bundle) | Humble Bundle's current bundles | `apiKey` | Yes | Unknown |
 | [Humor](https://humorapi.com) | Humor, Jokes, and Memes | `apiKey` | Yes | Unknown |
 | [Hypixel](https://api.hypixel.net/) | Hypixel player stats | `apiKey` | Yes | Unknown |
+| [PokéAPI](https://pokeapi.co/) | RESTful API for Pokémon data including species, abilities, moves, types, and game information | No | Yes | Yes |
 | [Hyrule Compendium](https://github.com/gadhagod/Hyrule-Compendium-API) | Data on all interactive items from The Legend of Zelda: BOTW | No | Yes | Unknown |
 | [Hytale](https://hytale-api.com/) | Hytale blog posts and jobs | No | Yes | Unknown |
 | [IGDB.com](https://api-docs.igdb.com) | Video Game Database | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- Added PokéAPI entry with description for Pokémon data
- API provides RESTful access to species, abilities, moves, types, and game information
- No authentication required, HTTPS enabled, CORS supported

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My addition is ordered alphabetically
- [ ] My submission has a useful description
- [ ] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [ ] Each table column is padded with one space on either side
- [ ] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
