### PR TITLE
Add AlphaAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
+| [AlphaAI](https://alphai.io/developers) | Financial news with per-ticker relevance score (1-10), category, and SEC Form 4 insider data | `apiKey` | Yes | Unknown |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds **AlphaAI** to the **Finance** category.

- **What it is:** financial news pre-analyzed at ingest — every article gets a per-ticker relevance score (1–10), a category, and impact analysis; SEC Form 4 insider filings are included as structured data. Available as a REST API and an MCP server.
- **Free tier, no card:** 20 requests/min and 100 requests/day — a real evaluation tier, not a trial.
- **Auth** `apiKey` (Bearer token) · **HTTPS** Yes · **CORS** Unknown.
- Docs & live playground: https://alphai.io/developers · OpenAPI 3.1 spec: https://api.alphai.io/api/schema/

Follows the contributing guidelines: single new entry, placed alphabetically in Finance (after Alpha Vantage), description ≤100 chars with no trailing punctuation, auth value from the accepted set.