### PR TITLE
Add open-banking.io to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
+| [open-banking.io](https://open-banking.io/) | EU open banking API for account information and payment initiation across 5,000+ banks without requiring eIDAS certificates | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## Description

Added [open-banking.io](https://open-banking.io/) to the Finance section.

open-banking.io is a European open banking API that provides account information (AIS) and payment initiation (PIS) across 5,000+ EU banks. Its key differentiator is that it operates without requiring customers to purchase eIDAS/QWAC certificates (which typically cost €2,000–10,000/year), making PSD2 bank data access significantly more accessible to developers and SMBs.

- **Auth:** API key
- **HTTPS:** Yes
- **CORS:** Unknown
- Placed alphabetically between Nordigen and OpenFIGI