### PR TITLE
Add Marvel Cinematic Universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |
 | [Marvel](https://developer.marvel.com) | Marvel Comics | `apiKey` | Yes | Unknown |
+| [Marvel Cinematic Universe](https://augustomarcelo.github.io/mcuapi/) | Movies, TV shows, characters and in-universe chronological timeline | No | Yes | Yes |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |    
 | [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |
 | [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds a free, no-key REST API for Marvel Cinematic Universe data to **Games & Comics**.

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [Marvel Cinematic Universe](https://augustomarcelo.github.io/mcuapi/) | Movies, TV shows, characters and in-universe chronological timeline | No | Yes | Yes |

57 movies, 56 TV show seasons, 302 characters, and a 113-entry chronological
timeline across five continuity branches. Read-only, MIT licensed, open source
at https://github.com/AugustoMarcelo/mcuapi with Swagger docs at
https://mcuapi.up.railway.app/docs

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit