### PR TITLE
Add Dealaka

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
+| [Dealaka](https://dealaka.com/data) | US bank, card and brokerage sign-up bonuses, verified against each issuer's own terms | No | Yes | Yes |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds Dealaka to **Finance**.

A free, no-key API for current US sign-up bonuses across banks, credit cards, brokerages, apps, travel loyalty programs and crypto exchanges. Each figure is verified against the institution's own published terms and carries the date it was last checked.

- Endpoint (JSON): https://dealaka.com/data/offers.json
- Endpoint (CSV): https://dealaka.com/data/offers.csv
- Documentation and column dictionary: https://dealaka.com/data

Against the checklist:

- **Auth:** `No` — no key, no registration, no rate-limit signup
- **HTTPS:** Yes
- **CORS:** Yes (`access-control-allow-origin: *` on both endpoints)
- **Documentation:** https://dealaka.com/data — every column, its meaning, the licence, and the two caveats a consumer needs (the amount field holds the floor of a range, and the cash/points/miles units must not be aggregated)
- **Licence:** CC BY 4.0 on the structured records
- Alphabetical placement between CongressInvests and Dino.markets, description 85 characters, one API in this PR, single commit