### PR TITLE
Add Hushvert file conversion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
+| [Hushvert](https://hushvert.com/for-developers) | Privacy-first file conversion: office to PDF, PDF to Word, images, media; free tier | `apiKey` | Yes | Yes |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
 | [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth` | Yes | Unknown |
 | [Mattermost](https://api.mattermost.com/) | An open source platform for developer collaboration | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds **Hushvert** to `Documents & Productivity`, inserted alphabetically between Html2PDF and iLovePDF.

- Description under 100 characters
- Auth: `apiKey`
- HTTPS: Yes
- CORS: Yes (verified `access-control-allow-origin: *` on https://hushvert.com/api/v1/formats)

Hushvert is a file-conversion API (office to PDF, PDF to Word, images, media) with a free tier, in the same category as the existing CloudConvert and iLovePDF entries.

Disclosure: I maintain hushvert.
