### PR TITLE
Add ByKaranteli API

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ API | Description | Auth | HTTPS | CORS |
 | [btcnode.uk](https://btcnode.uk) | Bitcoin blockchain data, fees, mempool, SEC insider trades, Reddit sentiment. x402 micropayments for paid endpoints. | No | Yes | Unknown |
 | [BtcTurk](https://docs.btcturk.com/) | Real-time cryptocurrency data, graphs and API that allows buy&sell | `apiKey` | Yes | Yes |
 | [Bybit](https://bybit-exchange.github.io/docs/linear/#t-introduction) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |
+| [ByKaranteli](https://bykaranteli.com/developers) | Crypto derivatives data: funding rates, open interest, liquidation maps, ETF flows and Fear & Greed | No | Yes | Yes |
 | [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
 | [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
 | [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds ByKaranteli to the Cryptocurrency section.

Free, no-key JSON API for crypto derivatives data: cross-exchange funding rates, open interest, liquidation maps, Fear & Greed, BTC dominance and signal outcomes. Self-describing endpoint catalog at `/api/v1/public/manifest`, docs at https://bykaranteli.com/developers

- Auth: `No` (no key, no signup)
- HTTPS: `Yes`
- CORS: `Yes` (verified: `access-control-allow-origin: *` on the public endpoints)
- Description length: 97 characters

Updated after review of CONTRIBUTING: the branch is rebased onto current `master` and squashed to a single commit, the description is now under the 100-character limit, and the entry sits in alphabetical order directly after `Bybit`.