### PR TITLE
Add WhatsTrending.ai API to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,6 +1294,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
+| [WhatsTrending.ai](https://whatstrending.ai/docs) | AI model usage leaderboard, AI news, trending AI repos and funding data | No | Yes | Yes |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

Adds WhatsTrending.ai: a free, no-key REST API for AI ecosystem data - model usage leaderboard (ranked by OpenRouter token volume, with live pricing and context windows), AI news feed, trending AI repos, and funding data. No auth, HTTPS, CORS enabled on all endpoints. Docs with live examples: https://whatstrending.ai/docs
