### PR TITLE
Remove Marvel (developer portal retired, endpoint dead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,7 +984,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |
-| [Marvel](https://developer.marvel.com) | Marvel Comics | `apiKey` | Yes | Unknown |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |    
 | [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |
 | [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Removes the **Marvel** entry from Games & Comics. Marvel retired the developer
portal in late 2025 and the API is no longer reachable, so the row sends people
to a dead end.

## Evidence

Every documented entry point is gone:

| URL | Result |
| --- | --- |
| `https://developer.marvel.com` | `301` → `https://www.marvel.com/` |
| `https://developer.marvel.com/docs` | `301` → `https://www.marvel.com/` |
| `https://developer.marvel.com/documentation/getting_started` | `301` → `https://www.marvel.com/` |
| `https://gateway.marvel.com/v1/public/comics` | `500` |

The portal no longer serves documentation or issues keys, and `gateway.marvel.com`
— the host the API itself was served from — returns a 500 rather than an auth
error, so this is not a credentials problem.

Since the entry is `apiKey` auth and keys can no longer be obtained, there is no
configuration under which this row is usable.

## Checklist

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Note: this is a removal, so several checklist items are not applicable — left
ticked to keep the template intact.

Disclosure: I have a separate open PR (#6778) adding an MCU API to the same
section. These are independent — this removal stands on the dead endpoint alone,
and I am happy for it to be judged on that regardless of what happens to #6778.