### PR TITLE
fix(scripts): use raw string format for regex patterns in format.py

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(rf'{anchor}\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]


### PR DESCRIPTION
## Description
This PR fixes Python 3.12+ DeprecationWarning: invalid escape sequence warnings in scripts/validate/format.py.

## Details
- Converted regex string literals to raw strings.
- All 31 validation tests pass cleanly with zero warnings.