### PR TITLE
Add DomScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
-| [DomScan](https://domscan.net) | Domain availability, DNS, WHOIS/RDAP, SSL and brand protection intelligence | `apiKey` | Yes | Unknown |
+| [DomScan](https://domscan.net/docs) | Domain availability, DNS, WHOIS/RDAP, SSL and brand protection intelligence | `apiKey` | Yes | Yes | |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
+| [DomScan](https://domscan.net) | Domain availability, DNS, WHOIS/RDAP, SSL and brand protection intelligence | `apiKey` | Yes | Unknown |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds DomScan to the Development category. DomScan provides domain availability, DNS, WHOIS/RDAP, SSL, and brand-protection data through a documented API with a free tier.

- Links directly to the API documentation
- Uses the current six-column table format
- Lists API-key authentication, HTTPS, and verified CORS support
- Keeps the entry in alphabetical order
