### PR TITLE
Add Kiprio DNS, SSL, WHOIS, IP, FX, and BizDay APIs (batch 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
 | [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
 | [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
+| [Kiprio Bizday](https://kiprio.com/v1/bizday/) | UK business day calculator with bank holidays for England, Scotland, Northern Ireland | No | Yes | Yes |
 | [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
 | [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
 | [Namedays Calendar](https://nameday.abalin.net) | Provides namedays for multiple countries | No | Yes | Yes |
@@ -475,6 +476,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangerate.dev](https://exchangerate.dev/docs) | Live & historical FX, 168 pairs back to 1999, Frankfurter-compatible, free 10k/mo | No | Yes | Unknown |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
+| [Kiprio FX Rates](https://kiprio.com/v1/fx/) | Live foreign exchange rates for 150+ currency pairs with historical and multi-currency support | `apiKey` | Yes | Yes |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |
@@ -574,6 +576,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
 | [Keyvalue](https://keyvalue.immanuel.co/) | Simple key-value storage REST API for quick prototyping | No | Yes | Unknown |
+| [Kiprio DNS Lookup](https://kiprio.com/v1/dns-lookup/) | Query A, AAAA, MX, TXT, NS, CNAME DNS records for any domain. Structured JSON with TTLs | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
@@ -1047,6 +1050,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
 | [Kakao Maps](https://apis.map.kakao.com) | Kakao Maps provide multiple APIs for Korean maps | `apiKey` | Yes | Unknown |
 | [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
+| [Kiprio IP Lookup](https://kiprio.com/v1/ip-lookup/) | Geolocate any IP — country, region, city, ISP, timezone, coordinates | `apiKey` | Yes | Yes |
 | [Kiprio UK Postcode](https://kiprio.com/v1/postcode) | UK postcode lookup with lat/lon, district, ward, constituency | `apiKey` | Yes | Yes |
 | [LatLng](https://www.latlng.work/docs) | Geocoding, reverse geocoding, places, and static maps | No | Yes | Yes |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
@@ -1612,6 +1616,9 @@ API | Description | Auth | HTTPS | CORS |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
+| [Kiprio SSL Inspector](https://kiprio.com/v1/ssl/) | Inspect SSL/TLS certificates — expiry, issuer, SANs, protocol, cipher suite, security grade | `apiKey` | Yes | Yes |
+| [Kiprio WHOIS Lookup](https://kiprio.com/v1/whois/) | Look up domain WHOIS data — registrar, dates, nameservers, status codes | `apiKey` | Yes | Yes |
+| [Kiprio WHOIS Monitor](https://kiprio.com/v1/whois-monitor/) | Monitor domain expiry dates. Watch list with 90/30/7 day email alerts before expiry | `apiKey` | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |


### PR DESCRIPTION
Adding 7 free APIs from kiprio.com to complement the 3 already listed (Email Validate, UK Postcode, Translate).

All APIs:
- ✅ Have free tiers with no credit card required
- ✅ Return JSON from publicly accessible demo endpoints
- ✅ HTTPS enabled, CORS enabled
- ✅ Stable production endpoints (kiprio.com hosted on 99.99% uptime cPanel)

New additions:
1. **Bizday** (Calendar) — UK business day calculator with bank holidays for England, Scotland, Northern Ireland
2. **FX Rates** (Currency Exchange) — Live foreign exchange rates for 150+ currency pairs
3. **DNS Lookup** (Development) — Query A, AAAA, MX, TXT, NS, CNAME DNS records
4. **IP Lookup** (Geocoding) — Geolocate any IP with country, region, city, ISP, timezone
5. **SSL Inspector** (Security) — Inspect SSL/TLS certificates: expiry, issuer, SANs, protocol, cipher suite
6. **WHOIS Lookup** (Security) — Domain WHOIS registration data
7. **WHOIS Monitor** (Security) — Domain expiry monitoring with 90/30/7 day email alerts

Each API has been verified to return valid JSON from its demo endpoint.