### PR TITLE
Add Beach Day to Weather list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1997,6 +1997,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Weather
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [Beach Day](https://beachdayapi.com) | Beach and beach-condition data for planning beach days | `apiKey` | Yes | No |
 | [Weatherstack](https://weatherstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-Time & Historical World Weather Data API | `apiKey` | Yes | Unknown |
 | [7Timer!](http://www.7timer.info/doc.php?lang=en) | Weather, especially for Astroweather | No | No | Unknown |
 | [AccuWeather](https://developer.accuweather.com/apis) | Weather and forecast data | `apiKey` | No | Unknown |


### PR DESCRIPTION
## Summary
Add Beach Day to the Weather category.

## Why this belongs here
Beach Day API provides beach and beach-condition data for planning beach days. It is a public HTTPS API with token-based auth and no CORS support.

## Details
- Docs URL: https://beachdayapi.com/docs/
- Auth: `apiKey`
- HTTPS: Yes
- CORS: No

## Entry
| [Beach Day](https://beachdayapi.com/) | Beach and beach-condition data for planning beach days | `apiKey` | Yes | No |

## Checklist
- [x] Submission follows the contributing guide
- [x] Entry is alphabetized
- [x] Description is under 100 characters
- [x] Description does not end with punctuation
- [x] Columns are padded with one space on either side
- [x] Relevant issues and PRs were searched
- [x] Changes were squashed into a single commit