### PR TITLE
Add EDGAR Events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
+| [EDGAR Events](https://api.edgarevents.com/docs) | SEC 8-K item codes, 13D activist stakes, and S-1 filings as typed JSON, with signed webhooks | `apiKey` | Yes | No | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds EDGAR Events to the Finance section.

EDGAR Events returns SEC EDGAR filings as typed JSON: 8-K item codes labeled with a materiality flag, SC 13D activist stakes resolved to holder/target/percent-of-class, and S-1/424B and merger forms. Poll the REST API or register an HMAC-signed webhook. Data is live from data.sec.gov.

- Free tier available (`apiKey` auth); paid tier is optional, not required to use the API.
- HTTPS: Yes. CORS: No (server-to-server; no Access-Control-Allow-Origin header).
- Interactive docs (open, no key): https://api.edgarevents.com/docs
- Description is 92 chars; entry placed alphabetically between EconPulse and Fed Treasury.

Checklist:
- [x] One link added
- [x] Alphabetical order kept within Finance
- [x] Auth value from the accepted list (`apiKey`)
- [x] Description under 100 characters
- [x] Name has no TLD and does not end with "API"