### PR TITLE
Add Seed Oil Tracker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PunkAPI](https://punkapi.com/) | Brewdog Beer Recipes | No | Yes | Unknown |
 | [RecipeAPI](https://recipeapi.io) | Recipes, ingredients, nutrition data and cooking instructions | `apiKey` | Yes | Yes |
 | [Rustybeer](https://rustybeer.herokuapp.com/) | Beer brewing tools | No | Yes | No |
+| [Seed Oil Tracker](https://seedoiltracker.com/ai-tool) | Seed-oil/PUFA grades and cooking oil data for 512 US restaurant chains | No | Yes | Yes |
 | [Spoonacular](https://spoonacular.com/food-api) | Recipes, Food Products, and Meal Planning | `apiKey` | Yes | Unknown |
 | [Systembolaget](https://api-portal.systembolaget.se) | Govornment owned liqour store in Sweden | `apiKey` | Yes | Unknown |
 | [TacoFancy](https://github.com/evz/tacofancy-api) | Community-driven taco database | No | No | Unknown |


### PR DESCRIPTION
Adds Seed Oil Tracker to Food & Drink.

- Free, no key required
- HTTPS: yes
- CORS: yes (verified via response headers, access-control-allow-origin: *)
- Docs: https://seedoiltracker.com/ai-tool
- OpenAPI 3.1 spec: https://seedoiltracker.com/ai-tool/openapi.json

API grades 512 US restaurant chains by seed-oil / PUFA (polyunsaturated fat) content, returns each chain's cooking oil and cleanest menu picks. Endpoints: GET /ai/chain?name=, GET /ai/search?q=, GET /ai/rankings.