### PR TITLE
Add Zennet — x402 pay-per-use prediction market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+| [Zennet](https://zennet.cloud) | x402 pay-per-use APIs: Polymarket signals, CEX/DEX spreads, contract risk scores, gas oracle | No | Yes | Yes |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## What
Adds zennet.cloud to the Cryptocurrency section.

zennet.cloud offers 11 x402-powered micro-APIs for prediction markets and crypto trading:
- Polymarket mispricing signals
- CEX/DEX arbitrage spreads
- Cross-market arbitrage (Polymarket vs Kalshi)
- Sentiment vs pricing divergence
- Resolution sniper (bucket market edge detection)
- Gas oracle (Polygon, Base, Arbitrum)
- Contract risk score (5-point check)
- Wallet intel
- Spread alert webhooks

$0.01-0.02 per query via x402. No auth required.