### PR TITLE
Add Bolsai API

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
+| [Bolsai](https://usebolsai.com/docs) | Brazilian stock market fundamentals, prices, dividends, and FII data from B3, CVM and BCB | `apiKey` | Yes | No | |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adds Bolsai, a REST API for Brazilian stock market data (fundamentals, prices, dividends, and FII data), sourced from B3, CVM, and BCB. Free tier available.

- Docs: https://usebolsai.com/docs
- Added under Finance, alphabetically between Boleto.Cloud and BriefTape.