### PR TITLE
Add DomainIntel API to Anti-Malware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |
+| [DomainIntel](https://rapidapi.com/domainintel-domainintel-default/api/domainintel) | RDAP, DNS, certificate transparency & bulk domain lookups — free tier | `apiKey` | Yes | Unknown |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AbuseIPDB](https://docs.abuseipdb.com/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
 | [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
 | [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html) | Malware execution and analysis | `apiKey` | Yes | Unknown |
+| [DomainIntel API](https://domainintel.onrender.com) | WHOIS/RDAP, DNS records, SSL certificates, bulk domain checks | `apiKey` | Yes | Unknown |
 | [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google Link/Domain Flagging | `apiKey` | Yes | Unknown |
 | [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Yes | Unknown |
 | [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | Yes | No |


### PR DESCRIPTION
## Summary
Add DomainIntel API — domain intelligence API providing WHOIS/RDAP lookup, DNS records, SSL certificate checks, and bulk domain queries. Free tier: 500 requests/month.

Placed alphabetically in Anti-Malware section between CAPEsandbox and Google Safe Browsing.

🤖 Generated with Neo