### PR TITLE
Add PaintColorHQ Color Match API

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lordicon](https://lordicon.com/) | Icons with predone Animations | No | Yes | Yes |
 | [Metropolitan Museum of Art](https://metmuseum.github.io/) | Met Museum of Art | No | Yes | No |
 | [Noun Project](http://api.thenounproject.com/index.html) | Icons | `OAuth` | No | Unknown |
+| [PaintColorHQ Color Match](https://www.paintcolorhq.com/api) | Closest cross-brand paint color matches for any hex (CIEDE2000), 13 brands | No | Yes | Yes |
 | [PHP-Noise](https://php-noise.com/) | Noise Background Image Generator | No | Yes | Yes |
 | [Pixel Encounter](https://pixelencounter.com/api) | SVG Icon Generator | No | Yes | No |
 | [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/) | RijksMuseum Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the **PaintColorHQ Color Match API** to **Art & Design**, in the correct alphabetical position (between *Noun Project* and *PHP-Noise*).

It returns the closest cross-brand paint color equivalents for any hex, scored with CIEDE2000, across 13 brands and 26,000+ colors — the kind of cross-brand lookup other color APIs don't offer.

- [x] One entry, on one line, alphabetical within the section
- [x] Link points to API documentation: https://www.paintcolorhq.com/api
- [x] Free to use (free tier; no key required for the open endpoint)
- [x] Auth: No · HTTPS: Yes · CORS: Yes
- [x] Description is concise, no trailing period

Entry:
`| [PaintColorHQ Color Match](https://www.paintcolorhq.com/api) | Closest cross-brand paint color matches for any hex (CIEDE2000), 13 brands | No | Yes | Yes |`