### PR TITLE
Add Quant Data to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [Quant Data](https://quantdata.uk/docs) | Measured market statistics: day-type probabilities, volume-wave events with measured win rates, options max pain and dealer gamma | No | Yes | No | |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
| Field | Value |
|---|---|
| API | [Quant Data](https://quantdata.uk/docs) |
| Auth | No — every endpoint answers 10 calls/day per source with no key or signup (an optional key lifts the limit) |
| HTTPS | Yes |
| CORS | No |

Measured market statistics (day-type probabilities, volume-wave events with measured win rates, options max pain, dealer gamma). Genuinely usable for free without any credential: `curl https://api.quantdata.uk/v1/maxpain/SPY` returns the full JSON. Alphabetical position in the Finance table (promoted first row skipped).