### PR TITLE
Add WealthVille API

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ API | Description | Auth | HTTPS | CORS |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
+| [WealthVille](https://wealthville.net/developers) | DeFi liquidity pool scores and Enter/Hold/Exit signals across Solana and EVM chains | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**
 <br >

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ API | Description | Auth | HTTPS | CORS |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
-| [WealthVille](https://wealthville.net/developers) | DeFi liquidity pool scores and Enter/Hold/Exit signals across Solana and EVM chains | No | Yes | Unknown |
+| [WealthVille](https://wealthville.net/developers) | DeFi liquidity pool scores and Enter/Hold/Exit signals across Solana and EVM chains | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds one entry to `### Blockchain`, alphabetically after `Watchdata`.

```
| [WealthVille](https://wealthville.net/developers) | DeFi liquidity pool scores and Enter/Hold/Exit signals across Solana and EVM chains | No | Yes | Unknown |
```

A free, keyless REST API returning a 0-100 score and an Enter/Hold/Exit verdict for DeFi liquidity pools — ~68,800 on Solana and 575 across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC. There is also a public `/track-record` endpoint that reports hits *and* misses over a rolling 30 days.

Column notes:

- **Auth `No`** — no key, no signup, no rate limit on the public read endpoints.
- **HTTPS `Yes`**.
- **CORS `Unknown`** — deliberately not `Yes`. I tested each endpoint with an `Origin` header: `/track-record`, `/scores/top` and `/openapi.json` return `Access-Control-Allow-Origin: *`, but `/pools/top`, `/stats`, `/evm/pools` and `/signals/feed` return no CORS header at all. Since it is inconsistent rather than uniformly enabled, `Unknown` is the accurate value. I'll follow up to make it uniform and can amend the column afterwards.

Description is 83 characters. Running `scripts/validate/format.py` locally reports 5 errors, all of which are pre-existing on an unrelated table-separator row (L2064 before my change, L2065 after) — my entry does not add any.