### PR TITLE
Add Pan Africa Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1396,6 +1396,7 @@ API | Description | Auth | HTTPS | CORS |
 | [openAFRICA](https://africaopendata.org/) | Large datasets repository of African open data | No | Yes | Unknown |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
+| [Pan Africa Data](https://panafricadata.com) | Macroeconomic and subnational income distribution data for all 54 African countries | `apiKey` | Yes | Unknown |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds Pan Africa Data to the Finance category.

- REST API covering all 54 African countries
- National macroeconomic indicators: GDP, population, poverty, remittances, FDI, ODA
- Proprietary subnational income distribution at city level — 509 cities, 4 income classes
- History from 2000, forecasts to 2035
- apiKey auth, HTTPS, panafricadata.com
