### PR TITLE
Add Live Tennis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
+| [Live Tennis](https://docs.livetennisapi.com) | Live tennis scores, players, fixtures and win-probability for ATP, WTA, Challenger and ITF | `apiKey` | Yes | Yes |
 | [Lumify](https://lumify.ai/docs) | Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports | `apiKey` | Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Live Tennis** to the **Sports & Fitness** section.

A real-time tennis data API (REST + WebSocket) covering live scores, players, rankings, market prices and AI win-probability for ATP, WTA, Challenger and ITF.

- Auth: `apiKey`
- HTTPS: Yes
- CORS: No
- Docs / site: https://livetennisapi.com

One line added, placed in correct alphabetical order (between JCDecaux Bike and MLB Records and Stats). The entry title omits the trailing "API" per the contributing guidelines and the format validator.