### PR TITLE
Add OpenQR API

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Page Rank](https://www.domcop.com/openpagerank/) | API for calculating and comparing metrics of different websites using Page Rank algorithm | `apiKey` | Yes | Unknown |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
+| [OpenQR](https://openqr.uk/api) | Generate QR codes and manage dynamic (editable) QR codes with scan analytics | `apiKey` | Yes | Yes |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **OpenQR** to the Development category (alphabetical order).

OpenQR is a free QR code REST API: generate QR codes and create/manage **dynamic (editable)** QR codes with scan analytics. Bearer API key (free with sign-up), HTTPS, CORS enabled, OpenAPI spec at https://openqr.uk/openapi.json.

- Docs: https://openqr.uk/api
- API base: https://openqr.uk/v1

Follows the table format; Auth `apiKey`, HTTPS Yes, CORS Yes.