### PR TITLE
Add Kiprio WHOIS Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
 | [Keyvalue](https://keyvalue.immanuel.co/) | Simple key-value storage REST API for quick prototyping | No | Yes | Unknown |
+| [Kiprio WHOIS Lookup](https://kiprio.com/v1/whois/) | Look up domain WHOIS data — registrar, creation/expiry dates, nameservers, status codes | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## New API: Kiprio WHOIS Lookup

Adding [Kiprio WHOIS Lookup](https://kiprio.com/v1/whois/) to the **Development** section.

| Field | Value |
|---|---|
| API Name | Kiprio WHOIS Lookup |
| Category | Development |
| Description | Look up domain WHOIS data — registrar, creation/expiry dates, nameservers, status codes |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | Yes |

Free tier (50 req/day, no credit card). Documented at https://kiprio.com/v1/whois/