### PR TITLE
Add AI Model Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [AI Model Index](https://aimodelsindex.com/docs/api) | Source-backed AI model benchmarks, indexes, and leaderboard data | No | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [DeepAI](https://deepai.org/) | Provides AI-powered APIs for text generation, image processing, and more | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds [AI Model Index](https://aimodelsindex.com/docs/api) to the Machine Learning section.

Verification performed against the live public API:

- Authentication: No
- HTTPS: Yes
- CORS: Yes (`Access-Control-Allow-Origin: *`; GET/HEAD/OPTIONS supported)
- OpenAPI 3.1 document: https://aimodelsindex.com/api/v1/openapi.json
- Example no-auth endpoint: https://aimodelsindex.com/api/v1/data?resource=models&limit=1
- Access: permanently free public beta

The entry is alphabetized, uses the existing five-column table format, and has a 64-character description.

Disclosure: I maintain AI Model Index. This PR changes one README row only.