### PR TITLE
Add Cloudflare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [Changelogs.md](https://changelogs.md) | Structured changelog metadata from open source projects | No | Yes | Unknown |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
+| [Cloudflare](https://developers.cloudflare.com/api/) | Manage DNS, CDN, Workers and other services; documented with an official OpenAPI 3.0 spec | `apiKey` | Yes | No |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
 | [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds Cloudflare's official API to the Development section.

- Manage DNS, CDN, Workers and other services
- Documented with an official OpenAPI 3.0.3 spec (https://github.com/cloudflare/api-schemas)
- Auth: apiKey, HTTPS: Yes, CORS: No (verified live)
- Placed alphabetically between Ciprand and Cloudflare Trace
- Not a duplicate of any existing entry