### PR TITLE
Add GitHub Change Risk API

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Buddy](https://buddy.works/docs/api/getting-started/overview) | The fastest continuous integration and continuous delivery platform | `OAuth` | Yes | Unknown |
 | [CircleCI](https://circleci.com/docs/api/v1-reference/) | Automate the software development process using continuous integration and continuous delivery | `apiKey` | Yes | Unknown |
 | [Codeship](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/api-overview/) | Codeship is a Continuous Integration Platform in the cloud | `apiKey` | Yes | Unknown |
+| [GitHub Change Risk](https://76.13.79.47.nip.io/openapi.json) | Deterministic risk summaries for public GitHub compare ranges | No | Yes | Yes |
 | [Travis CI](https://docs.travis-ci.com/api/) | Sync your GitHub projects with Travis CI to test your code in minutes | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds the public, unauthenticated GitHub Change Risk endpoint to Continuous Integration.

Verified before submission:
- HTTPS endpoint
- browser CORS for public reads
- documented OpenAPI contract