### PR TITLE
feat: Add Sylvia API to Social category (no-OAuth Reddit data, freemium)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,6 +1749,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Yes | Unknown |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
+| [Sylvia API](https://sylvia-api.com) | Reddit data API — no OAuth, no approval, 480 req/min free | `apiKey` | Yes | Yes |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Sylvia API (https://sylvia-api.com) to the Social category.

Sylvia is a Reddit data API with:
- No OAuth / no Reddit app approval required
- 480 req/min free tier with $0.50 starting credit
- $0.0005/req pay-per-success pricing
- apiKey authentication (X-API-KEY header)
- Full historical data back to 2005
- Live comments firehose, recursive threads, search

Current Reddit entry in this category is the official API (OAuth-only, rate-limited, approval required). Sylvia is the only no-OAuth, no-approval, freemium Reddit data API.

Meets all CONTRIBUTING.md criteria:
- ✅ Free/freemium tier available
- ✅ apiKey auth
- ✅ HTTPS
- ✅ CORS enabled (api.sylvia-api.com)
- ✅ Actively maintained
- ✅ Public documentation (https://sylvia-api.com/docs)