### PR TITLE
Add MostExpensiveWatches to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
 | [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |
 | [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
+| [MostExpensiveWatches](https://mostexpensivewatches.net/api) | Documented luxury watch auction records, live listings, valuations and price indices | No | Yes | Yes |
 | [ModelPartFinder Error Codes](https://modelpartfinder.com/docs/api) | Lookup appliance and equipment error codes by brand and code, with recommended replacement parts | No | Yes | Yes |
 | [Nasdaq Data Link](https://docs.data.nasdaq.com/) | Stock market data | `apiKey` | Yes | Unknown |
 | [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | Open data about nobel prizes and events | No | Yes | Yes |


### PR DESCRIPTION
**MostExpensiveWatches** — https://mostexpensivewatches.net/api

Free, no-key public API for documented luxury-watch auction data: 1,150+ realized hammer prices ($100k–$31M) with primary sources, live multi-merchant listings search, reference valuations, and daily price indices. OpenAPI 3.1 spec at https://mostexpensivewatches.net/openapi.json; datasets are CC-BY 4.0.

- Auth: No
- HTTPS: Yes
- CORS: Yes

Checklist: free with full access, no device/purchase dependency, HTTPS, alphabetical placement in Open Data.