### PR TITLE
Add RunConvert API

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Renderly](https://renderlyapi.com) | HTML to PDF conversion API built on Chromium | `apiKey` | Yes | Yes |
 | [Rendex](https://rendex.dev) | Render HTML, Markdown, or URLs to PNG/JPEG/WebP/PDF, with extraction and templating | `apiKey` | Yes | Unknown |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
+| [RunConvert](https://www.runconvert.com/docs) | Convert video, audio, image, and document files programmatically | `apiKey` | Yes | No |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |
 | [staffSign](https://staffsign.de/docs) | Digital employment contract API with QES/eIDAS support for HR and staffing | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds RunConvert to the Documents & Productivity section.

RunConvert is a file conversion REST API (video, audio, image, document, archive, CAD, ebook, font conversion). Authenticated via API key (Bearer token), full HTTPS, with a free tier (signed-in accounts get free daily credits, no account required for limited guest usage).

- API docs: https://www.runconvert.com/docs
- Alphabetically placed after Restpack, before Todoist.
- Verified entry against `scripts/validate/format.py` with no new errors.
- Verified the docs link resolves (200).