### PR TITLE
Add AlphaSMO API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
+| [AlphaSMO](https://alphasmo.com/developer/docs) | SEC 13F institutional holdings, insider trading, and smart money convergence signals | No | Yes | Yes |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds AlphaSMO to the Finance section: SEC 13F institutional holdings, Form 4 insider trading, and a "smart money convergence" signal (tickers where hedge funds and company insiders are both buying).

- No auth required, CORS enabled
- Docs: https://alphasmo.com/developer/docs

One line added, alphabetically placed, following the existing table format. Local `pytest scripts/tests/test_validate_format.py` passes.