### PR TITLE
Add TranscriptFetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2048,6 +2048,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TMDb](https://www.themoviedb.org/documentation/api) | Community-based movie data | `apiKey` | Yes | Unknown |
 | [TrailerAddict](https://www.traileraddict.com/trailerapi) | Easily embed trailers from TrailerAddict | `apiKey` | No | Unknown |    
 | [Trakt](https://trakt.docs.apiary.io/) | Movie and TV Data | `apiKey` | Yes | Yes |
+| [TranscriptFetch](https://transcriptfetch.com/docs) | Timestamped transcripts for YouTube, TikTok, Instagram, X and Facebook video, server-side only | `apiKey` | Yes | No |
 | [TVDB](https://thetvdb.com/api-information) | Television data | `apiKey` | Yes | Unknown |
 | [TVMaze](http://www.tvmaze.com/api) | TV Show Data | No | No | Unknown |
 | [uNoGS](https://rapidapi.com/unogs/api/unogsng) | Unofficial Netflix Online Global Search, Search all netflix regions in one place | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds TranscriptFetch to the Video section.

Returns transcripts for YouTube, TikTok, Instagram, X and Facebook videos as timestamped JSON. When a video has no caption track, the audio is transcribed automatically.

- Auth: `apiKey` (bearer token)
- HTTPS: Yes
- CORS: No, by design. Keys are secret bearer tokens, so the API is meant for server-side use; browser apps should proxy through their own backend
- Free tier: 100 credits per month, no card required
- Docs: https://transcriptfetch.com/docs
- OpenAPI: https://transcriptfetch.com/api/v1/openapi.json

One entry, placed alphabetically between Trakt and TVDB in the Video section.
