### PR TITLE
Add Project Cost Estimator API to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ API | Description | Auth | HTTPS | CORS |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [Project Cost Estimator](https://projectcostestimator.com/api-docs) | Web project cost benchmarks by platform across 6 markets, CC BY 4.0 | No | Yes | Yes |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |
 | [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Project Cost Estimator to the **Development** section.

- **Auth:** No (open endpoint, no signup)
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **Docs:** https://projectcostestimator.com/api-docs
- **Endpoint:** https://projectcostestimator.com/api/cost-data (returns JSON)

The API returns web-project cost benchmarks by platform across 6 geographic markets, published under CC BY 4.0. It is free with no key required.

Checklist per CONTRIBUTING:
- One link added, alphabetical order kept (between Postman and ProxyCrawl)
- Description under 100 characters
- Columns padded with one space on either side
- Name does not include a TLD and does not end with `API`
- Targets the `master` branch