### PR TITLE
Add Tollmint to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Tollmint](https://tollmint.com) | Cited advertising and subscription law, with struck-down rules flagged | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds a free API for advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK.

Each rule cites a primary source, and the API records whether that URL still resolved when the corpus was built. It also tracks which rules are **no longer in force** — the FTC Click-to-Cancel rule was vacated on 8 July 2025 and the DOT ancillary-fee rule en banc on 3 February 2026, and both are still widely cited as current law.

- **Auth:** No — 11 corpus endpoints are free and need no key or account
- **HTTPS:** Yes
- **CORS:** Yes

Try it in a browser, no signup:

    https://api.tollmint.com/v1/legal/subscriptions?limit=2&jurisdiction=US

Catalog: https://api.tollmint.com/v1/agent/catalog
OpenAPI: https://api.tollmint.com/openapi.json

`scripts/validate/format.py` reports the same 560 pre-existing errors before and after this change; the added line contributes none.