### PR TITLE
Add GridNews API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1374,6 +1374,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Florida Man](https://github.com/juliayxhuang/florida-man-api#readme) | Static JSON dataset of 10,000+ Florida Man headlines by date | No | Yes | Yes |
 | [GNews](https://gnews.io/) | Search for news from various sources | `apiKey` | Yes | Yes |
 | [Graphs for Coronavirus](https://corona.dnsforfamily.com/api.txt) | Each Country separately and Worldwide Graphs for Coronavirus. Daily updates | No | Yes | Yes |
+| [GridNews](https://gridnews.io) | Market news, press releases, and sentiment analysis tagged by ticker symbol | `apiKey` | Yes | Unknown |
 | [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API) | Provides news from inshorts | No | Yes | Unknown |
 | [MarketAux](https://www.marketaux.com/) | Live stock market news with tagged tickers + sentiment and stats JSON API | `apiKey` | Yes | Yes |
 | [New York Times](https://developer.nytimes.com/) | The New York Times Developer Network | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
### Description of the PR

Adds GridNews (https://gridnews.io) to the News category — a news API providing market news, press releases, and sentiment analysis tagged by ticker symbol. Free tier available via API key.

### Contributor License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the license found in the root directory of this repository's source tree, and I have the right to submit it under those terms.