### PR TITLE
Add Merlonix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
+| [Merlonix](https://merlonix.com/docs/public-api/) | SSL, DNS, DMARC, blacklist and MCP server health checks for any domain or endpoint | No | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |
 | [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Yes | Unknown |


### PR DESCRIPTION
Adds Merlonix to the **Security** section.

It is a set of unauthenticated JSON endpoints for outside-in checks on a domain or an MCP endpoint: SSL/certificate expiry, DNS + DNSSEC, DMARC/SPF, DNSBL blacklist status, broken links, and remote MCP server health. No API key, no signup, no quota to buy — the rate limits (per IP, per minute, documented on the linked page) are the whole policy.

Try it without registering anything:

```
curl "https://api.merlonix.com/v1/public/domain-health?hostname=example.com"
curl "https://api.merlonix.com/v1/public/mcp-health?url=https://mcp.deepwiki.com/mcp"
```

Field values were verified live before submitting: **Auth** `No` (no key is accepted or required on any of these routes), **HTTPS** `Yes`, **CORS** `Yes` (every JSON route sends `Access-Control-Allow-Origin: *`, so it is usable client-side).

Disclosure: I work on Merlonix. There is a paid product for continuous monitoring and alerting, but nothing on the linked documentation page is gated — it is the free public surface, which is why I thought it fit here rather than being a marketing entry.

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically (between LoginRadius and Microsoft Security Response Center)
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (82)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category)
- [x] All changes have been squashed into a single commit