### PR TITLE
Add WhatsUsernames.link API

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
+| [WhatsUsernames.link](https://whatsusernames.link/developers) | Generate WhatsApp links, QR codes, and Business Platform BSUID tools | No | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 
 


### PR DESCRIPTION
Adds a free, keyless REST API for generating WhatsApp username/phone links and QR codes, plus WhatsApp Business Platform (BSUID) tools — no auth required, HTTPS, CORS enabled.

Docs: https://whatsusernames.link/developers
OpenAPI 3.1 spec: https://whatsusernames.link/api/v1/openapi.json

Added to Development, alphabetical order preserved.