### PR TITLE
Add SSL Domain Health Check API to Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,6 +1646,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SecurityTrails](https://securitytrails.com/corp/apidocs) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
+| [SSL Domain Health Check](https://rapidapi.com/goktugbk/api/ssl-domain-health-check) | SSL certificate validity, domain WHOIS status, and DNS record checks for any domain | `apiKey` | Yes | Unknown |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [URLhaus](https://urlhaus.abuse.ch/api/) | Database of malicious URLs used for malware distribution | `No` | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds **SSL Domain Health Check** to the Security category — an API for checking SSL certificate validity, domain WHOIS registration status, and DNS record resolution for any domain.

- Auth: `apiKey`
- HTTPS: Yes
- Alphabetically inserted between `Spyse` and `Threat Jammer`

## Checklist

- [x] Added my API in alphabetical order
- [x] Used the correct format: `| Name | Description | Auth | HTTPS | CORS |`
- [x] Description does not exceed 100 characters
- [x] Confirmed HTTPS is supported