### PR TITLE
Add BeachFinder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1736,6 +1736,7 @@ API | Description | Auth | HTTPS | CORS |
 | [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey` | Yes | Yes |
 | [ApiMedic](https://apimedic.com/) | ApiMedic offers a medical symptom checker API primarily for patients | `apiKey` | Yes | Unknown |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |
+| [BeachFinder](https://getbeachfinder.com/ai-search) | Search beaches, swim spots, conditions and water activities worldwide | No | Yes | No |
 | [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey` | Yes | No |
 | [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Yes | Unknown |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds BeachFinder to Sports & Fitness.

BeachFinder provides a free, unauthenticated HTTPS API for searching beaches, lakes and swim spots, checking planning conditions and discovering water activities worldwide.

## Validation

- Documentation: https://getbeachfinder.com/ai-search
- OpenAPI: https://getbeachfinder.com/openapi.json
- Live endpoint returns HTTP 200 JSON
- Authentication: none
- HTTPS: yes
- CORS: no, verified with a cross-origin request
- Description is under 100 characters and the entry is alphabetically placed
- No paid service or device purchase is required