### PR TITLE
Add Validate API to Data Validation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Data Validation
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [Validate](https://rapidapi.com/jonashaemecommerce/api/validate7) | IBAN, VAT, email, disposable-email, phone, credit card, and postal code validation | `apiKey` | Yes | Unknown |
 | [VATlayer](https://vatlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | VAT number validation | `apiKey` | Yes | Unknown | |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |


### PR DESCRIPTION
Adds Validate (IBAN, VAT, email, disposable-email, phone, credit card, and postal code validation API) to the Data Validation category, per CONTRIBUTING.md guidelines. Free tier available, no card required.