### PR TITLE
Add ScreenshotAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping with a simple API | `apiKey` | Yes | Unknown |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
+| [ScreenshotAPI](https://screenshotapi.to/docs) | Capture website screenshots as PNG, JPEG, WebP, or PDF | `apiKey` | Yes | Yes |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds ScreenshotAPI to the Development section.

ScreenshotAPI provides a documented free tier, API key authentication, HTTPS, CORS, and screenshot/PDF generation docs at https://screenshotapi.to/docs.