### PR TITLE
Add USDA NRCS API to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1448,6 +1448,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |
 | [University of Oslo](https://data.uio.no/) | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No | Yes | Unknown |
 | [UPC database](https://upcdatabase.org/api) | More than 1.5 million barcode numbers from all around the world | `apiKey` | Yes | Unknown |
+| [USDA NRCS](https://sdmdataaccess.nrcs.usda.gov/) | Soil and land management data, vegetation data, conservation practices | No | Yes | Unknown |
 | [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
 | [Voidly](https://voidly.ai/api-docs) | Internet censorship measurements, incidents, and ISP-level blocking data across 126 countries | No | Yes | No |
 | [Warnely](https://warnely.com/developers) | Composite travel-safety scores for 180 countries (FCDO + US State + GPI + WGI + live incident wire), OpenAPI 3.1 spec, CC BY 4.0 | No | Yes | Yes |


### PR DESCRIPTION
## Summary
Added the USDA Natural Resources Conservation Service (NRCS) API to the Open Data category.

## Changes
- Added USDA NRCS API entry to the Open Data section
- Alphabetically placed after UPC database and before Urban Observatory
- Documentation URL: https://sdmdataaccess.nrcs.usda.gov/

## API Details
- **Name**: USDA NRCS  
- **Description**: Soil and land management data, vegetation data, conservation practices
- **Auth**: No (free access, no API key required)
- **HTTPS**: Yes
- **CORS**: Unknown (likely not supported for browser access, server-side use recommended)

## Why This API?
The USDA NRCS provides valuable geospatial and environmental data for conservation, agriculture, and land management research. It's freely accessible to all users without authentication.

## Validation
- ✅ Entry follows exact formatting guidelines
- ✅ Description is under 100 characters (85 chars)
- ✅ Alphabetically ordered in the Open Data section
- ✅ One API per PR as required
- ✅ No functionality changes, documentation only

