### PR TITLE
Add Kiprio SSL Inspector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,7 @@ API | Description | Auth | HTTPS | CORS |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
+| [Kiprio SSL Inspector](https://kiprio.com/v1/ssl) | Inspect SSL/TLS certificates: expiry, issuer, protocol, cipher suite | `apiKey` | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Kiprio SSL Inspector](https://kiprio.com/v1/ssl) to the Security section.

- Inspects SSL/TLS certificates for any domain: expiry date, issuer, protocol version, cipher suite, and security grade
- Free tier available (sign up for API key)
- HTTPS: Yes, CORS: Yes
- Auth: `apiKey` (X-API-Key header)