### PR TITLE
Add DocuQueue API

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
 | [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
+| [DocuQueue](https://docuqueue.com) | Generate PDF documents from templates with an editor and a simple API | `apiKey` | Yes | Unknown |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
This PR adds DocuQueue (https://docuqueue.com) to the "Documents & Productivity" section.

**API Details:**
- **Name:** DocuQueue
- **URL:** https://docuqueue.com
- **Description:** Generate PDF documents from templates with an editor and a simple API
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Unknown