### PR TITLE
Add Product API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1691,6 +1691,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
+| [Product API](https://productapi.dev/documentation) | Structured product data — descriptions, images, prices and specs from a single REST call | `apiKey` | Yes | No |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds Product API — a structured product-data search API (https://productapi.dev).

- Auth: apiKey
- HTTPS: Yes
- CORS: No
- Free tier: 20 free credits every month, no card required; paid usage at $0.05/call beyond that
- Docs: https://productapi.dev/documentation