### PR TITLE
Add endoflife.ai (software EOL dates & risk scores API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
+| [endoflife.ai](https://endoflife.ai/api) | Software end-of-life dates, support status and EOL Risk Scores for 460+ products | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |
 | [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |


### PR DESCRIPTION
## What does this PR do?

Adds **endoflife.ai** to the Development category.

- **API**: https://endoflife.ai/api (base URL https://api.endoflife.ai, OpenAPI spec at https://api.endoflife.ai/openapi.json)
- **What it provides**: end-of-life dates, support status, and 0-100 EOL Risk Scores for 460+ software products (Node.js, Python, Ubuntu, PostgreSQL, Kubernetes, ...)
- **Auth**: none required (anonymous 100 req/day; optional free key raises limits)
- **HTTPS**: yes · **CORS**: yes (`Access-Control-Allow-Origin: *`)

### Checklist
- [x] Entry is in alphabetical order within its category
- [x] Follows the `| API | Description | Auth | HTTPS | CORS |` format
- [x] API is free to use and publicly accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)