### PR TITLE
Add Tilth API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |
 | [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |
 | [Teleport](https://developers.teleport.org/) | Quality of Life Data | No | Yes | Unknown |
+| [Tilth](https://www.tilth.uk/data) | Free daily UK fertiliser price index across nine grades, CC BY 4.0 licensed | No | Yes | Yes |
 | [Umeå Open Data](https://opendata.umea.se/api/) | Open data of the city Umeå in northen Sweden | No | Yes | Yes |
 | [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |
 | [University of Oslo](https://data.uio.no/) | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Tilth](https://www.tilth.uk/data) to the `Open Data` section: a free public API returning a daily UK fertiliser price index across nine grades (CC BY 4.0 licensed). No authentication required, served over HTTPS, CORS enabled for direct browser/agent use.
[Tilth API](https://www.tilth.uk/api/v1/public/fertiliser/openapi.json)