### PR TITLE
Add JobsPipe to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ API | Description | Auth | HTTPS | CORS |
 | [GraphQL Jobs](https://graphql.jobs/docs/api/) | Jobs with GraphQL | No | Yes | Yes |
 | [HeroHunt People Search](https://www.herohunt.ai/people-search-api) | Search 1 billion people profiles across LinkedIn and GitHub for talent sourcing | `apiKey` | Yes | Yes |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
+| [JobsPipe](https://jobspipe.dev/docs) | Aggregated job postings from 30+ ATS feeds and job boards, normalized into one schema | `apiKey` | Yes | Yes |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
 | [JobDataLake](https://www.jobdatalake.com/docs) | 1M+ enriched job listings from 20,000+ companies with salary, skills, seniority | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds JobsPipe to the Jobs section, in alphabetical order.

- Docs: https://jobspipe.dev/docs
- OpenAPI spec: https://jobspipe.dev/openapi.json
- Auth: `apiKey` (Bearer token)
- HTTPS: Yes
- CORS: Yes (verified via preflight; `Access-Control-Allow-Origin` echoes the request origin)
- Free tier: 100 requests/month

🤖 Generated with [Claude Code](https://claude.com/claude-code)