### PR TITLE
Add Newsflash API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,7 @@ API | Description | Auth | HTTPS | CORS |
 | [New York Times](https://developer.nytimes.com/) | The New York Times Developer Network | `apiKey` | Yes | Unknown |
 | [News](https://newsapi.org/) | Headlines currently published on a range of news sources and blogs | `apiKey` | Yes | Unknown |
 | [NewsData](https://newsdata.io/docs) | News data API for live-breaking news and headlines from reputed  news sources | `apiKey` | Yes | Unknown |
+| [Newsflash](https://newsflash.sh/docs) | Deduplicated news events from 260+ sources with corroboration/confidence scores for AI agents | `apiKey` | Yes | No |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖 | `apiKey` | Yes | Unknown |
 | [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |
 | [NPR One](http://dev.npr.org/api/) | Personalized news listening experience from NPR | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds **Newsflash** to the News category.

Newsflash (https://newsflash.sh) is a news event API built for AI agents: it crawls 260+ global sources and deduplicates them into events with corroboration counts and confidence scores, plus a real-time SSE stream, semantic search, and a 5-year archive. Docs: https://newsflash.sh/docs

- **Auth**: `apiKey` — a keyless test tier exists (50 req/day per IP), and a free API key (email OTP) raises limits, matching how other free-tier-plus-key APIs are marked here
- **HTTPS**: Yes
- **CORS**: No (verified — no `Access-Control-*` headers returned)
- Entry keeps alphabetical order (between NewsData and NewsX), description is 93 chars, and `scripts/validate/format.py` reports no new errors for this line

Disclosure: I built Newsflash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTSt4BDWJCsGjUyLCnbuj5
