### PR TITLE
Add IntoDNS.ai API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,6 +1633,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Hashable](https://hashable.space/pages/api/) | A REST API to access high level cryptographic functions and methods | No | Yes | Yes |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
+| [IntoDNS.ai](https://intodns.ai/api-docs) | DNS and email security scanner: SPF, DKIM, DMARC, DNSSEC, MTA-STS, BIMI and blacklist checks | No | Yes | Yes |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |


### PR DESCRIPTION
Adds **IntoDNS.ai** to the Security category.

- **What:** free DNS and email security scanner API — SPF, DKIM, DMARC, DNSSEC, MTA-STS, BIMI, and blacklist checks.
- **Auth:** No (no key or signup required)
- **HTTPS:** Yes
- **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **Docs:** https://intodns.ai/api-docs

Entry inserted alphabetically between `Intelligence X` and `IPLogs`. Format matches the neighbouring rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)