### PR TITLE
Add Tariffs Tool API (US import tariff & customs-duty data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Tariffs Tool](https://www.tariffstool.com/developers) | US import tariff and customs-duty rates by country and product sector, with Section 301/232/122 stacking applied | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
-| [Tariffs Tool](https://www.tariffstool.com/developers) | US import tariff and customs-duty rates by country and product sector, with Section 301/232/122 stacking applied | No | Yes | Yes |
+| [Tariffs Tool](https://www.tariffstool.com/developers) | US import tariff & customs-duty rates by country & product sector, with 301/232/122 stacking | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the **Tariffs Tool API** to the **Government** category.

- **What it is:** Free JSON API for current US import tariff and customs-duty rates by country and product sector, with the full stacking regime (Section 301 / 232 / 122 and bilateral ceilings) applied, plus a dated feed of tariff-regime changes.
- **Auth:** No — no key or signup required.
- **HTTPS:** Yes.
- **CORS:** Yes (`Access-Control-Allow-Origin: *`).
- **Docs:** https://www.tariffstool.com/developers
- **Live endpoint:** https://www.tariffstool.com/api/v1/rates

Checklist:
- [x] Entry added in alphabetical order within its category
- [x] Description is clear, capitalized, and has no trailing period
- [x] Link is HTTPS and returns 200
- [x] One API per pull request
- [x] Follows the table format

🤖 Generated with [Claude Code](https://claude.com/claude-code)