### PR TITLE
Add Halal Terminal API (Shariah stock/ETF screening) to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
 | [Goldprice.dev](https://goldprice.dev/docs) | Cross-validated gold, silver & copper spot, futures & 30-year history in 13 currencies | No | Yes | Unknown | |
+| [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 75+ countries with 121K+ bank entries | No | Yes | Yes |


### PR DESCRIPTION
Adds Halal Terminal: Shariah-compliant stock and ETF screening API across 5 methodologies (AAOIFI, DJIM, FTSE, MSCI, S&P), with purification rates and zakat calculation. Free tier (500 tokens/month), apiKey auth, HTTPS, CORS enabled, OpenAPI docs at https://api.halalterminal.com/docs. Placed alphabetically in Finance.