### PR TITLE
Add Autokin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1940,6 +1940,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Auto Body Shop Directory](https://autobodyshopnear.com/developers/body-shop-api) | Find auto body shops by ZIP code, city, location, or profile | No | Yes | No |
+| [Autokin](https://docs.autokin.io) | Australian vehicle valuations from text, VIN, or rego, with comparable-listing evidence | `apiKey` | Yes | Unknown |
 | [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe | No | Yes | No |
 | [CarVector](https://carvector.io/docs) | Vehicle specs, images, recalls, and DTC codes across 1925-2029 | `apiKey` | Yes | Yes |
 | [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Autokin to the Vehicle category. Australian vehicle valuation API with a free tier; documentation at https://docs.autokin.io