### PR TITLE
Add PolyDoc API

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
+| [PolyDoc](https://polydoc.tech) | HTML/URL to PDF and screenshots, plus Factur-X/ZUGFeRD e-invoices; free tier | `apiKey` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
 | [Renderly](https://renderlyapi.com) | HTML to PDF conversion API built on Chromium | `apiKey` | Yes | Yes |
 | [Rendex](https://rendex.dev) | Render HTML, Markdown, or URLs to PNG/JPEG/WebP/PDF, with extraction and templating | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PolyDoc to **Documents & Productivity** (alphabetical, between Podio and PrexView).

PolyDoc is a REST API for converting HTML or URLs to PDF and screenshots, plus Factur-X / ZUGFeRD e-invoices. It has a free tier (150 conversions/month, no credit card, no device or service purchase required), so it meets the free-access guideline.

- Description under 100 characters
- Alphabetical order within the section
- Auth: apiKey, HTTPS: Yes, CORS: Unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)