### PR TITLE
Add London Strategic Edge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
+| [London Strategic Edge](https://github.com/londonstrategicedge/lse-data) | Free market data, 118,000 datasets: stocks, FX, crypto, options, futures, and websockets | `apiKey` | Yes | No | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds London Strategic Edge, free market data with 118,000 datasets across stocks, FX, crypto, options and futures, plus live websocket streaming. Free API key at londonstrategicedge.com/data.

- [x] One API addition, alphabetical order within Finance
- [x] Description under 100 characters
- [x] Free tier: yes (free API key, no purchase required)
- [x] HTTPS: yes
- [x] Searched existing PRs/issues for duplicates: none