### PR TITLE
Add Kiprio Bizday API

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
 | [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
 | [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
+| [Kiprio Bizday](https://kiprio.com/v1/bizday/) | UK business day calculator — next/prev business days, bank holidays for England, Scotland, Northern Ireland | No | Yes | Yes |
 | [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
 | [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
 | [Namedays Calendar](https://nameday.abalin.net) | Provides namedays for multiple countries | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
 | [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
 | [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
-| [Kiprio Bizday](https://kiprio.com/v1/bizday/) | UK business day calculator — next/prev business days, bank holidays for England, Scotland, Northern Ireland | No | Yes | Yes |
+| [Kiprio Bizday](https://kiprio.com/v1/bizday/) | UK business day calculator — next/prev business days, bank holidays for England, Wales, Scotland | No | Yes | Yes |
 | [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
 | [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
 | [Namedays Calendar](https://nameday.abalin.net) | Provides namedays for multiple countries | No | Yes | Yes |


### PR DESCRIPTION
## New API: Kiprio Bizday

Adding [Kiprio Bizday](https://kiprio.com/v1/bizday/) to the **Calendar** section.

| Field | Value |
|---|---|
| API Name | Kiprio Bizday |
| Category | Calendar |
| Description | UK business day calculator — next/prev business days, bank holidays for England, Scotland, Northern Ireland |
| Auth | No (free, no key required) |
| HTTPS | Yes |
| CORS | Yes |

Free, no API key required. Documentation and live examples at https://kiprio.com/v1/bizday/