### PR TITLE
Add Kiprio FX Rates API

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangerate.dev](https://exchangerate.dev/docs) | Live & historical FX, 168 pairs back to 1999, Frankfurter-compatible, free 10k/mo | No | Yes | Unknown |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
+| [Kiprio FX Rates](https://kiprio.com/v1/forex/) | Live currency conversion between any ISO 4217 currency pair | `apiKey` | Yes | Yes |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangerate.dev](https://exchangerate.dev/docs) | Live & historical FX, 168 pairs back to 1999, Frankfurter-compatible, free 10k/mo | No | Yes | Unknown |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
-| [Kiprio FX Rates](https://kiprio.com/v1/forex/) | Live currency conversion between any ISO 4217 currency pair | `apiKey` | Yes | Yes |
+| [Kiprio FX Rates](https://kiprio.com/v1/fx/) | Live currency conversion between any ISO 4217 currency pair | `apiKey` | Yes | Yes |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [Kiprio FX Rates](https://kiprio.com/v1/forex/) to the Currency Exchange section.

- **Description**: Live currency conversion between any ISO 4217 currency pair
- **Auth**: `apiKey`
- **HTTPS**: Yes
- **CORS**: Yes