### PR TITLE
Remove hijacked URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1810,7 +1810,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
 | [DummyJSON](https://dummyjson.com/) | Fake REST API with products, users, posts, comments, todos and more | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
-| [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
 | [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |
 | [GeneradorDNI](https://api.generadordni.es) | Data generator API. Profiles, vehicles, banks and cards, etc | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
I am 90% certain that FakeJSON's URL has currently been hijacked. At the very least, its URL is now a redirect to a site completely unrelated to JSON or software development at all in first glance.

(In the more general case, I don't know if it'd be possible, or a good idea, to have a bot e.g. do a periodic sweep over the list of links, and perhaps flag the most suspicious redirected URLs.)

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [X] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [X] ~~My addition is ordered alphabetically~~ *(not an addition)*
- [X] ~~My submission has a useful description~~ *(not an addition)*
- [X] ~~The description does not have more than 100 characters~~ *(not an addition)*
- [X] ~~The description does not end with punctuation~~ *(not an addition)*
- [x] ~~Each table column is padded with one space on either side~~ *(not an addition)*
- [X] I have searched the repository for any relevant issues or pull requests
- [X] ~~Any category I am creating has the minimum requirement of 3 items~~ *(not an addition)*
- [X] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
