### PR TITLE
Add AI Economics Tools API (Machine Learning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Machine Learning
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [AI Economics Tools](https://piszczek.pl/tools/api) | AI cost, energy and agent-verification calculators: token cost, LLM energy, Proof-Adjusted Autonomy, revocation exposure | No | Yes | Yes |
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Machine Learning
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
-| [AI Economics Tools](https://piszczek.pl/tools/api) | AI cost, energy and agent-verification calculators: token cost, LLM energy, Proof-Adjusted Autonomy, revocation exposure | No | Yes | Yes |
+| [AI Economics Tools](https://piszczek.pl/tools/api) | AI cost, energy and agent-verification calculators by Michał Piszczek: token cost, LLM energy, Proof-Adjusted Autonomy, revocation exposure | No | Yes | Yes |
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Machine Learning
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
-| [AI Economics Tools](https://piszczek.pl/tools/api) | AI cost, energy and agent-verification calculators by Michał Piszczek: token cost, LLM energy, Proof-Adjusted Autonomy, revocation exposure | No | Yes | Yes |
+| [AI Economics Tools](https://piszczek.pl/tools/api) | Token cost, LLM energy, agent-hour and Proof-Adjusted Autonomy calculators by Michał Piszczek | No | Yes | Yes |
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |


### PR DESCRIPTION
**What does this PR add?**

[AI Economics Tools](https://piszczek.pl/tools/api) — a free, no-auth JSON API exposing 12 calculators for AI economics: token cost across vendors, context-window sizing, agent-hour cost, model-routing savings, LLM energy per query, joules per verified task, org-wide token burn, humanoid energy budgets, revocation exposure, Proof-Adjusted Autonomy, verification bottleneck and proof debt.

**Checklist**
- [x] Full free access — no key, no sign-up, no paid tier, no device required
- [x] HTTPS: yes
- [x] CORS: yes (open)
- [x] Auth: No
- [x] Alphabetical order preserved (Machine Learning section)
- [x] Discovery document at the root lists every tool, parameter and formula: `curl -s https://piszczek.pl/tools/api`

Example call:
```
curl -s "https://piszczek.pl/tools/api/proof-adjusted-autonomy?a=90&c=95&r=80&t=90"
```
Responses are stateless (inputs never stored) and include the result, the formula and a one-line interpretation.