### PR TITLE
Add Yingsuan AI: LLM API gateway with free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,6 +1317,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
+| [Yingsuan AI](https://yingsuan.top) | LLM API gateway with free tier (100 calls, 3 free models). OpenAI-compatible endpoint for DeepSeek, GLM, Qwen | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -1317,7 +1317,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
-| [Yingsuan AI](https://yingsuan.top) | LLM API gateway with free tier (100 calls, 3 free models). OpenAI-compatible endpoint for DeepSeek, GLM, Qwen | `apiKey` | Yes | Yes |
+| [Yingsuan AI](https://yingsuan.top) | LLM API gateway with free tier (100 calls, 3 free models). OpenAI-compatible endpoint for DeepSeek, Kimi K3, GLM, Qwen | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Add Yingsuan AI to Machine Learning category

Yingsuan AI is an LLM API aggregation platform providing a unified OpenAI-compatible endpoint for multiple AI models:

- **DeepSeek** (deepseek-chat, deepseek-reasoner)
- **Moonshot/Kimi** (kimi-k3) — 2.8T params, 1M context, agentic reasoning. **Just launched!**
- **Zhipu/GLM** (glm-4-flash, glm-4-air, glm-4-plus) — includes 2 permanently free models
- **SiliconFlow/Qwen** (Qwen2.5-7B, Qwen2.5-72B, DeepSeek-V3) — includes 1 permanently free model

### Key features
- 100 free trial calls, no credit card required
- 3 permanently free models (glm-4-flash, glm-4.7-flash, Qwen2.5-7B-Instruct)
- OpenAI-compatible API format (/v1/chat/completions, /v1/models)
- Multi-provider routing with automatic fallback
- Targeting developers in Southeast Asia/South Asia

### Checklist
- [x] API has free tier access
- [x] API supports HTTPS
- [x] API uses apiKey authentication (Bearer token)
- [x] Entry added in alphabetical order within Machine Learning category
- [x] Description is concise and accurate