### PR TITLE
Add SINTEGRA Brasil API

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pick an Agency](https://www.pickanagency.com/developers) | Search 47,000+ marketing agencies by service, location and rating | No | Yes | Yes |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Signaliz](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction) | GTM enrichment, lead generation, email verification, and company signals | `apiKey` | Yes | Unknown |
+| [SINTEGRA Brasil](https://www.sintegrabrasil.com.br/api) | Brazilian company registry data by CNPJ from Federal Revenue open data | No | Yes | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | Yes | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Yes | Unknown |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Adds **SINTEGRA Brasil** to *Business*: free lookup of Brazilian company registry data by CNPJ (the Brazilian federal company ID), sourced from Federal Revenue open data (71M+ establishments, updated monthly).

- Free without auth (3 req/min per IP); optional free API key raises limits (30 req/min, 2,000/day)
- HTTPS + CORS enabled; JSON responses
- OpenAPI spec: https://www.sintegrabrasil.com.br/openapi.json
- Docs: https://www.sintegrabrasil.com.br/api
