### PR TITLE
Fix Lordicon description typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Icon Horse](https://icon.horse) | Favicons for any website, with fallbacks | No | Yes | Yes |
 | [Iconfinder](https://developer.iconfinder.com) | Icons | `apiKey` | Yes | Unknown |
 | [Icons8](https://img.icons8.com/) | Icons (find "search icon" hyperlink in page) | No | Yes | Unknown |
-| [Lordicon](https://lordicon.com/) | Icons with predone Animations | No | Yes | Yes |
+| [Lordicon](https://lordicon.com/) | Icons with pre-made animations | No | Yes | Yes |
 | [Metropolitan Museum of Art](https://metmuseum.github.io/) | Met Museum of Art | No | Yes | No |
 | [Noun Project](http://api.thenounproject.com/index.html) | Icons | `OAuth` | No | Unknown |
 | [PHP-Noise](https://php-noise.com/) | Noise Background Image Generator | No | Yes | Yes |


### PR DESCRIPTION
## Summary\n- Fix typo in Art & Design section (predone -> pre-made) for clarity.\n\n## Checklist\n- [x] Followed contribution guidelines.\n- [x] Maintains formatting/alignment of existing table rows.\n- [x] Single focused change.