### PR TITLE
Add TechRole Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JobDataLake](https://www.jobdatalake.com/docs) | 1M+ enriched job listings from 20,000+ companies with salary, skills, seniority | `apiKey` | Yes | Yes |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [TechRole Index](https://techrole.ru/open-data-daily) | Russian IT profession, vacancy publication and salary aggregates | No | Yes | Yes |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |
 | [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
TechRole Index provides a free, unauthenticated HTTPS endpoint and documentation for Russian IT profession and vacancy-publication aggregates.

- Documentation and data dictionary: https://techrole.ru/open-data-daily
- Direct JSON: https://techrole.ru/open-data-daily.json
- CORS: enabled
- Authentication: none
- Data: 180-day daily aggregates by profession, seniority, region, salary bounds, currency and tax status

The documentation identifies the official source, provenance, update time, schema and source-specific reuse terms. Publication flow is explicitly distinguished from a stock of simultaneously active vacancies.