### PR TITLE
Add Solematica API

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |
 | [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
 | [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |
+| [Solematica](https://www.solematica.it/sviluppatori) | Compare Italian solar (photovoltaic) installer offers, energy prices (PUN/ARERA) and satellite roof data | No | Yes | No |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |
 | [SustainMetrics](https://www.sustainmetrics.net/api) | 18,000+ GHG emission factors from DEFRA, EPA, ADEME, Ember | `apiKey` | Yes | Yes |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |


### PR DESCRIPTION
**Add the Solematica API to the Environment category.**

Free, public API for the Italian solar (photovoltaic) market: compare the live offers of national solar installers, current electricity prices (PUN/ARERA) and satellite-derived roof data.

- Entry added in **Environment**, in alphabetical order (between PVWatts and Srp Energy)
- Format: `| [Solematica](link) | Description | Auth | HTTPS | CORS |`
- **Auth:** No · **HTTPS:** Yes · **CORS:** No
- Documentation link returns 200: https://www.solematica.it/sviluppatori
- One entry, no duplicates, description has no trailing period
