### PR TITLE
Add MyIPRadar to Geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
 | [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No | Yes
 | [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |
+| [MyIPRadar](https://myipradar.com/api) | Public IP of the caller with geolocation, ISP/ASN and request headers | No | Yes | No |
 | [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/) | Provides worldwide forward / reverse geocoding | No | Yes | Yes |
 | [One Map, Singapore](https://www.onemap.gov.sg/docs/) | Singapore Land Authority REST API services for Singapore addresses | `apiKey` | Yes | Unknown |
 | [OnWater](https://onwater.io/) | Determine if a lat/lon is on water or land | No | Yes | Unknown |


### PR DESCRIPTION
## What does this PR do?
Adds **MyIPRadar** to the Geocoding section (alphabetical order).

- **API:** https://myipradar.com/api (endpoint: `https://myipradar.com/api/ip`)
- **Description:** Returns the caller's public IP with approximate geolocation, ISP/ASN and a safe echo of request headers, as JSON.
- **Auth:** No · **HTTPS:** Yes · **CORS:** No (server-side/scripts usage)
- Free, no key, rate-limited per IP (burst 60, refill 1/s). Only returns information about the caller — no arbitrary-IP lookups.

Docs page includes example request, sample response and limits: https://myipradar.com/api