### PR TITLE
Add Tallytopia API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1606,6 +1606,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
 | [SpaceX](https://api.spacex.land/graphql/) | GraphQL, Company, Ships, launchpad and launch data | No | Yes | Unknown |
 | [Sunrise and Sunset](https://sunrise-sunset.org/api) | Sunset and sunrise times for a given latitude and longitude | No | Yes | No |
+| [Tallytopia](https://tallytopia.com/api-docs) | Calculators for finance, health, math, space and sports with step-by-step results | No | Yes | Yes |
 | [Times Adder](https://github.com/FranP-code/API-Times-Adder) | With this API you can add each of the times introduced in the array sended | No | Yes | No |
 | [TLE](https://tle.ivanstanojevic.me/#/docs) | Satellite information | No | Yes | No |
 | [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | No |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) into a single commit

Adds [Tallytopia](https://tallytopia.com/api-docs) to Science & Math: a free, keyless JSON API for 73 calculators (finance, health, math, space, sports, DIY, everyday). Every response includes the full step-by-step calculation, not just the result. CORS is open to all origins, HTTPS only, no auth. An OpenAPI 3.1 spec is available at https://tallytopia.com/api/v1/openapi.json and an interactive explorer at https://tallytopia.com/api-explorer.

Example: https://tallytopia.com/api/v1/calculate/mortgage-payment?principal=300000&annualRate=7&years=30