### PR TITLE
Add CSIRTS (security advisories API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,6 +1596,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
+| [CSIRTS](https://www.csirts.com/about) | Security advisories from 21 national CERTs and vendor PSIRTs with CISA KEV and exploit status | No | Yes | Yes |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
 | [Domain Intelligence](https://oti-labs.com/domain-intelligence-api) | DNS, WHOIS/RDAP, SSL, subdomain enumeration, and email security in one parallel call | `apiKey` | Yes | No |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Adds [CSIRTS](https://www.csirts.com/about) to the Security section: a free, keyless JSON API over security advisories aggregated from 21 national CERTs and vendor PSIRTs (CISA, CERT-EU, CERT-Bund, CERT-FR, JPCERT/CC, MSRC, Cisco, Fortinet, …), normalized and English-translated, with CISA KEV and public-exploit-availability flags per CVE. HTTPS, CORS `*`, OpenAPI 3.1 spec at https://www.csirts.com/api/openapi.json.