### PR TITLE
Add Kiprio IP Geolocation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
 | [Kakao Maps](https://apis.map.kakao.com) | Kakao Maps provide multiple APIs for Korean maps | `apiKey` | Yes | Unknown |
 | [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
+| [Kiprio IP Geolocation](https://kiprio.com/v1/ip/) | IP geolocation with country, city, ISP, ASN, timezone and VPN/Tor detection | `apiKey` | Yes | Yes |
 | [Kiprio UK Postcode](https://kiprio.com/v1/postcode) | UK postcode lookup with lat/lon, district, ward, constituency | `apiKey` | Yes | Yes |
 | [LatLng](https://www.latlng.work/docs) | Geocoding, reverse geocoding, places, and static maps | No | Yes | Yes |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [Kiprio IP Geolocation](https://kiprio.com/v1/ip/) to the Geocoding section.

- **Description**: IP geolocation with country, city, ISP, ASN, timezone and VPN/Tor detection
- **Auth**: `apiKey`
- **HTTPS**: Yes
- **CORS**: Yes