### PR TITLE
Add 1TempMail Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Email
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [1TempMail](https://www.1tempmail.com/api/) | Instant, secure, and free disposable temporary email service with API and MCP server support. | `apiKey` | Yes | Unknown |
 | [mailboxlayer](https://mailboxlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Email address validation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |


### PR DESCRIPTION
## Add 1TempMail to Email category

This PR adds [1TempMail](https://www.1tempmail.com) to the Email category.

**Why this API is valuable:**
- Free and anonymous temporary email service
- 60-minute validity (longer than typical 10-minute services)
- REST API and MCP server for developer and AI tool integration
- No registration or API key required
- HTTPS supported

**Entry:**
`| [1TempMail](https://www.1tempmail.com) | Free disposable temp email with 60-min validity, REST API, and MCP server for AI/developer integration | No | Yes |`

**Checklist:**
- [x] Submission formatted according to CONTRIBUTING.md
- [x] Entry ordered alphabetically within Email category
- [x] Description is useful and clear
- [x] Description is within 100 characters
- [x] Description does not end with punctuation
- [x] Each table column padded with one space on either side
- [x] No duplicate or related issues found
- [x] No new category created
- [x] Changes squashed into a single commit

Thank you for maintaining this great list