### PR TITLE
Add Andaman Ferry Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1840,6 +1840,7 @@ API | Description | Auth | HTTPS | CORS |
 | [airportsapi](https://airport-web.appspot.com/api/docs/) | Get name and website-URL for airports by ICAO code | No | Yes | Unknown |
 | [AIS Hub](http://www.aishub.net/api) | Real-time data of any marine and inland vessel equipped with AIS tracking system | `apiKey` | No | Unknown |
 | [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth` | Yes | Unknown |
+| [Andaman Ferry Data](https://www.bookyourferry.com/andaman-ferry-data) | Inter-island ferry operators, routes, fares and schedules for India's Andaman Islands | No | Yes | Yes |
 | [apilayer aviationstack](https://aviationstack.com/) | Real-time Flight Status & Global Aviation Data API | `OAuth` | Yes | Unknown |
 | [Apimetro](https://apimetro.dev/swagger/index.html) | Geospatial data for Mexico City public transport system (Metro, Metrobús, Cablebús, RTP, etc.) | No | Yes | Yes |
 | [AviationAPI](https://docs.aviationapi.com) | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather | No | Yes | No |


### PR DESCRIPTION
Adds **Andaman Ferry Data** to the Transportation section.

Free, no-auth JSON endpoints (HTTPS + CORS-enabled) for inter-island passenger ferry services in India's Andaman & Nicobar Islands — operators, routes, fares, schedules and cancellation policies. Docs and raw endpoints: https://www.bookyourferry.com/andaman-ferry-data

- **Auth:** No
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **License:** CC-BY 4.0 (open data)

Openly licensed reference data, free to use with no key — in line with the existing **BC Ferries** entry already in this section. Placed alphabetically (between *Amadeus for Developers* and *apilayer aviationstack*); description is 85 characters.

Checklist:
- [x] One API added, in the most appropriate section (Transportation)
- [x] Alphabetical order maintained
- [x] Description under 100 characters, no trailing period
- [x] Auth / HTTPS / CORS use accepted values
- [x] Link resolves (HTTP 200) and points to the API docs page
- [x] No TLD in the API name
