### PR TITLE
Add FrameFetch to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1993,6 +1993,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dailymotion](https://developer.dailymotion.com/) | Dailymotion Developer API | `OAuth` | Yes | Unknown |
 | [Dune](https://github.com/ywalia01/dune-api) | A simple API which provides you with book, character, movie and quotes JSON data | No | Yes | Yes |
 | [Final Space](https://finalspaceapi.com/docs/) | Final Space API | No | Yes | Yes |
+| [FrameFetch](https://framefetch.net) | Turn any social-video URL into transcript, frames, OCR text and metadata | `apiKey` | Yes | No |
 | [Game of Thrones Quotes](https://gameofthronesquotes.xyz/) | Some Game of Thrones quotes | No | Yes | Unknown |
 | [Harry Potter Charactes](https://hp-api.herokuapp.com/) | Harry Potter Characters Data with with imagery | No | Yes | Unknown |
 | [Hyperserve](https://hyperserve.io/) | Video backend API: upload any format, transcode to MP4, deliver via CDN | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adding FrameFetch — an API that turns any social-video URL (YouTube, TikTok, Instagram, Reddit, Pinterest) into transcript, frames, on-screen text (OCR), and metadata.

- Website: https://framefetch.net
- Docs: https://framefetch.net/docs
- OpenAPI: https://framefetch.net/openapi.json

Entry added alphabetically in the Video section. Auth: apiKey · HTTPS: Yes · CORS: No (verified live).