### PR TITLE
Add Rope Drop News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |
 | [PotterDB](https://docs.potterdb.com/) | Harry Potter universe database with characters, spells, potions and more | No | Yes | Yes |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
+| [Rope Drop News](https://ropedropnews.com/developers) | Live Disney and Universal theme park wait times, ride reliability, crowds, and Lightning Lane prices | No | Yes | No |
 | [TasteDive](https://tastedive.com/read/api) | Content-based recommendations for movies, music, TV shows, books, games, and podcasts | `apiKey` | Yes | No |
 | [Techy](https://techy-api.vercel.app/) | JSON and Plaintext API for tech-savvy sounding phrases | No | Yes | Unknown |
 | [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2) | REST API for Yo Momma Jokes | No | Yes | Unknown |


### PR DESCRIPTION
Adds Rope Drop News to the Entertainment category.

Rope Drop News publishes free, first-party live theme-park data for Walt Disney World, Disneyland, and Universal Epic Universe: wait times, ride reliability, crowd levels, and Lightning Lane prices. Served as anonymous JSON feeds and CC BY 4.0 CSV datasets over HTTPS.

- Docs: https://ropedropnews.com/developers
- Auth: No, HTTPS: Yes, CORS: No
- Free and open, no API key required.