### PR TITLE
Add AlterLab API

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
-| [AlterLab](https://alterlab.io) | Web scraping API with automatic anti-bot bypass, JS rendering, and structured data extraction | `apiKey` | Yes | Unknown |
+| [AlterLab](https://alterlab.io) | Web scraping API with automatic website compatibility, JS rendering, and structured data extraction | `apiKey` | Yes | Unknown |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
+| [AlterLab](https://alterlab.io) | Web scraping API with automatic anti-bot bypass, JS rendering, and structured data extraction | `apiKey` | Yes | Unknown |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |


### PR DESCRIPTION
Adds AlterLab to the **Development** section.

[AlterLab](https://alterlab.io) is a web data API — scrape, crawl, search, map, and extract — with automatic website compatibility and JavaScript rendering.

- Auth: `apiKey`
- HTTPS: Yes
- CORS: Unknown
- Docs: https://docs.alterlab.io
- Free credits on signup, no subscription required

Entry follows the table format and is placed alphabetically within the section.
