### PR TITLE
Add VideoGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1328,6 +1328,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
+| [VideoGen](https://docs.videogen.io) | AI video workflows and media tools: script-to-video, clips, voice, and images | `apiKey` | Yes | Unknown |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Summary
Adds [VideoGen](https://docs.videogen.io) to the Machine Learning section.

VideoGen is a documented HTTPS REST API (`https://api.videogen.io`) for AI video workflows (script-to-video, voiceover-to-video, slideshow-to-video) and standalone media tools (image/video generation, TTS, avatars, etc.). Authentication uses a developer API key (Bearer); OAuth 2.1 is also supported for third-party apps.

## Checklist
- [x] Alphabetical order within section (between Unplugg and WolframAlpha)
- [x] One API per PR
- [x] API name does not end with "API"
- [x] Description under 100 characters
- [x] Link points to official documentation


Made with [Cursor](https://cursor.com)