### PR TITLE
Add XiaoKe API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
+| [XiaoKe API Gateway](https://github.com/y9695430-lang/xiaoke-api-gateway) | Multi-service API for AI agents: PDF→JSON, Web→Markdown, OCR, Code Review, Translation, Summarization, MD→HTML. x402 autonomous payments | No | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 
 


### PR DESCRIPTION
## XiaoKe API Gateway

7 micro-services for AI agents with x402 autonomous payments (USDC on Base).

**Services:** PDF→JSON, Web→Markdown, OCR, Code Review, Translation, Summarization, Markdown→HTML

- 🔓 No auth required (payment via x402 protocol)
- 🤖 AI agents auto-discover and pay
- 🌐 Public endpoint: https://xiaoke-pdf-api.loca.lt
- 📖 Docs: https://y9695430-lang.github.io/xiaoke-api-gateway
- ⭐ GitHub: https://github.com/y9695430-lang/xiaoke-api-gateway

All endpoints follow the public-apis format.