### PR TITLE
Add open-banking.io to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
+| [Open Banking](https://open-banking.io) | EU open banking API for account aggregation and payment initiation without eIDAS certificates | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds [open-banking.io](https://open-banking.io) to the Finance section — an EU open banking API for account aggregation (AIS) and payment initiation (PISP) that works without eIDAS QWAC certificates. Placed alphabetically between Nordigen and OpenFIGI. Disclosure: I am the developer of open-banking.io.