### PR TITLE
Add ETF Holdings API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Edgrapi](https://edgrapi.com) | Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q sections as normalized JSON | `apiKey` | Yes | Unknown | |
+| [ETF Holdings](https://etf-holdings.com/docs) | Current and historical ETF holdings data from issuer websites and SEC filings | `apiKey` | Yes | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds ETF Holdings to the Finance section.

**What it is:** an API for current ETF holdings, historical ETF holdings, and ETF holdings analysis and comparison reports. Data comes from issuer websites or SEC filings, depending which endpoint you use.

**Free tier:** yes. A free account gets an API key with 5000 holdings/day. No card required to sign up.

**Documentation:** https://etf-holdings.com/docs

Checklist against the contributing guidelines:

- [x] Free tier available (5000 holdings/day on a free account)
- [x] Added in alphabetical order within the section
- [x] Description is 77 characters, under the 100 limit
- [x] Auth is `apiKey`, enclosed in backticks
- [x] Name does not end with "API" and contains no TLD
- [x] One link in this pull request
- [x] Public documentation exists at the linked URL
- [x] Single commit
- [x] Targets `master`