### PR TITLE
Add FreeDictionaryAPI.com to Dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
 | [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
 | [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |
+| [FreeDictionaryAPI.com](https://freedictionaryapi.com/) | Wiktionary‑sourced definitions across many languages (CC BY‑SA) | No | Yes | CC BY‑SA (attribution) |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
 | [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
 | [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |
-| [FreeDictionaryAPI.com](https://freedictionaryapi.com/) | Wiktionary‑sourced definitions across many languages (CC BY‑SA) | No | Yes | CC BY‑SA (attribution) |
+| [FreeDictionaryAPI.com](https://freedictionaryapi.com/) | Wiktionary‑sourced definitions across many languages | No | Yes | CC BY‑SA |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Add FreeDictionaryAPI.com to Dictionaries

This PR adds FreeDictionaryAPI.com which serves Wiktionary-sourced definitions across many languages
License note: data is CC BY-SA and consumers should follow attribution and share-alike requirements
Preview README to confirm table formatting and alphabetical order
Closes #6401