### PR TITLE
Add Artificial Intelligence Jobs API (Jobs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth` | Yes | Unknown |
+| [Artificial Intelligence Jobs](https://artificialintelligencejobs.co/developers) | Live AI/ML job listings from 260+ companies' own career pages, with salary, location, remote and seniority filters | No | Yes | Yes |
 | [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |
 | [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | Jobs with GraphQL | No | Yes | Yes |
 | [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding a free, no-auth, CORS-enabled public API for live AI/ML jobs.

- **API:** https://artificialintelligencejobs.co/api/jobs
- **Docs:** https://artificialintelligencejobs.co/developers  ·  OpenAPI: https://artificialintelligencejobs.co/openapi.json
- **Auth:** No  ·  **HTTPS:** Yes  ·  **CORS:** Yes

Returns live AI/ML job listings pulled daily from 260+ companies' own career pages, filterable by category, city, region, company, level, remote and salary. Filled roles are removed automatically.

Complies with the contributing guidelines (HTTPS, CORS: yes, no auth required, real docs).