### PR TITLE
Correct InfraNode Auth: No (keyless), was apiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,7 +1384,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
-| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
+| [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | No | Yes | Unknown |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
 | [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
One-line correction to the existing **InfraNode** entry under *Open Data*.

InfraNode is a keyless public API (no API key, no account). The entry currently lists Auth as `apiKey`, which is incorrect. Corrected to `No`.

- [x] Single existing entry corrected, no new entry
- [x] Description unchanged, under 100 chars, no trailing period
- [x] Link works and uses HTTPS
- [x] Format matches the guidelines