### PR TITLE
Add UnoRouter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
+| [UnoRouter](https://unorouter.com) | OpenAI-compatible gateway routing chat/completions across 200+ models with a free model tier | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
 


### PR DESCRIPTION
Adds UnoRouter to the Machine Learning section.

UnoRouter is an OpenAI-compatible LLM gateway that routes chat/completions across 200+ models behind one key, with a free model tier (no purchase required to use the free models).

- Auth: `apiKey`
- HTTPS: Yes
- CORS: Yes (verified: `access-control-allow-origin: *`, OPTIONS preflight returns 204)
- Free tier: 159 free models plus guest access

Inserted alphabetically in Machine Learning. Single squashed commit.

Replaces #6256 (stale branch had accumulated unrelated upstream commits and merge conflicts); this is a clean single-line add off current master.