### PR TITLE
Add restful-api API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Random Data](https://random-data-api.com) | Random data generator | No | Yes | Unknown |
 | [Randommer](https://randommer.io/randommer-api) | Random data generator | `apiKey` | Yes | Yes |
 | [RandomUser](https://randomuser.me) | Generates and list user data | No | Yes | Unknown |
+| [restful-api](https://restful-api.dev) | Fake REST API for testing and prototyping with CRUD endpoints | No | Yes | No |
 | [RoboHash](https://robohash.org/) | Generate random robot/alien avatars | No | Yes | Unknown |
 | [Spanish random names](https://random-names-api.herokuapp.com/public) | Generate spanish names (with gender) randomly | No | Yes | Unknown |
 | [Spanish random words](https://palabras-aleatorias-public-api.herokuapp.com) | Generate spanish words randomly | No | Yes | Unknown |


### PR DESCRIPTION
Add [restful-api](https://restful-api.dev) to the **Test Data** category.

**About the API**
- Free, no authentication required, HTTPS-only.
- A fake REST API for prototyping and testing (products, users, carts, auth, full CRUD) — a modern companion to the existing `DummyJSON` / `FakerAPI` entries.
- Clear documentation at https://restful-api.dev

**Checklist (from the PR template)**
- [x] Formatted per the contributing guide (5-column table, single-space padding)
- [x] Ordered alphabetically within the section
- [x] Useful description, <= 100 chars, no trailing punctuation
- [x] Exactly one link added; not already present in the list
- [x] Squashed into a single commit, targeting `master`

The added link returns HTTP 200 with CORS enabled and was verified against the repo's own `scripts/validate/links.py` flow.