### PR TITLE
Add dotsweep API

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
+| [dotsweep](https://dotsweep.com/docs) | Domain availability across 1200+ TLDs with registration and renewal prices | No | Yes | Yes |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds dotsweep to Development.

| Field | Value |
|---|---|
| Docs | https://dotsweep.com/docs |
| Auth | `No` — no key, no account, no signup |
| HTTPS | Yes |
| CORS | Yes — verified: `access-control-allow-origin: *` |

Domain availability checked against the registries themselves (RDAP, with a WHOIS fallback), returning **renewal** price alongside registration, the registry's minimum term, and eligibility rules. Free and unmetered; a repeat lookup is served from the edge cache.

```
curl https://dotsweep.com/check/example.com
{"domain":"example.com","status":"taken","confidence":"certain","source":"dns"}
```

Placed alphabetically between `DomainDb Info` and `DownStatus`. Description is 74 characters. Not a paid service and not a free tier over a paid product — there is nothing to buy.