### PR TITLE
Add TimeZone Hero API

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Talordata](https://docs.talordata.com/) | SERP data from major search engines with a free trial | `apiKey` | Yes | Unknown |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
+| [TimeZone Hero](https://www.timezonehero.com/developers) | Convert times between any two time zones, daylight saving aware | No | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **TimeZone Hero** to the `Development` section — a free JSON API for converting a time between any two time zones. No API key, no signup, no paid tier. Conversions come from the IANA time zone database, so daylight saving is handled for the given date. CORS-enabled, so it works from the browser.

Example:

```
GET https://www.timezonehero.com/api/convert?from=est&to=pst&time=15:00
-> { "summary": "3:00 PM EDT is 12:00 PM PDT", "offsetHours": -3, ... }
```

Docs: https://www.timezonehero.com/developers

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit