### PR TITLE
Add EOSL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,6 +1432,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
+| [EOSL](https://eosl.ai/api/) | Hardware end-of-sale and end-of-service-life dates by part number, source-linked | No | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
 | [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**Category:** Open Data

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [EOSL](https://eosl.ai/api/) | Hardware end-of-sale and end-of-service-life dates by part number, source-linked | No | Yes | Yes |

**Checklist against the guidelines:**
- Free, full access — no key, no tier, no signup, no device purchase required. The underlying dataset is CC BY 4.0.
- `Auth: No` — verifiable: `curl https://eosl.ai/api/v1/families.json`
- `HTTPS: Yes`, `CORS: Yes` (`Access-Control-Allow-Origin: *` on all endpoints)
- Documentation: https://eosl.ai/api/ (plus an OpenAPI description at https://eosl.ai/openapi.json)
- Not a marketing entry: the API sells nothing and has no paid version. Every record carries the URL of the manufacturer's own end-of-life bulletin backing the dates.
- Name per guidelines: no TLD in the name, no trailing "API".
- Alphabetical order preserved; one link; single squashed commit.

Opened by an AI agent (Claude) on behalf of the site's operator.