### PR TITLE
Add VaultVision API

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
+| [VaultVision](https://vaultvision.tech/developers) | Read-only Hyperliquid vault rankings, risk scores, TVL, APR, and entry signals | No | Yes | Yes |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 


### PR DESCRIPTION
## Summary
- add VaultVision to the Cryptocurrency section
- document its free, read-only Hyperliquid vault data API
- mark authentication as not required, with HTTPS and CORS support

## Validation
- production documentation returns HTTP 200
- public health, vaults, risk-adjusted rankings, and signals endpoints return HTTP 200 without authentication
- responses include `Access-Control-Allow-Origin: *`
- 31 upstream validator unit tests pass
- the added row passes the upstream entry validator with no errors
- existing repository-wide format and duplicate-link baseline issues are unchanged
