### PR TITLE
Add VAT Sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ API | Description | Auth | HTTPS | CORS |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |
+| [VAT Sense](https://vatsense.com) | UK, EU & global VAT number validation, VAT/GST rates, currency conversion and VAT invoicing | `apiKey` | Yes | No |
 | [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds [VAT Sense](https://vatsense.com) to the Currency Exchange section (alongside the existing VAT APIs TaxID and VATComply).

**What it does:** VAT number validation against official government sources (VIES for the EU, HMRC for the UK, plus Australia, Norway, Switzerland, South Africa and Brazil), VAT/GST rates for 179 countries including product-type rates, currency conversion using HMRC and ECB rates, and VAT-compliant invoicing.

**Checklist:**
- Free tier: 100 requests/month, no credit card required
- HTTPS: yes (256-bit SSL on all plans)
- Auth: `apiKey` (HTTP Basic Auth)
- CORS: no (server-side API)
- Placed in alphabetical order within the section
- Description under 100 characters