### PR TITLE
Add DNSai API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1598,6 +1598,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
+| [DNSai](https://dnsai.com/api/) | DNS intelligence and email security lookups (DNS, WHOIS, SPF, DKIM, DMARC, blacklists) | `apiKey` | Yes | Unknown |
 | [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |


### PR DESCRIPTION
DNSai adds a few things the existing lookup tools in this section don't cover: DKIM selector discovery (finds a domain's signing keys without knowing selector names), SPF analysis with the 10-DNS-lookup limit check, plain-English interpretation of results aimed at non-experts, and a free API plus MCP server so the same checks run inside AI assistants. All basic lookups are free with no signup or ads.

Disclosure: I'm the founder of DNSai. Happy to adjust wording or placement, and no hard feelings if it's not a fit for the list.
