### PR TITLE
Add Remote OpenClaw API

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey` | Yes | No |
+| [Remote OpenClaw](https://www.remoteopenclaw.com/api) | Directory of 13,000+ MCP servers, AI agent skills and plugins | No | Yes | Yes |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |
 | [SavePage.io](https://www.savepage.io) | A free, RESTful API used to screenshot any desktop, or mobile website | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds Remote OpenClaw to the Development section, in alphabetical order.

Remote OpenClaw is a free directory of 13,000+ MCP servers, AI agent skills and plugins. The API is keyless (Auth: No), served over HTTPS, CORS enabled, and returns JSON. Docs and a live playground are at https://www.remoteopenclaw.com/api with an OpenAPI spec at https://www.remoteopenclaw.com/api/openapi.json.

- Description is under 100 characters
- One link, single-line change
- Follows the existing table format