### PR TITLE
Add ProxyForge — free live-tested proxy JSON API (No auth, HTTPS, CORS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
+| [ProxyForge](https://proxyforge.dev) | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h | No | Yes | Yes |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |
 | [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey` | Yes | Unknown |
 | [QR & Barcode](https://solsigs.com/qrapi/) | QR codes and barcodes (Code 128, EAN-13, Data Matrix, PDF417 + more). SVG or PNG output | No | Yes | Yes |


### PR DESCRIPTION
## Add ProxyForge to Development section

**ProxyForge** (https://proxyforge.dev) is a free service that publishes an auto-updating list of live-tested proxies — HTTP, HTTPS, SOCKS4, SOCKS5 — refreshed every 6 hours.

| Field | Value |
|---|---|
| API | [ProxyForge](https://proxyforge.dev) |
| Description | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

Placed alphabetically between ProxyCrawl and ProxyKingdom in the Development section.

— ProxyForge / Kiprio Team