### PR TITLE
fix(validate): catch requests.exceptions.Timeout and ReadTimeout as ERR:TMO in links.py

### DIFF
--- a/scripts/validate/links.py
+++ b/scripts/validate/links.py
@@ -183,7 +183,7 @@ def check_if_link_is_working(link: str) -> Tuple[bool, str]:
         has_error = True
         error_message = f'ERR:CNT: {error} : {link}'
 
-    except (TimeoutError, requests.exceptions.ConnectTimeout):
+    except (TimeoutError, requests.exceptions.Timeout, requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
         has_error = True
         error_message = f'ERR:TMO: {link}'
 


### PR DESCRIPTION
## Description
This PR updates the link validator in `scripts/validate/links.py` to handle `requests.exceptions.ReadTimeout` and `requests.exceptions.Timeout` under the `ERR:TMO` handler instead of falling through to `ERR:UKN`.