### PR TITLE
Add Stopover Planner API to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1892,6 +1892,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | No |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
+| [Stopover Planner](https://rapidapi.com/stopover-labs-stopover-labs-default/api/stopover-planner) | Live Google Flights fares with booking links: stopover, country-wide and explore-everywhere search | `apiKey` | Yes | Yes |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |
 | [TransitLand](https://www.transit.land/documentation/datastore/api-endpoints.html) | Transit Aggregation | No | Yes | Unknown |
 | [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx) | Marta | No | No | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

Adds Stopover Planner to Transportation: live Google Flights fares (GBP) with a booking link on every flight, plus search types not covered by existing entries (multi-day stopover itineraries, country-wide sweeps, explore-everywhere). Free tier: 50 requests/month via RapidAPI (`apiKey` auth, HTTPS).

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
