### PR TITLE
Add CarDossier Poland Market API (Transportation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1897,6 +1897,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BIC-Boxtech](https://docs.bic-boxtech.org/) | Container technical detail for the global container fleet | `OAuth` | Yes | Unknown |
 | [BlaBlaCar](https://dev.blablacar.com) | Search car sharing trips | `apiKey` | Yes | Unknown |
 | [Boston MBTA Transit](https://www.mbta.com/developers/v3-api) | Stations and predicted arrivals for MBTA | `apiKey` | Yes | Unknown |
+| [CarDossier Poland Market](https://car-dossier.com/en/api/docs) | Polish used-car market data: valuations, price history, liquidity and regional prices (free tier, keyless demo) | `apiKey` | Yes | Yes |
 | [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | Transitland API | No | Yes | Unknown |
 | [Compare Flight Prices](https://rapidapi.com/obryan-software-obryan-software-default/api/compare-flight-prices/) | API for comparing flight prices across platforms | `apiKey` | Yes | Unknown |
 | [CruiseFeed](https://cruisefeed.io) | Normalized cruise line inventory: ships, sailings, itineraries, ports and lead-in fares | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the CarDossier Poland Market API to Transportation (alphabetical position).

- Polish used-car market data: valuations, price history trends, market liquidity, regional pricing — computed from 1.4M+ active listings updated daily
- Free tier: 50 credits on registration (no card), plus a keyless demo tier (5 calls/IP/day, no auth at all) so the API can be tried instantly
- Auth: `apiKey` (X-API-Key header) · HTTPS: Yes · CORS: Yes (Access-Control-Allow-Origin: *)
- Docs: https://car-dossier.com/en/api/docs · OpenAPI 3.1: https://car-dossier.com/openapi.yaml

Checked the formatting guidelines (5-column row, accepted Auth/CORS values, alphabetical order).