### PR TITLE
Add AvailEngine API

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
+| [AvailEngine](https://docs.availengine.com) | Booking engine as a service for any vertical | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |


### PR DESCRIPTION
Add [AvailEngine](https://docs.availengine.com) — a booking engine as a service API for any booking vertical. Uses \piKey\ auth, supports HTTPS and CORS, and offers a free tier (1 business, 50 bookings/month, no credit card required).