### PR TITLE
Add MyIPRightNow to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |
 | [MY IP](https://www.myip.com/api-docs/) | Get IP address information | No | Yes | Unknown |
+| [MyIPRightNow](https://myiprightnow.com) | Public IP address with network, location, and connection details | No | Yes | Yes |
 | [Nationalize.io](https://nationalize.io) | Estimate the nationality of a first name | No | Yes | Yes |
 | [Netlify](https://docs.netlify.com/api/get-started/) | Netlify is a hosting service for the programmable web | `OAuth` | Yes | Unknown |
 | [NetworkCalc](https://networkcalc.com/api/docs) | Network calculators, including subnets, DNS, binary, and security tools | No | Yes | Yes |


### PR DESCRIPTION
Adds a free public IP API to the **Development** section, alphabetically between `MY IP` and `Nationalize.io`.

```
| [MyIPRightNow](https://myiprightnow.com) | Public IP address with network, location, and connection details | No | Yes | Yes |
```

**Endpoint:** `https://myiprightnow.com/api/ip`

```console
$ curl -s https://myiprightnow.com/api/ip
{
  "ip": "203.0.113.42",
  "version": 4,
  "city": "Denver",
  "region": "Colorado",
  "country": "US",
  "timezone": "America/Denver",
  "network": "Example Communications, LLC",
  "asn": 64496,
  "httpProtocol": "HTTP/3",
  "tlsVersion": "TLSv1.3"
}
```

Against the fields:

- **Auth: No** — no key, no account, no sign-up.
- **HTTPS: Yes** — HTTP redirects to HTTPS.
- **CORS: Yes** — `Access-Control-Allow-Origin: *`, so it works from browser JavaScript.

Not a paid product and not a free tier of one: there is no paid plan, no rate-limit upsell, and nothing to buy. The response is served `no-store` and nothing is logged or stored.

Disclosure: I built and run this.