### PR TITLE
Add Kiprio DNS Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey` | Yes | Yes |
 | [JSONPlaceholder](https://jsonplaceholder.typicode.com) | Fake REST API for testing and prototyping | No | Yes | Yes |
 | [Keyvalue](https://keyvalue.immanuel.co/) | Simple key-value storage REST API for quick prototyping | No | Yes | Unknown |
+| [Kiprio DNS Lookup](https://kiprio.com/v1/dns-lookup/) | Query DNS records (A, AAAA, MX, TXT, NS, CNAME, SOA) for any domain | `apiKey` | Yes | Yes |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [Kiprio DNS Lookup](https://kiprio.com/v1/dns-lookup/) to the Development section.

- **Description**: Query DNS records (A, AAAA, MX, TXT, NS, CNAME, SOA) for any domain
- **Auth**: `apiKey`
- **HTTPS**: Yes
- **CORS**: Yes