### PR TITLE
Add TmpState API

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Talordata](https://docs.talordata.com/) | SERP data from major search engines with a free trial | `apiKey` | Yes | Unknown |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
+| [TmpState](https://tmpstate.dev/llms.txt) | Temporary JSON database from one curl for agents and prototypes | No | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds TmpState to the Development section.

Disclosure: I built TmpState.

Why it qualifies:
- Free tier with no signup and no API key.
- HTTPS API with CORS enabled.
- Public documentation is linked in the entry.