### PR TITLE
Add OrbitalWiki API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1590,6 +1590,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
 | [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
+| [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ tracked satellites merging CelesTrak, GCAT, and Wikidata with source claims | `apiKey` | Yes | Unknown |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |

--- a/README.md
+++ b/README.md
@@ -1590,7 +1590,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
 | [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
-| [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ tracked satellites merging CelesTrak, GCAT, and Wikidata with source claims | `apiKey` | Yes | Unknown |
+| [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
Adds OrbitalWiki to Science & Math.

OrbitalWiki is a free, public satellite catalog (16,000+ tracked objects) that merges CelesTrak orbital elements, Jonathan McDowell's GCAT launch records, and Wikidata enrichment into one catalog with per-field source provenance. Read-only REST API, free tier 1,000 req/day, key from the dashboard at https://orbitalwiki.com/developers.

- Alphabetized under Science & Math (between OpenAlex and Purple Air)
- Description is 94 characters (under the 100 char limit)
- One link, single PR per guidelines