### PR TITLE
Add DepthFeed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
+| [DepthFeed](https://depthfeed.com/docs) | Historical prediction-market order-book data for backtesting | `apiKey` | Yes | No |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds DepthFeed to Finance.

DepthFeed provides a self-serve REST API for historical and live prediction-market order-book data. The Explorer plan is free, requires no payment method, and lets developers create an API key from the dashboard.

## Verification

- Documentation: https://depthfeed.com/docs
- API base: `https://api.depthfeed.com/v3`
- Authentication: API key (`Authorization: Bearer` or `X-API-Key`)
- HTTPS: yes
- CORS: no; GET responses contain no `Access-Control-Allow-Origin` header and preflight returns 405
- Duplicate search: no existing DepthFeed name, domain, issue, or pull request
- Description: under 100 characters
- Placement: alphabetical in Finance
- The added row passes the documented five-column, allowed-value, length, capitalization, and alphabetical-placement rules
- The repository-wide validators also report numerous pre-existing baseline formatting and duplicate-link findings unrelated to this one-row change

Affiliation disclosure: I am submitting this on behalf of the DepthFeed team.
