### PR TITLE
Add Inodra (Sui blockchain API) to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ API | Description | Auth | HTTPS | CORS |
 | [icy.tools](https://developers.icy.tools/) | GraphQL based NFT API | `apiKey` | Yes | Unknown |
 | [Indodax](https://github.com/btcid/indodax-official-api-docs) | Trade your Bitcoin and other assets with rupiah | `apiKey` | Yes | Unknown |
 | [INFURA Ethereum](https://infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes | Yes |
+| [Inodra](https://docs.inodra.com) | Sui blockchain data: JSON-RPC, gRPC and GraphQL gateways, webhooks, archival history | `apiKey` | Yes | No |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [Localbitcoins](https://localbitcoins.com/api-docs/) | P2P platform to buy and sell Bitcoins | No | Yes | Unknown |


### PR DESCRIPTION
## Description
Adds [Inodra](https://docs.inodra.com) to the Cryptocurrency section (alphabetical order, after INFURA Ethereum).

Inodra provides API access to the Sui blockchain: JSON-RPC-compatible, gRPC and GraphQL gateways, webhooks, and archival history. Free tier available (1M credits/month, no card required) — sign-up gives an `apiKey`.

- Auth: `apiKey`
- HTTPS: Yes
- CORS: No

## Checklist
- [x] Free tier, no device/service purchase required
- [x] Entry follows the table format and alphabetical order
- [x] Auth/CORS values use the accepted inputs