### PR TITLE
Add FilingFirehose API (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Edgrapi](https://edgrapi.com) | Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q sections as normalized JSON | `apiKey` | Yes | Unknown | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
+| [FilingFirehose](https://filingfirehose.com) | Structured SEC EDGAR filings (8-K, 13D, S-3 ATM) with body-text parsing beyond filer-reported items | No | Yes | Yes |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adding [FilingFirehose](https://filingfirehose.com) under **Finance** — structured SEC EDGAR filings API with body-text parsing that goes beyond filer-reported 8-K items.

- Free, no-auth public endpoints: `/v1/public/8k`, `/v1/public/13d`, `/v1/public/atm`, `/v1/public/live-stats`
- HTTPS, CORS enabled
- OpenAPI spec: https://filingfirehose.com/openapi.json
- Covers 8-K (with item classification), S-3 ATM offerings, and 13D activist filings
- No purchase / device required to access the free tier

Verified the entry is alphabetically placed between Fed Treasury and Finage, and the existing schema (No auth | HTTPS Yes | CORS Yes) is respected.