### PR TITLE
Add UTM tracking to BuyWhere link for public-apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,7 +1659,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes | Unknown |
-| [BuyWhere](https://buywhere.ai) | Real-time product catalog API for AI agents across merchants in 7 countries (SG, MY, TH, VN, PH, ID, US) | `apiKey` | Yes | Unknown |
+| [BuyWhere](https://buywhere.ai?utm_source=public-apis&utm_medium=referral&utm_campaign=june30_25k&utm_content=public-apis) | Real-time product catalog API for AI agents across merchants in 7 countries (SG, MY, TH, VN, PH, ID, US) | `apiKey` | Yes | Unknown |
 | [Digi-Key](https://www.digikey.com/en/resources/api-solutions) | Retrieve price and inventory of electronic components as well as place orders | `OAuth` | Yes | Unknown |
 | [Descripio Amazon Reviews](https://docs.descripio.com) | Amazon product reviews for 12 marketplaces | `apiKey` | Yes | Unknown |
 | [Dummy Products](https://dummyproducts-api.herokuapp.com/) | An api to fetch dummy e-commerce products JSON data with placeholder images | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Add UTM parameters to the BuyWhere listing for referral traffic measurement.

**UTM added:** `?utm_source=public-apis&utm_medium=referral&utm_campaign=june30_25k&utm_content=public-apis`
**Directory:** public-apis

**Why:** UTM parameters let us measure which directory referrals drive real visits in PostHog. Standard format: `?utm_source=directory&utm_medium=referral&utm_campaign=june30_25k&utm_content={dir-name}`