### PR TITLE
Add Indexed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
+| [Indexed](https://indexed.vc/docs/api) | Startup funding rounds, investors, and company tech stacks for founders, sales, and GTM engineers | `apiKey` | Yes | No |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
 | [Invovate](https://invovate.com/api) | Generate PDF, JSON & UBL invoices in 11 languages from one JSON POST | `apiKey` | Yes | No |
 | [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Indexed to the **Business** category.

| Field | Value |
| --- | --- |
| API | Indexed |
| Description | Startup funding rounds, investors, and company tech stacks for founders, sales, and GTM engineers |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No |
| Link | https://indexed.vc/docs/api |

Placed under `### Business`, alphabetically between Google Analytics and Instatus. Rebased on current `master` — single commit, `README.md` only (+1/-0).

**Documentation:** REST endpoints for company and investor search and detail, bulk enrichment by domain, and funding-round webhooks. Auth, rate limits, pagination, credit costs and error codes are documented, and there is a full OpenAPI 3.1 spec at https://indexed.vc/openapi.yaml

**Access:** every plan is issued an API key, no card required. `GET /api/v1/industries` needs no authentication at all; a free key adds company and investor search and `/api/v1/usage`. Detail endpoints, reveal, bulk enrichment and webhooks are on paid plans. (Per @daltino's question above — the free tier is functional on its own and requires no payment.)

**CORS is `No`** — verified, no `Access-Control-Allow-Origin` header is returned, so the API is server-side only.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (97)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (adding to an existing category)
- [x] All changes have been squashed into a single commit
