### PR TITLE
Add afriref API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,6 +1121,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Government
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [afriref](https://afriref.dev) | Cited African government reference data: rates, VAT, wages, tax, holidays for 34 countries | No | Yes | No |
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |


### PR DESCRIPTION
Adds afriref to the Government section.

afriref provides cited government reference data (central-bank policy rates, VAT, minimum wages, CPI, corporate/income tax, public holidays) for 34 African countries. Every value links to its official primary source with a last-confirmed date.

Free, no auth: public holidays for all 34 countries + full catalog. Paid access ($0.001/call) via x402 or prepaid card packs - not required for the free tier this listing covers.

All contributing-guide checklist items verified before submitting: alphabetical placement confirmed against scripts/validate/format.py's sort logic, description is 90 characters with no trailing punctuation, table columns padded to match neighboring rows, single squashed commit, repo searched beforehand for existing afriref entries (none found).