### PR TITLE
Add cz-agents Due Diligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
 | [Conversor IAE CNAE](https://www.conversoriaecnae.es/api/v1/docs) | Spanish IAE/CNAE tax activity codes, 2009→2025 crosswalk and AEAT obligations | `apiKey` | Yes | No |
+| [cz-agents Due Diligence](https://cz-agents.dev/docs/) | Czech company due diligence by IČO: registry facts, sanctions screening, risk score | No | Yes | No |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
 | [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |
 | [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members) | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No | No | Unknown |


### PR DESCRIPTION
Adds a free, no-key API for Czech company due diligence.

`GET https://dd.cz-agents.dev/v1/dd/{ico}` returns registry facts from ARES (name,
address, legal form, VAT status), the statutory body with a per-member EU+OFAC
sanctions check, and a transparent risk score.

- **Auth:** none — no key, no registration, no rate-limit token
- **HTTPS:** yes
- **CORS:** no (verified with an `Origin` header; the response carries no
  `access-control-allow-origin`)
- **Docs:** https://cz-agents.dev/docs/

Placed in `Government` alongside the other national company registries
(UK Companies House, OpenRegistry, Brazil Receita WS), in alphabetical order between
`Conversor IAE CNAE` and `Data USA`. There is currently no Czech company registry
listed anywhere in the README.

Verified before opening: the endpoint returns 200 on repeated anonymous calls, and
`scripts/validate/format.py` reports no findings on the added line (the 560 pre-existing
findings elsewhere are unchanged by this diff).
