### PR TITLE
Add ThreatActorUsernames API to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1624,6 +1624,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SecurityTrails](https://securitytrails.com/corp/apidocs) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
+| [Threat Actor Usernames](https://threatactorusernames.com/docs) |  Search through 3M+ threat actor usernames and find where they operate | No | Yes | Unknown
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [URLhaus](https://urlhaus.abuse.ch/api/) | Database of malicious URLs used for malware distribution | `No` | Yes | Unknown |


### PR DESCRIPTION
Add

|[Threat Actor Usernames](https://threatactorusernames.com/docs)  API to the Security section


- Adds exactly one API.
- Placed alphabetically
- Free tier (no key required); HTTPS; JSON responses.
- Description is under 100 characters.
- Threat Actor Usernames lets anyone search through 3M+ threat actor usernames and find where they operate and post online
