### PR TITLE
Add Security Guard License Verification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Security Guard License Verification](https://rapidapi.com/operational-systems-llc-operational-systems-llc-default/api/security-guard-license-verification-api) | Verify US security guard licenses by name or license number against official state databases | `apiKey` | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**API Name:** Security Guard License Verification

**API Homepage:** https://api.operational-systems.com/sg/docs

**Short description:** Verify US security guard licenses by name or license number against official state licensing databases. California: 502,966 records refreshed monthly from CA DCA bulk data. Coming soon: TX, FL, NY.

**Auth:** apiKey (via RapidAPI)
**HTTPS:** Yes
**CORS:** Yes