### PR TITLE
Add Mansa API

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
+| [Mansa](https://mansaapi.com/docs) | African financial data: stock markets, licensed banks, SWIFT codes, currencies, holidays | `apiKey` | Yes | Yes | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
-| [Mansa](https://mansaapi.com/docs) | African financial data: stock markets, licensed banks, SWIFT codes, currencies, holidays | `apiKey` | Yes | Yes | |
+| [Mansa](https://mansaapi.com/docs) | African financial data: stock markets, licensed banks, SWIFT codes, currencies, holidays | `apiKey` | Yes | Unknown | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
-| [Mansa](https://mansaapi.com/docs) | African financial data: stock markets, licensed banks, SWIFT codes, currencies, holidays | `apiKey` | Yes | Unknown | |
+| [Mansa](https://mansaapi.com/docs) | African financial data: stock markets, licensed banks, SWIFT codes, currencies, holidays | `apiKey` | Yes | No | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## What does this PR do?
Adds **Mansa** to the Finance section.

Mansa API (mansaapi.com) provides African financial data: live stock market data from 21 African exchanges, the licensed-bank registry for 22 countries (verified against central-bank registers, incl. SWIFT/BIC codes), currencies, mobile networks, and public holidays for 53 African countries.

- Docs: https://mansaapi.com/docs
- OpenAPI: https://mansaapi.com/openapi.json
- Auth: apiKey (free tier, no card required)
- Alphabetical order preserved (before MercadoPago)

🤖 Generated with [Claude Code](https://claude.com/claude-code)