### PR TITLE
Add Noon Barbari API (Cryptocurrency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mexc](https://www.mexc.com/api-docs) | Cryptocurrency info, place order | `apiKey` | Yes | Unknown |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
+| [Noon Barbari](https://noonbarbari.xyz/developers) | Crypto indicator signals, DCA, buy-and-hold, overfitting checks and async strategy backtests | `apiKey` | Yes | No |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Noon Barbari crypto backtesting API to the Cryptocurrency section — indicator signals, DCA, buy-and-hold, an overfitting check and async backtests.

- Docs: https://noonbarbari.xyz/developers
- OpenAPI: https://api.noonbarbari.xyz/openapi.json

Entry placed alphabetically (after Nomics, before NovaDax); Auth `apiKey`, HTTPS Yes, CORS No; no trailing period in the description.