### PR TITLE
Add SkipOdds API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1759,6 +1759,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
+| [SkipOdds](https://skipodds.com/docs) | De-vigged fair win probabilities across 13 sports, averaged from 69+ bookmakers | `apiKey` | Yes | Yes |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |
 | [Sport Places](https://developers.decathlon.com/products/sport-places) | Crowd-source sports places around the world | No | Yes | No |


### PR DESCRIPTION
Contributing-guide checklist: entry is alphabetically ordered (between RacingHub and Sport Data in Sports & Fitness), description is 79 characters with no ending punctuation, table columns padded with one space, single squashed commit, and I searched for existing SkipOdds issues/PRs (none).

SkipOdds is a sports odds API returning de-vigged fair win probabilities across 13 sports, averaged from 69+ bookmakers. HTTPS and CORS enabled, apiKey auth. Free demo key (100 requests/day, no card) so reviewers can verify: curl -H "x-api-key: skipodds-demo-2026" https://skipodds.com/v1/fixtures