### PR TITLE
Add stillworks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
+| [stillworks](https://stillworks.supercapybara.com) | Directories list. We check. Live-probed status of keyless LLM API endpoints, ranked by uptime | No | Yes | Yes |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

**Section:** Machine Learning

`GET https://stillworks.supercapybara.com/api/llm/up` returns the LLM chat endpoints that are currently
answering with no `Authorization` header at all — base URL, model id, latency, and how much of the last week
each one answered — ranked, so `models[0]` is the pick and the rest are fallbacks. Every row was produced by a
real chat completion sent on a schedule, not by reading provider documentation, and the failures are published
next to the successes. Capability flags (`tools`, `json_schema`, `json_object`, `vision`) are marked `proved`
only when a real call demonstrated them.

Verified for this entry: no auth, HTTPS, `Access-Control-Allow-Origin: *`.

What it does not claim, stated on the response itself: keyless quotas are commonly per-IP, so an endpoint that
answers the service's address can still refuse yours; rows probed with the project's own free-tier key prove
only that the endpoint answered that account.

```
curl -s https://stillworks.supercapybara.com/api/llm/up
```

Source and docs: https://github.com/bon5co/stillworks (MIT)

Disclosure: I work on stillworks — this is a self-submission, not a third-party recommendation.
