### PR TITLE
Add AI Model Watch to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [AI Model Watch](https://aimodelwatch.dev/api) | Daily prices, context windows and lifecycle/EOL dates for 190+ LLMs, every row source-linked | No | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [DeepAI](https://deepai.org/) | Provides AI-powered APIs for text generation, image processing, and more | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **AI Model Watch** to the Machine Learning category.

It's a free, no-auth JSON API for AI/LLM model metadata — current prices (input/output/cached per 1M tokens), context-window sizes, and lifecycle/deprecation-EOL dates for 190+ models across every major provider, refreshed daily and each row carrying the official `source_url` it was read from.

- Docs: https://aimodelwatch.dev/api
- Endpoints: `https://aimodelwatch.dev/api/models.json`, `https://aimodelwatch.dev/api/deprecations.json`
- No key, no signup, no rate limit; `Access-Control-Allow-Origin: *` (CORS-open); HTTPS.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
