### PR TITLE
Update Goldprice.dev description

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
-| [Goldprice.dev](https://goldprice.dev/docs) | Cross-validated gold, silver & copper spot, futures & 30-year history in 13 currencies | No | Yes | Unknown | |
+| [Goldprice.dev](https://goldprice.dev/docs) | Gold, silver & copper spot, futures, dealer prices, options-probability surface; 31 currencies | No | Yes | Unknown | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 75+ countries with 121K+ bank entries | No | Yes | Yes |


### PR DESCRIPTION
The Goldprice.dev entry's description was stale: it said "13 currencies" (actually 31) and didn't mention two products the API has since added (per-country physical dealer prices, and an options/prediction-market probability surface). This PR updates the description text only — name, link, Auth, HTTPS, and CORS columns are unchanged.