### PR TITLE
Add Tollmint to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Tollmint](https://api.tollmint.com) | Advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [Tollmint](https://api.tollmint.com) to the Government section.

A free API for advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK. No authentication required for the 11 corpus endpoints, HTTPS only, CORS enabled (verified: \Access-Control-Allow-Origin: *\).

- [x] Alphabetical order within section (between Represent by Open North and UK Companies House)
- [x] One API per PR
- [x] Description under 100 characters
- [x] Link points to the API

Fixes #6738