### PR TITLE
Add Kiprio PDF Text to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
 | [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth` | Yes | Unknown |
+| [Kiprio PDF Text](https://kiprio.com/v1/pdf-text/) | Extract plain text from PDF documents for LLM and RAG pipelines | No | Yes | Yes |
 | [Mattermost](https://api.mattermost.com/) | An open source platform for developer collaboration | `OAuth` | Yes | Unknown |
 | [Mercury](https://mercury.postlight.com/web-parser/) | Web parser | `apiKey` | Yes | Unknown |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Kiprio PDF Text API under **Documents & Productivity**.

| Field | Value |
|---|---|
| API | [Kiprio PDF Text](https://kiprio.com/v1/pdf-text/) |
| Description | Extract plain text from PDF documents for LLM and RAG pipelines |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

The API accepts PDF file uploads (multipart/form-data) or a URL parameter and returns extracted text with word and character counts. Free tier offers 20 requests/day with no API key required.