### PR TITLE
Add Live Tennis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
+| [Live Tennis](https://docs.livetennisapi.com) | Real-time scores, players, rankings and fixtures for ATP, WTA, Challenger and ITF | `apiKey` | Yes | Yes |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Live Tennis** to *Sports & Fitness*.

Real-time tennis data for ATP, WTA, Challenger and ITF — live and upcoming matches with point-by-point scores, player profiles and rankings, and the forward fixture schedule.

| Field | Value | Verified |
|---|---|---|
| Auth | `apiKey` | `401` without a key |
| HTTPS | Yes | |
| CORS | Yes | `access-control-allow-origin: *` on the public endpoints |

**Free tier, no card** — 1,000 requests/day covering live and upcoming matches, scores, players and fixtures: <https://livetennisapi.com/subscribe/free>. Paid plans add historical results, match events, market prices and model output, but the free tier is usable on its own rather than being a trial.

Docs: <https://docs.livetennisapi.com>

**Disclosure:** I maintain this API. Flagging that explicitly since the contributing guide rejects marketing attempts — I've kept the entry to a plain factual description in the existing format, and I'm happy to reword or withdraw it if it reads as promotional.

Single added line, placed alphabetically between `JCDecaux Bike` and `MLB Records and Stats`. `scripts/validate/format.py` reports no new errors (it caught my first draft ending the title in "API" — fixed before opening this).