### PR TITLE
Add OGCheck API to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Netlify](https://docs.netlify.com/api/get-started/) | Netlify is a hosting service for the programmable web | `OAuth` | Yes | Unknown |
 | [NetworkCalc](https://networkcalc.com/api/docs) | Network calculators, including subnets, DNS, binary, and security tools | No | Yes | Yes |
 | [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) | Query information about your favorite Node.js libraries programatically | No | Yes | Unknown |
+| [OGCheck](https://github.com/rahulatrkm/ogcheck) | Validate Open Graph tags, robots.txt and sitemap.xml for any URL; free | `No` | Yes | Unknown |
 | [OneSignal](https://documentation.onesignal.com/docs/onesignal-api) | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App | `apiKey` | Yes | Unknown |
 | [Open Page Rank](https://www.domcop.com/openpagerank/) | API for calculating and comparing metrics of different websites using Page Rank algorithm | `apiKey` | Yes | Unknown |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |


### PR DESCRIPTION
Adds OGCheck, a free (no-signup) API that validates Open Graph/Twitter Card tags, robots.txt and sitemap.xml for any URL in one request.

- Auth: No (free, no key required)
- HTTPS: Yes
- Docs & live demo: https://ogcheck-app.azurewebsites.net
- Open source (MIT): https://github.com/rahulatrkm/ogcheck

Placed alphabetically in Development. Distinct from OpenGraphr (which retrieves OG data) — OGCheck validates OG/robots/sitemap correctness. Fully functional free tier, no purchase required.