### PR TITLE
Add Coloripedia API

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Améthyste](https://api.amethyste.moe/) | Generate images for Discord users | `apiKey` | Yes | Unknown |
 | [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
+| [Coloripedia](https://coloripedia.com/api/) | 312 named colors with hex, RGB, HSL, CMYK, families and tags | No | Yes | Yes |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

---

Adds Coloripedia to **Art & Design**.

It's a reference dataset of 312 named colors — hex, RGB, HSL and CMYK values, families,
tags and relations between colors. Every endpoint is a static file generated at deploy
time and served from a CDN, so there is no key, no quota and nothing to rate-limit.

```
curl https://coloripedia.com/api/v1/colors/sage.json
```

- Auth: none
- HTTPS: yes
- CORS: `Access-Control-Allow-Origin: *`
- Licence: CC BY 4.0, so it's usable commercially
- Docs: https://coloripedia.com/api/

The section already lists Colormind, ColourLovers and xColors, but those generate
schemes or palettes. This one answers the different question of *what a colour is
called* and what its documented values are, and it can be downloaded in full as
[JSON](https://coloripedia.com/api/v1/colors.json) or
[CSV](https://coloripedia.com/api/v1/colors.csv) rather than only queried.

No paid tier exists, and there is nothing to purchase or sign up for.
