### PR TITLE
Add ComparEdge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
+| [ComparEdge](https://comparedge.com/api-docs) | Verified pricing, plans, and hidden costs for 490+ SaaS, AI, and LLM tools | No | Yes | Yes |
 | [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey` | Yes | Yes |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |


### PR DESCRIPTION
Adds ComparEdge to the Development section (alphabetical order, after Codex).

ComparEdge is a free, no-key REST API for verified SaaS, AI, and LLM pricing across 490+ tools: plan-by-plan prices, hidden costs, and category positioning, each record dated and linked to the vendor source. OpenAPI 3.1 spec and docs at https://comparedge.com/api-docs.

Checklist:
- [x] My addition is in alphabetical order within its section.
- [x] Description is under 100 characters and does not begin with `A`/`An`.
- [x] Columns padded with one space on each side.
- [x] HTTPS: Yes, Auth: No, CORS: Yes.
- [x] Single API added in this PR.
- [x] Link is to the API docs, not a generic homepage.