### PR TITLE
Add Dino Markets API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1718,6 +1718,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Yes | Unknown |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes | Yes |
 | [CollegeFootballData.com](https://collegefootballdata.com) | Unofficial detailed American college football statistics, records, and results API | `apiKey` | Yes | Unknown |
+| [Dino Markets](https://dino.markets/docs) | Cross-venue sports prediction-market data: Kalshi and Polymarket matched, live arb, free tier | `apiKey` | Yes | No |
 | [DiscGolf](https://discgolfapi.com/docs/) | Structured disc golf course data | No | Yes | Yes |
 | [Ergast F1](http://ergast.com/mrd/) | F1 data from the beginning of the world championships in 1950 | No | Yes | Unknown |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds Dino Markets to Sports & Fitness.

Real-time cross-venue sports prediction-market data — matches the same games across Kalshi and Polymarket, computes the live arbitrage between the two venues, and serves it over REST + WebSocket. Free tier included (60 req/min, no card).

- [x] Alphabetical order maintained (inserted between CollegeFootballData.com and DiscGolf)
- [x] Description under 100 characters
- [x] One link per PR
- [x] Auth/HTTPS/CORS columns verified against the live API