### PR TITLE
Add PostLake API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NAVER](https://developers.naver.com/main/) | NAVER Login, Share on NAVER, Social Plugins and more | `OAuth` | Yes | Unknown |
 | [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
 | [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth` | Yes | Unknown |
+| [PostLake](https://postlake.dev/docs/) | One API to publish, schedule, and read analytics across every major social network | `apiKey` | Yes | No |
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Yes | Unknown |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **PostLake** to the Social section.

- Docs: https://postlake.dev/docs/
- Free tier: 20 credits/month, no card required — full API access, not a trial.

One REST endpoint publishes, schedules and reads analytics across every major social network, returning a single normalised response instead of each platform's raw payload. Sits alongside the existing Ayrshare entry in the same section.

Entry placed alphabetically (after Pinterest, before Product Hunt); description is 82 characters.