### PR TITLE
Add LayerCall to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1717,6 +1717,7 @@ API | Description | Auth | HTTPS | CORS |
 | [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IPLogs](https://iplogs.com/docs) | Free VPN, proxy, Tor and datacenter IP detection. 13 sources, active probing | No | Yes | Yes |
+| [LayerCall](https://www.layercall.com/docs) | Fraud and trust scoring for an IP, email, phone, domain or device in one call | `apiKey` | Yes | No |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |


### PR DESCRIPTION
Adding LayerCall to the Security section.

**Disclosure:** I built this API, so flagging that up front rather than having you find out.

| Field | Value |
|---|---|
| Entry | `[LayerCall](https://www.layercall.com/docs)` |
| Description | Fraud and trust scoring for an IP, email, phone, domain or device in one call (77 chars) |
| Auth | `apiKey` |
| HTTPS | Yes |
| CORS | No |

**On the free-tier requirement:** 1,000 lookups a month across every endpoint, no card required, and no daily cap underneath the monthly figure. At the limit it stops and returns an error rather than silently billing. There is also a test mode that returns synthetic data and never bills, so the API can be evaluated in CI without spending anything.

**On CORS:** deliberately `No`. This is a server-side API — browser-side calls would put the caller's API key in client code, so cross-origin requests are not enabled by design.

Checks:
- [x] Placed alphabetically in Security (between IPLogs and LoginRadius)
- [x] Name excludes TLD and the word "API"
- [x] Description under 100 characters, no trailing period
- [x] Auth uses an accepted value, in backticks
- [x] Link goes to documentation
- [x] One API in this PR
- [x] `scripts/validate/format.py` reports nothing against this line (the L2079 errors it prints are pre-existing on master, in the Weather section header)