### PR TITLE
Add SSRF guard to the link validator

### DIFF
--- a/scripts/tests/test_validate_links.py
+++ b/scripts/tests/test_validate_links.py
@@ -7,6 +7,8 @@ from validate.links import check_duplicate_links
 from validate.links import fake_user_agent
 from validate.links import get_host_from_link
 from validate.links import has_cloudflare_protection
+from validate.links import validate_url
+from validate.links import is_private_ip
 
 
 class FakeResponse():
@@ -170,3 +172,41 @@ class TestValidateLinks(unittest.TestCase):
         self.assertFalse(result1)
         self.assertFalse(result2)
         self.assertFalse(result3)
+
+    def test_validate_url_blocks_non_http_schemes(self):
+        for link in ['ftp://example.com/file', 'file:///etc/passwd', 'gopher://example.com/']:
+            with self.subTest(link=link):
+                has_error, message = validate_url(link)
+                self.assertTrue(has_error)
+                self.assertIn('ERR:URL', message)
+
+    def test_validate_url_blocks_private_and_reserved_ips(self):
+        # Literal IPs keep this deterministic and free of DNS/network calls.
+        blocked = [
+            'http://127.0.0.1/',                          # loopback
+            'http://10.0.0.1/',                           # private (RFC 1918)
+            'http://192.168.1.1/admin',                   # private (RFC 1918)
+            'http://169.254.169.254/latest/meta-data/',   # link-local cloud metadata
+            'http://[::1]/',                              # IPv6 loopback
+        ]
+        for link in blocked:
+            with self.subTest(link=link):
+                has_error, message = validate_url(link)
+                self.assertTrue(has_error)
+                self.assertIn('ERR:URL', message)
+
+    def test_validate_url_allows_public_http_urls(self):
+        # Public literal IPs: no DNS lookup, no outbound request.
+        for link in ['http://1.1.1.1/', 'https://8.8.8.8/']:
+            with self.subTest(link=link):
+                has_error, message = validate_url(link)
+                self.assertFalse(has_error)
+                self.assertEqual(message, '')
+
+    def test_is_private_ip_for_literal_addresses(self):
+        for private in ['127.0.0.1', '10.0.0.1', '192.168.1.1', '169.254.169.254', '::1']:
+            with self.subTest(ip=private):
+                self.assertTrue(is_private_ip(private))
+        for public in ['1.1.1.1', '8.8.8.8']:
+            with self.subTest(ip=public):
+                self.assertFalse(is_private_ip(public))

--- a/scripts/validate/links.py
+++ b/scripts/validate/links.py
@@ -3,7 +3,10 @@
 import re
 import sys
 import random
+import ipaddress
+import socket
 from typing import List, Tuple
+from urllib.parse import urlparse
 
 import requests
 from requests.models import Response
@@ -149,6 +152,57 @@ def has_cloudflare_protection(resp: Response) -> bool:
     return False
 
 
+def _is_ip_literal(value: str) -> bool:
+    """Return True if `value` is already an IP address rather than a hostname."""
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_non_public_ip(ip: str) -> bool:
+    """Return True if `ip` is a valid address that is not globally routable
+    (private, loopback, link-local, reserved, ...)."""
+    try:
+        return not ipaddress.ip_address(ip).is_global
+    except ValueError:
+        return False
+
+
+def is_private_ip(hostname: str) -> bool:
+    """Return True if `hostname` is, or resolves to, a non-public IP address.
+
+    Acts as an SSRF guard for the link checker: a URL whose host points at an
+    internal address is refused before it is fetched. A DNS failure is treated
+    as *not* private, so an unreachable host still surfaces as a normal request
+    error rather than being mislabelled.
+    """
+    try:
+        candidates = (
+            [hostname]
+            if _is_ip_literal(hostname)
+            else [info[4][0] for info in socket.getaddrinfo(hostname, None)]
+        )
+    except socket.gaierror:
+        return False
+    return any(_is_non_public_ip(ip) for ip in candidates)
+
+
+def validate_url(link: str) -> Tuple[bool, str]:
+    """Return (has_error, message) for a link, guarding against SSRF.
+
+    A link is rejected before any request is made when its scheme is not
+    HTTP(S) or when its host is not publicly routable.
+    """
+    parsed = urlparse(link)
+    if parsed.scheme not in ('http', 'https'):
+        return (True, f'ERR:URL: unsupported scheme "{parsed.scheme}" : {link}')
+    if is_private_ip(parsed.hostname or ''):
+        return (True, f'ERR:URL: non-public host : {link}')
+    return (False, '')
+
+
 def check_if_link_is_working(link: str) -> Tuple[bool, str]:
     """Checks if a link is working.
 
@@ -160,8 +214,9 @@ def check_if_link_is_working(link: str) -> Tuple[bool, str]:
     first value False and the second an empty string.
     """
 
-    has_error = False
-    error_message = ''
+    has_error, error_message = validate_url(link)
+    if has_error:
+        return (has_error, error_message)
 
     try:
         resp = requests.get(link, timeout=25, headers={


### PR DESCRIPTION
> Note: this is a security fix to the repository's CI tooling (`scripts/`), **not** an API list addition — so the list-entry checklist in the PR template does not apply here.

## What

Add scheme + private-IP validation to the link checker (`scripts/validate/links.py`) so it refuses to request non-`http(s)` URLs or hosts that resolve to private / reserved / loopback / link-local addresses.

## Why

`check_if_link_is_working()` passes each README URL straight to `requests.get()`. Because anyone can open a PR adding an entry, a URL such as `http://169.254.169.254/latest/meta-data/` or `http://127.0.0.1/` would make the CI runner issue a request to an internal address — a server-side request forgery (SSRF) vector.

This is defense-in-depth hardening of the CI tooling: it removes the obvious SSRF surface (internal IPs and non-HTTP schemes). It is not a full DNS-rebinding mitigation, since `requests.get()` re-resolves the host afterward — but it closes the direct case reachable via a pull request.

## Change

- `validate_url()` rejects unsupported URL schemes and blocks hostnames whose literal or resolved IPs are private/reserved/loopback/link-local, before any request is made.
- `check_if_link_is_working()` calls it first and short-circuits with an `ERR:URL:` message.
- No behavior change for the legitimate public `https` API links already in the list.

## Testing

- Added cases in `scripts/tests/test_validate_links.py`: blocked schemes, blocked private/reserved IPs (including cloud-metadata `169.254.169.254`), allowed public URLs, and `is_private_ip`. They use literal IPs, so they require no network access.
- Full suite green — `cd scripts && python -m unittest discover tests/`:

```
Ran 35 tests in 0.002s

OK
```
