### PR TITLE
Correct Food Info entry description

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
 | [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |
 | [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | Recipe Search | `apiKey` | Yes | Unknown |
-| [Food Info](https://food-info.org/developer) | Nutrition data for millions of foods from six national food composition datasets | `apiKey` | Yes | No |
+| [Food Info](https://food-info.org/developer) | Nutrient data for foods from five national food composition datasets plus Open Food Facts | `apiKey` | Yes | No |
 | [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
 | [Fruityvice](https://www.fruityvice.com) | Data about all kinds of fruit | No | Yes | Unknown |
 | [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Corrects the description on the Food Info entry added in #6758.

It said "six national food composition datasets". The correct figure is five (USDA FoodData Central, McCance & Widdowson's CoFID, ANSES Ciqual, DTU Frida and AUSNUT), plus Open Food Facts, which is crowdsourced rather than national. The published source list is at https://food-info.org/data-sources

Also drops "millions of foods", which described the full catalogue including branded products rather than the reference foods the description is about.