### PR TITLE
Add Crypto Fear & Greed Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CoinStats](https://documenter.getpostman.com/view/5734027/RzZ6Hzr3?version=latest) | Crypto Tracker | No | Yes | Unknown |
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | Cryptocurrency data | No | Yes | Unknown |
+| [Crypto Fear & Greed Index](https://qiaobax.com/tools/fear-greed-index/) | Free, transparent crypto market sentiment index, no key required | No | Yes | Yes |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
 | [Cryptonator](https://www.cryptonator.com/api/) | Cryptocurrencies Exchange Rates | No | Yes | Unknown |


### PR DESCRIPTION
Adds a free, transparent Crypto Fear & Greed Index API to the Cryptocurrency section.

- No API key required
- HTTPS: Yes
- CORS: Yes (`Access-Control-Allow-Origin: *`)
- Methodology is fully public: https://qiaobax.com/tools/fear-greed-index/
- Source code: https://github.com/wobuliangren/crypto-fear-greed-index

Inserted in alphabetical order in the Cryptocurrency table.