### PR TITLE
Add ReqKey API

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ API | Description | Auth | HTTPS | CORS |
 | [GetOTP](https://otp.dev/en/docs/) | Implement OTP flow quickly | `apiKey` | Yes | No |
 | [Micro User Service](https://m3o.com/user) | User management and authentication | `apiKey` | Yes | No |
 | [MojoAuth](https://mojoauth.com) | Secure and modern passwordless authentication platform | `apiKey` | Yes | Yes |
+| [ReqKey](https://www.reqkey.com/docs) | API key authentication, usage credits, rate limiting and request analytics for your API | `apiKey` | Yes | No |
 | [SAWO Labs](https://sawolabs.com) | Simplify login and improve user experience by integrating passwordless authentication in your app | `apiKey` | Yes | Yes |
 | [Stytch](https://stytch.com/) | User infrastructure for modern applications | `apiKey` | Yes | No |
 | [Warrant](https://warrant.dev/) | APIs for authorization and access control | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds ReqKey to the **Authentication & Authorization** section, in alphabetical position between MojoAuth and SAWO Labs.

| Field | Value |
|---|---|
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No (server-to-server; called from your backend middleware) |
| Docs | https://www.reqkey.com/docs |

ReqKey is an API for adding key authentication, usage credits, rate limiting and request analytics to your own API. It has a permanent free tier — 100,000 requests/month and 1,000 keys, no credit card and no trial expiry — and pricing is published without signup at https://www.reqkey.com/pricing.

- One link, one commit.
- `scripts/validate/format.py` produces an identical error set before and after this change; no new errors, and none on the added line or its section.

Disclosure: I work on ReqKey.