### PR TITLE
Add Proxmint Free Proxies to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ API | Description | Auth | HTTPS | CORS |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [Proxmint Free Proxies](https://proxmint.com/free-proxies#api) | Free live-tested proxy list (HTTP/HTTPS/SOCKS4/SOCKS5), revalidated every 30 min, JSON or txt | No | Yes | Yes |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyForge](https://proxyforge.dev) | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h | No | Yes | Yes |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add Proxmint Free Proxies to Development section

A free, key-free API over a list of live-tested public proxies — HTTP, HTTPS,
SOCKS4, SOCKS5 — revalidated every 30 minutes. Filterable by country, protocol
and anonymity; returns JSON, or plain `ip:port` lines with `?format=txt`.

| Field | Value |
|---|---|
| API | [Proxmint Free Proxies](https://proxmint.com/free-proxies#api) |
| Description | Free live-tested proxy list (HTTP/HTTPS/SOCKS4/SOCKS5), revalidated every 30 min, JSON or txt |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

No API key or signup; rate limited to 60 requests/minute per IP. Docs and example
requests are on the linked page. Placed alphabetically between Postman and
ProxyCrawl in the Development section.

Note: this PR originally proposed a different Proxmint endpoint (an IP geolocation
API). It has been rebased onto current `master` and now proposes only the free
proxy list — one link, one commit.
