### PR TITLE
Add Plug-In Solar Legality (US) API to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Yes | Unknown |
 | [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Yes | Unknown |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
+| [Plug-In Solar Legality (US)](https://pluginsolarhub.org/developers/) | 50-state US plug-in/balcony solar legal status, electricity rates & live legislation | No | Yes | Yes |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |
 | [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
 | [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Free no-auth JSON API: 50-state US plug-in/balcony solar legal status, electricity rates & live legislation. HTTPS, CORS-open, no key, no rate limit. CC BY 4.0. Docs: https://pluginsolarhub.org/developers/