### PR TITLE
Add Mydentify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ API | Description | Auth | HTTPS | CORS |
 | [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
 | [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
 | [Meirra](https://meirra.com/api) | SEO monitoring, email verification, lead generation, and marketing analytics | `apiKey` | Yes | Yes |
+| [Mydentify](https://mydentify.com/openapi.json) | Search structured product directories and weekly leaderboards | No | Yes | Yes |
 | [ORB Intelligence](https://api.orb-intelligence.com/docs/) | Company lookup | `apiKey` | Yes | Unknown |
 | [Pick an Agency](https://www.pickanagency.com/developers) | Search 47,000+ marketing agencies by service, location and rating | No | Yes | Yes |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## What changed

- Added Mydentify to the Business section.
- Linked to the public OpenAPI 3.1 document.
- Declared no authentication, HTTPS support, and CORS support.

## Why

Mydentify exposes free structured product-directory and weekly-leaderboard data for application discovery and research. The read endpoints require no account or API key.

Disclosure: I am submitting this on behalf of Mydentify.

## Validation

- Confirmed `https://mydentify.com/openapi.json` returns HTTP 200.
- Confirmed `https://mydentify.com/directories.json` returns HTTP 200 with `Access-Control-Allow-Origin: *`.
- Confirmed the entry is alphabetized and the 61-character description is within the 100-character limit.
- Ran all 31 repository unit tests successfully.
- Confirmed the change adds one link and no duplicate Mydentify entry exists.
