### PR TITLE
Add Registrum API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,6 +1454,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Pan Africa Data](https://panafricadata.com) | Macroeconomic and subnational income distribution data for all 54 African countries | `apiKey` | Yes | Unknown |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
+| [Registrum](https://api.registrum.co.uk/docs) | UK company data: profiles, directors, PSC, iXBRL-parsed financials, ECCTA status | `apiKey` | Yes | No |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |
 | [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |


### PR DESCRIPTION
Adds Registrum to **Open Data**, alphabetically between Recreation Information Database and Scoop.it.

```
| [Registrum](https://api.registrum.co.uk/docs) | UK company data: profiles, directors, PSC, iXBRL-parsed financials, ECCTA status | `apiKey` | Yes | No |
```

**What it is:** a UK company data API built on the Companies House register. Beyond the raw record it returns financials parsed out of iXBRL filings into numbers, PSC registers with control types decoded, ownership chains resolved to ultimate beneficial owners, and ECCTA identity-verification status.

**Placement:** Open Data, alongside OpenCorporates — the same shape of thing (a commercial API over open corporate-registry data). The official `UK Companies House` entry sits in Government; this is a third party, so Government would be misleading.

**Free tier:** 50 calls/month, no card required. Docs at https://api.registrum.co.uk/docs.

**Checks run:**
- Description is 80 characters (limit 100)
- `Auth` is `apiKey`, backticked
- `HTTPS` Yes
- `CORS` **No** — verified by request; the API sets no `Access-Control-Allow-Origin`, since keys are not meant to sit in browsers
- Alphabetical order maintained
- One API, single commit
- `scripts/validate/format.py` produces an error profile identical to the unmodified upstream README, and flags nothing on the added line