### PR TITLE
Add Commodity to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,6 +1381,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
+| [Commodity](https://c0mm0.com) | Continuously verified catalog of official European public-sector APIs and datasets | No | Yes | Yes |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds **Commodity** (https://c0mm0.com) to the **Open Data** section — a continuously verified catalog of official European public-sector APIs and datasets. Every entry is uptime-checked every 15 minutes and re-verified every 6 hours; the API is free, requires no key, supports CORS, and serves machine-readable formats (OpenAPI 3.1, DCAT-AP, bulk JSON/CSV export, CC0-licensed nightly snapshots).

- API docs: https://c0mm0.com/openapi.json
- Example: `https://c0mm0.com/api/v1/entries?country_code=FR&type=API`

## Checklist

- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
