### PR TITLE
Add Rexilion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [PumpFunData](https://pumpfundata.com/docs) | Historical Pump.fun and PumpSwap AMM swap data as hourly Parquet files | `apiKey` | Yes | Unknown |
+| [Rexilion](https://rexilion.com/rexilion-api/) | Bitcoin market and on-chain metrics for dashboards and research | `apiKey` | Yes | No |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Rexilion to the Cryptocurrency section.\n\nRexilion provides API-keyed Bitcoin market and on-chain metric time-series for dashboards and research workflows.\n\nChecks performed:\n- Public docs URL returns HTTP 200: https://rexilion.com/rexilion-api/\n- OpenAPI URL returns valid JSON: https://rexilion.com/docs/rexilion-api.openapi.json\n- HTTPS supported\n- CORS checked as No