### PR TITLE
Add Lumify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
+| [Lumify](https://lumify.ai/docs) | Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports | `apiKey` | Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Lumify** to the **Sports & Fitness** section.

- **What it is:** an agent-ready sports intelligence API — real-time schedules, live scores, odds, and public betting splits across MLB, NFL, NBA, NHL, NCAAF, NCAAB, tennis, and soccer.
- **Docs:** https://lumify.ai/docs
- **Auth:** `apiKey` (Bearer) — self-serve free tier (1,000 credits, no card required).
- **HTTPS:** Yes  ·  **CORS:** No

Entry placed alphabetically. Ran `scripts/validate/format.py` locally — the added line introduces no new formatting errors.

Made with [Cursor](https://cursor.com)