### PR TITLE
Fix auth for CoinCap (v2 retired, requires apiKey) and Econdb (now requires auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
 | [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
 | [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [CoinCap](https://docs.coincap.io/) | Real time Cryptocurrency prices through a RESTful API | No | Yes | Unknown |
+| [CoinCap](https://pro.coincap.io/api-docs) | Real time Cryptocurrency prices through a RESTful API | `apiKey` | Yes | Unknown |
 | [CoinDCX](https://docs.coindcx.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [CoinDesk](https://old.coindesk.com/coindesk-api/) | CoinDesk's Bitcoin Price Index (BPI) in multiple currencies | No | Yes | Unknown |
 | [CoinGecko](http://www.coingecko.com/api) | Cryptocurrency Price, Market, and Developer/Social Data | No | Yes | Yes |
@@ -834,7 +834,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
-| [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
+| [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | `apiKey` | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Edgrapi](https://edgrapi.com) | Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q sections as normalized JSON | `apiKey` | Yes | Unknown | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |


### PR DESCRIPTION
Two entries verified stale on 2026-07-30 by live-probing the endpoints:

**CoinCap** (Cryptocurrency)
- `api.coincap.io` no longer resolves (DNS dead)
- `docs.coincap.io` returns 301
- The current API (`rest.coincap.io/v3`) returns 401 without an API key
- Changed Auth `No` -> `apiKey`, updated link to https://pro.coincap.io/api-docs

**Econdb** (Finance)
- `https://www.econdb.com/api/series/CPIUS/?format=json` returns HTTP 401 `{"detail":"Authentication credentials were not provided."}`
- Changed Auth `No` -> `apiKey`

No other changes.