### PR TITLE
Add MyStars API

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
 | [Mexc](https://www.mexc.com/api-docs) | Cryptocurrency info, place order | `apiKey` | Yes | Unknown |
+| [MyStars](https://mystars.tg/docs) | Buy and resell Telegram Stars and Premium, paid in GRAM or USDT on TON | `apiKey` | Yes | Unknown |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds MyStars to the Cryptocurrency section.

MyStars is a public fulfilment API for buying and reselling Telegram Stars and Telegram Premium: request a price quote, check recipient eligibility for any Telegram @username, create an order and pay on-chain in GRAM or USDT on the TON network. Delivery is confirmed via signed webhooks.

The API key is free (issued in the Telegram bot, no signup form), the pricing and product endpoints are free to call, and official open-source SDKs are published under MIT for TypeScript and Python. Docs: https://mystars.tg/docs - OpenAPI 3.1 spec: https://mystars.tg/openapi.json

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit