### PR TITLE
Add ssid.ai API to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,6 +1666,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SecurityTrails](https://securitytrails.com/corp/apidocs) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
+| [ssid.ai](https://ssid.ai/api-docs) | MAC address (OUI) vendor lookup, randomized-MAC detection, and router default-login directory | No | Yes | Yes |
 | [SSL Domain Health Check](https://rapidapi.com/goktugbk/api/ssl-domain-health-check) | SSL certificate validity, domain WHOIS status, and DNS record checks for any domain | `apiKey` | Yes | Unknown |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |


### PR DESCRIPTION
Adds ssid.ai — a free MAC address (OUI) vendor lookup and randomized-MAC detector, plus a manufacturer-cited router default-login directory and compliance index.

- **Auth:** No (free tier, 100 req/day; higher tiers with an API key)
- **HTTPS:** Yes
- **CORS:** Yes
- Docs: https://ssid.ai/api-docs
- Example: `GET https://ssid.ai/api/v1/lookup?mac=F4:F5:E8:11:22:33`

Placed alphabetically in Security, between Spyse and SSL Domain Health Check — nearest existing neighbors by category are Shodan/Censys/GreyNoise (search engines / lookup tools for internet-connected devices), which ssid.ai's device-identity lookup fits the same pattern as.