### PR TITLE
Add LATAM Tax ID API

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
+| [LATAM Tax ID](https://web-production-75c34.up.railway.app/docs) | Validate NIT, CUIT, RUC, RUT and RFC tax IDs for Colombia, Argentina, Peru, Chile and Mexico | No | Yes | Yes | |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds a free, no-auth API for validating tax IDs across 5 Latin American countries in a single endpoint: NIT/cédula (Colombia), CUIT/CUIL (Argentina), RUC (Peru), RUT (Chile), and RFC format (Mexico).

- No existing entry for CUIT/NIT/RUT/RFC/RUC validation was found in Finance.
- Auth: No, HTTPS: Yes, CORS: Yes (verified).
- Entry placed alphabetically between Klarna and MercadoPago.
- Ran `python scripts/validate/format.py README.md` locally; diff against unmodified master shows no new validation errors introduced by this change (all reported issues are pre-existing in master).