### PR TITLE
Add InvoicePDF API to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
+| [InvoicePDF](https://github.com/rahulatrkm/invoicepdf) | Generate invoice and receipt PDFs from JSON; no headless browser, free tier | `No` | Yes | Unknown |
 | [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth` | Yes | Unknown |
 | [Mattermost](https://api.mattermost.com/) | An open source platform for developer collaboration | `OAuth` | Yes | Unknown |
 | [Mercury](https://mercury.postlight.com/web-parser/) | Web parser | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds InvoicePDF, a free (no-signup) API that generates invoice and receipt PDFs from JSON without a headless browser.

- Auth: No (free tier requires no signup/key)
- HTTPS: Yes
- Docs & live demo: https://invoicepdf-app.azurewebsites.net
- Open source (MIT): https://github.com/rahulatrkm/invoicepdf

Entry added alphabetically in Documents & Productivity. Not a paid-only/marketing listing — the free tier is fully functional with no purchase required.