### PR TITLE
Add ChronoVerify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Botd](https://github.com/fingerprintjs/botd) | Botd is a browser library for JavaScript bot detection | `apiKey` | Yes | Yes |
 | [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | Bugcrowd API for interacting and tracking the reported issues programmatically | `apiKey` | Yes | Unknown |
 | [Censys](https://search.censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
+| [ChronoVerify](https://chronoverify.com/method) | Image capture time and provenance verification: C2PA Content Credentials, EXIF, pixel forensics | No | Yes | No |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds ChronoVerify to the Security section (alphabetical order preserved).

ChronoVerify is an image capture time and provenance verification API: it reads EXIF and XMP, cryptographically validates C2PA Content Credentials against the official trust lists, and runs classical pixel forensics, returning one plain-language verdict. The public endpoint is free and requires no authentication or signup (`curl -X POST https://chronoverify.com/v1/verify -F "url=..."`); a free API key (no card) is also available for individual quota. It is provenance validation, not a deepfake detector.

- Docs: https://chronoverify.com/method
- OpenAPI: https://chronoverify.com/openapi.json
- Auth: No (keyless public path; optional bearer key for metering)
- HTTPS: Yes, CORS: No

Checklist: entry follows the table format, description is under 100 characters, one link in this PR, alphabetical order kept, no duplicate (searched existing entries and PRs).