### PR TITLE
Add Veritify API to Data Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ API | Description | Auth | HTTPS | CORS |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
 | [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes | |
 | [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes | |
+| [Veritify](https://github.com/PantaleonSystems/veritify-python/blob/main/docs/getting-started.md) | Verify data integrity and novelty in files with a public cryptographic receipt | `apiKey` | Yes | Yes | |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds Veritify to the Data Validation section.

Veritify measures the integrity, novelty, and authenticity of arbitrary data (audio, text, documents), returning a cryptographically verifiable receipt hash that anyone can independently confirm — no trust or API key required to verify. Self-service API keys, free tier, documented Python SDK.

- Docs: https://github.com/PantaleonSystems/veritify-python/blob/main/docs/getting-started.md
- Live instance: https://veritify-api-production.up.railway.app/health

Checklist per CONTRIBUTING.md:
- [x] Alphabetically placed within the section
- [x] Description ≤ 100 characters
- [x] Name doesn't end with "API", no TLD in the name
- [x] `Auth` value is one of the accepted enum values (`apiKey`)
- [x] Free tier, no purchase required
- [x] One link, one PR