### PR TITLE
Add Loa API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Infermedica](https://developer.infermedica.com/docs/) | NLP based symptom checker and patient triage API for health diagnosis from text | `apiKey` | Yes | Yes |
 | [LAPIS](https://cov-spectrum.ethz.ch/public) | SARS-CoV-2 genomic sequences from public sources | No | Yes | Yes |
 | [Lexigram](https://docs.lexigram.io/) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
+| [Loa](https://www.loacare.com/api-partnership) | Search providers and compare source-labeled US healthcare prices | No | Yes | No |
 | [Longevity World Cup](https://longevityworldcup.com/api/data/athletes) | Public biological age competition data with biomarkers and rankings | No | Yes | Yes |
 | [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
 | [MedlinePlus Genetics](https://medlineplus.gov/about/developers/geneticsdatafilesapi/) | Genetic conditions, genes, chromosomes and mtDNA data | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds Loa to the Health category. Loa provides free public reads for searching U.S. healthcare providers and hospitals and comparing source-labeled medical prices.

Verified before submission:
- Documentation: https://www.loacare.com/api-partnership
- OpenAPI 3.1 contract: https://www.loacare.com/api/v1/openapi.json
- Public unauthenticated read: `GET /api/v1/entities/search`
- HTTPS: yes
- CORS: no

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit