### PR TITLE
Add PodKit to Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
 | [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |
 | [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |
+| [PodKit](https://podkitapp.com/docs) | Podcast search, metadata, chapters, and transcripts | `apiKey` | Yes | Yes |
 | [PotterDB](https://docs.potterdb.com/) | Harry Potter universe database with characters, spells, potions and more | No | Yes | Yes |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
 | [TasteDive](https://tastedive.com/read/api) | Content-based recommendations for movies, music, TV shows, books, games, and podcasts | `apiKey` | Yes | No |


### PR DESCRIPTION
Adding PodKit, a podcast data API (search, episode metadata, chapters, and
transcripts), to the Entertainment section in alphabetical order (between
NaMoMemes and PotterDB).

- [x] Formatted per the contributing guide
- [x] Ordered alphabetically within Entertainment
- [x] Description ≤ 100 chars and does not end with a period
- [x] Auth enclosed in backticks (`apiKey`)
- [x] Only one link added in this PR
- [x] API name has no TLD and does not end with "API"