### PR TITLE
Add MyPayslip API

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
+| [MyPayslip](https://mypayslip.lk/openapi.json) | Sri Lanka salary calculations with APIT, EPF, ETF, and net pay | No | Yes | Yes | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

Adds the free, read-only MyPayslip Sri Lanka salary calculation API to Finance. The endpoint requires no authentication, supports HTTPS and CORS, and publishes an OpenAPI 3.1 specification at the linked documentation URL.

Validation performed:
- Added entry passes `check_entry` with zero errors
- Documentation URL is reachable and unique in the list
- Live endpoint returns the documented salary calculation without authentication
- Cross-origin request returns `Access-Control-Allow-Origin: *`

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit