### PR TITLE
Add Verifly email verification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [Verifier](https://verifier.meetchopra.com/docs#/) | Verifies that a given email is real | `apiKey` | Yes | Yes |
+| [Verifly](https://verifly.email) | Email verification for AI agents | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds **Verifly** ([verifly.email](https://verifly.email)) to the **Email** section — an email-verification API for AI agents (verify, clean, and validate email addresses).

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
