### PR TITLE
Add CruiseFeed to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1873,6 +1873,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Boston MBTA Transit](https://www.mbta.com/developers/v3-api) | Stations and predicted arrivals for MBTA | `apiKey` | Yes | Unknown |
 | [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | Transitland API | No | Yes | Unknown |
 | [Compare Flight Prices](https://rapidapi.com/obryan-software-obryan-software-default/api/compare-flight-prices/) | API for comparing flight prices across platforms | `apiKey` | Yes | Unknown |
+| [CruiseFeed](https://cruisefeed.io) | Normalized cruise line inventory: ships, sailings, itineraries, ports and lead-in fares | `apiKey` | Yes | Unknown |
 | [CTS](https://api.cts-strasbourg.eu/) | CTS Realtime API | `apiKey` | Yes | Yes |
 | [FAA N-Number Registry](https://n-number.starfile.org/api) | Every FAA-registered civil aircraft in the United States, lookup by N-number or Mode S hex code | No | Yes | Yes |
 | [Grab](https://developer.grab.com/docs/) | Track deliveries, ride fares, payments and loyalty points | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds [CruiseFeed](https://cruisefeed.io) to the Transportation category.

CruiseFeed provides normalized cruise line inventory - ships, sailings, day-by-day itineraries, ports and lead-in fares - across cruise lines as a JSON REST API, with a free tier (100 requests/month, no credit card).

- [x] Entry is in alphabetical order within Transportation
- [x] Auth (`apiKey`), HTTPS (Yes) and CORS (Unknown) provided
- [x] Description is factual and not an advertisement
- [x] Link is valid and points to the service
- [x] Only one entry added