### PR TITLE
Add Food Info API

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
 | [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |
 | [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | Recipe Search | `apiKey` | Yes | Unknown |
+| [Food Info](https://food-info.org/developer) | Nutrition data for millions of foods from six national food composition datasets | `apiKey` | Yes | No |
 | [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
 | [Fruityvice](https://www.fruityvice.com) | Data about all kinds of fruit | No | Yes | Unknown |
 | [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Food Info to the Food & Drink section.

**What it is:** a nutrition data API covering millions of foods, merged from six national food composition datasets — USDA FoodData Central (US), McCance & Widdowson's CoFID (UK), ANSES Ciqual (France), the Danish Food Composition Database, FSANZ AUSNUT (Australia/NZ), and Open Food Facts for branded products. Endpoints cover food search, full nutrient panels per 100 g and per serving, and reverse nutrient search (foods richest or lowest in a given nutrient).

**Free tier:** yes. A free account gets an API key with 100 requests/day. No card required to sign up.

**Documentation:** https://food-info.org/developer — covers authentication, both tiers' rate limits, every endpoint with parameters, example requests and responses, and the error codes.

Checklist against the contributing guidelines:

- [x] Free tier available (100 requests/day on a free account)
- [x] Added in alphabetical order within the section
- [x] Description is 80 characters, under the 100 limit
- [x] Auth is `apiKey`, enclosed in backticks
- [x] Name does not end with "API" and contains no TLD
- [x] One link in this pull request
- [x] Public documentation exists at the linked URL
- [x] Single commit
- [x] Targets `master`

CORS is `No`: keys are intended to stay server-side, so browser origins are not enabled.