### PR TITLE
Add BORME API to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
+| [BORME API](https://api.bormeapi.com/docs) | Spain's official company registry (BORME) as typed English JSON events | `apiKey` | Yes | No |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |


### PR DESCRIPTION
Adds **BORME API** — Spain's official company registry (BORME gazette) as typed English JSON: incorporations, director changes, insolvencies. 9.5M events since 2009, updated every business day.

- Docs: https://api.bormeapi.com/docs (OpenAPI/Swagger)
- Auth: `apiKey` (free tier available)
- HTTPS: yes; CORS: no
- Source: official boe.es open data

Checklist:
- [x] Alphabetical order within the category
- [x] Description under 100 characters
- [x] Docs link goes to API documentation