### PR TITLE
Add PDFFleet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [OCR.Space](https://ocr.space/ocrapi) | OCR text extraction from images and PDFs with a free tier | `apiKey` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PDFFleet](https://pdffleet.com) | HTML and URL to PDF API with templates and a free tier | `apiKey` | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PDFFleet to the Documents & Productivity section.

**PDFFleet** is an HTML/URL-to-PDF API that renders with headless Chromium. It offers a free tier (50 PDFs/month, no credit card required) alongside paid tiers, and supports HTML input, URL input, and named templates with JSON data merge.

- Auth: API key
- HTTPS: Yes
- CORS: Yes
- Free tier: 50 PDFs/month (no purchase required)
- Docs: https://pdffleet.com/docs

Placed alphabetically between PandaDoc and Pocket in the Documents & Productivity section, per the alphabetical ordering guideline.