### PR TITLE
Add ProfitEngine API (32+ developer tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ API | Description | Auth | HTTPS | CORS |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [ProfitEngine API](https://rapidapi.com/Midas7742/api/profitengine-api) | QR codes, email validation, URL shortening, hashing, UUID generation & more | `apiKey` | Yes | Yes |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |
 | [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added ProfitEngine API to the Development category. Free tier with 500K requests/month. 32+ endpoints covering QR codes, email validation, URL shortening, hashing, UUID generation, and more.