### PR TITLE
Add Snapshot Site API

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
 | [SiteIntel](https://siteintel.duckdns.org) | Extract metadata, tech stack, emails, and screenshots from any URL | `apiKey` | Yes | Unknown |
+| [Snapshot Site](https://snapshot-site.com) | Screenshot API with full-page capture, visual diff and AI webpage analysis | `apiKey` | Yes | Unknown |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |
 | [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Add Snapshot Site API

**Category:** Development

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [Snapshot Site](https://snapshot-site.com) | Screenshot API with full-page capture, visual diff and AI webpage analysis | `apiKey` | Yes | Unknown |

- Free tier: 50 requests/month, no credit card required
- Docs: https://snapshot-site.com/api-docs
- Follows the entry format: alphabetical order (after SiteIntel), description under 100 characters, one link per PR

Thank you for maintaining this list!