### PR TITLE
Add Live Tennis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
+| [Live Tennis](https://docs.livetennisapi.com) | Real-time scores, players, rankings and fixtures for ATP, WTA, Challenger and ITF | `apiKey` | Yes | Yes |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey` | Yes | Unknown |
 | [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |


### PR DESCRIPTION
Adds Live Tennis to **Sports & Fitness**.

```
| [Live Tennis](https://docs.livetennisapi.com) | Real-time scores, players, rankings and fixtures for ATP, WTA, Challenger and ITF | `apiKey` | Yes | Yes |
```

**Free tier, no card required** — 30 requests/minute, 1,000/day, covering live and upcoming matches, players, rankings and fixtures. The description lists only what the free key actually returns.

Checked against CONTRIBUTING:
- Alphabetical order within the section (between JCDecaux Bike and Lumify)
- Description under 100 characters
- `apiKey` — verified: an unauthenticated request returns 401
- HTTPS — verified
- CORS — verified: `access-control-allow-origin: *` on the public endpoints
- `scripts/validate/format.py` reports no errors for this line
- One link in this PR