### PR TITLE
Add PocketWorld API to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |
 | [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
+| [PocketWorld](https://pocketworld.org/api) | Live earth data including flights, ships, satellites, weather and disasters | No | Yes | Yes |
 | [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |
 | [Solematica](https://www.solematica.it/sviluppatori) | Compare Italian solar (photovoltaic) installer offers, energy prices (PUN/ARERA) and satellite roof data | No | Yes | No |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |


### PR DESCRIPTION
## Add PocketWorld API

**Description:** Live earth data including flights, ships, satellites, weather and disasters

| Field | Value |
|-------|-------|
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| Category | Environment |

**API Docs:** https://pocketworld.org/api

- Free, no API key required
- 50+ JSON endpoints with live planetary data from NASA, NOAA, USGS
- CORS enabled (Access-Control-Allow-Origin: *)
- No account/signup needed