### PR TITLE
Add Cambio Uruguay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ API | Description | Auth | HTTPS | CORS |
 | [1Forge](https://1forge.com/forex-data-api/api-documentation) | Forex currency market data | `apiKey` | Yes | Unknown |
 | [Amdoren](https://www.amdoren.com/currency-api/) | Free currency API with over 150 currencies | `apiKey` | Yes | Unknown |
 | [Bank of Russia](https://www.cbr.ru/development/SXML/) | Exchange rates and currency conversion | No | Yes | Unknown |
+| [Cambio Uruguay](https://cambio-uruguay.com) | Real-time buy/sell rates from every Uruguayan exchange house, with conversion and history | No | Yes | Yes |
 | [Currency-api](https://github.com/fawazahmed0/currency-api#readme) | Free Currency Exchange Rates API with 150+ Currencies & No Rate Limits | No | Yes | Yes |
 | [CurrencyFreaks](https://currencyfreaks.com/) | Provides current and historical currency exchange rates with free plan 1K requests/month | `apiKey` | Yes | Yes |
 | [CurrencyScoop](https://currencyscoop.com/api-documentation) | Real-time and historical currency rates JSON API | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **Cambio Uruguay** to the **Currency Exchange** category.

| Field | Value |
|---|---|
| API | https://api.cambio-uruguay.com |
| Site | https://cambio-uruguay.com |
| Auth | No (no key, no account) |
| HTTPS | Yes |
| CORS | Yes (`Access-Control-Allow-Origin: *`) |

A free, no-auth REST API that aggregates **real-time buy/sell exchange rates from every Uruguayan casa de cambio (exchange house)**, plus currency conversion and historical rate series. Returns JSON.

Guidelines check:
- [x] Free, full public access — no API key, no account, no device purchase
- [x] Added to the **Currency Exchange** section in alphabetical order (after *Bank of Russia*)
- [x] Entry follows the `| [Title](link) | Description | Auth | HTTPS | CORS |` format
- [x] Description under 100 characters, no trailing punctuation, no "... API" in title
- [x] One entry, one category