### PR TITLE
Add Zillapi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
+| [Zillapi](https://zillapi.com) | US property data API — Zestimate, photos, taxes, price history | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds Zillapi to the Business section.

- **API**: [Zillapi](https://zillapi.com) — US property data API (Zestimate, photos, taxes, price history)
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes (verified via `OPTIONS` preflight against the API, `Access-Control-Allow-Origin: *`)

One link added, alphabetically placed at the end of the Business table. Free tier available, no credit card required.