### PR TITLE
Add College ROI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
+| [College ROI](https://le-teen.com/api) | Lifetime ROI of US colleges and majors, static JSON, CC BY 4.0 | No | Yes | Yes |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
 | [CuttingToolsAI](https://cuttingtoolsai.eu/api) | Cross-brand carbide insert grade equivalents by ISO application class | No | Yes | Yes |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds College ROI to Open Data: free, keyless, CORS-open static JSON API for the lifetime return on investment of US colleges and majors (30-year NPV per school, ROI stats per major/subfield), derived from public FREOPP/IPEDS/BEA data. Docs: https://le-teen.com/api · OpenAPI 3.1: https://le-teen.com/api/v1/openapi.json · underlying dataset CC BY 4.0, Zenodo DOI 10.5281/zenodo.21351603. Placed alphabetically next to CollegeScoreCard.ed.gov (the natural neighbor). Disclosure: I maintain this API.