### PR TITLE
Add BottleneckPC to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
+| [BottleneckPC](https://bottleneckpc.com/data) | PC hardware dataset: 300+ CPUs and 140+ GPUs with calibrated gaming scores, CC BY 4.0 | No | Yes | Yes |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |


### PR DESCRIPTION
**What does this PR do?**
Adds BottleneckPC to the Open Data section.

**Checklist:**
- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items

API details: free JSON endpoint at https://bottleneckpc.com/data.json - PC hardware dataset covering 300+ CPUs and 140+ GPUs with specs and calibrated 0-100 gaming scores, licensed CC BY 4.0. No auth, HTTPS, CORS enabled (Access-Control-Allow-Origin: *).