### PR TITLE
Add FlightFinder Safety Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1902,6 +1902,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CruiseFeed](https://cruisefeed.io) | Normalized cruise line inventory: ships, sailings, itineraries, ports and lead-in fares | `apiKey` | Yes | Unknown |
 | [CTS](https://api.cts-strasbourg.eu/) | CTS Realtime API | `apiKey` | Yes | Yes |
 | [FAA N-Number Registry](https://n-number.starfile.org/api) | Every FAA-registered civil aircraft in the United States, lookup by N-number or Mode S hex code | No | Yes | Yes |
+| [FlightFinder Safety Data](https://himaxym.com/developers) | Aviation accident and incident records, FAA wildlife and laser strikes, drone sightings | No | Yes | Yes |
 | [Grab](https://developer.grab.com/docs/) | Track deliveries, ride fares, payments and loyalty points | `OAuth` | Yes | Unknown |
 | [GraphHopper](https://docs.graphhopper.com/) | A-to-B routing with turn-by-turn instructions | `apiKey` | Yes | Unknown |
 | [Icelandic APIs](http://docs.apis.is/) | Open APIs that deliver services in or regarding Iceland | No | Yes | Unknown |


### PR DESCRIPTION
Adds the FlightFinder Safety Data API under Transportation.

**What it serves:** aviation accident and incident records aggregated from NTSB, ASN, B3A, CENIPA, ATSB and TSB Canada, plus the FAA wildlife-strike, laser-strike and drone-sighting datasets.

**Checked against the contributing rules before opening:**
- Free, no key required — `/api/v1/data/events`, `/sources`, `/ping`, `/wildlife-strikes`, `/drone-sightings` and `/aircraft/{family}/safety` all return `200 application/json` with no `Authorization` header. Auth listed as `No`.
- HTTPS: yes.
- CORS: yes — responses carry `access-control-allow-origin: *`.
- Description is 87 characters.
- Placed alphabetically, between FAA N-Number Registry and Grab.
- One link, one PR.
- Ran `scripts/validate/format.py` before and after the edit: 554 pre-existing errors either way, none introduced by this entry.

The underlying FAA datasets are published openly under CC BY 4.0 with DOIs (10.5281/zenodo.21597208, .21347862, .21347864), so anything built on this stays citable.