### PR TITLE
Add tgden — public Telegram catalog API (Social)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
+| [tgden](https://tgden.com/en/api-docs) | Public catalog of Telegram channels, group chats and bots with subscriber counts, categories, languages and full-text post search | No | Yes | Unknown |
 | [Telegraph](https://telegra.ph/api) | Create attractive blogs easily, to share | `apiKey` | Yes | Unknown |
 | [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth` | Yes | Unknown |
 | [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1755,7 +1755,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |
-| [tgden](https://tgden.com/en/api-docs) | Public catalog of Telegram channels, group chats and bots with subscriber counts, categories, languages and full-text post search | No | Yes | Unknown |
+| [tgden](https://tgden.com/en/api-docs) | Public catalog of Telegram channels, group chats and bots with subscriber counts, categories, languages and full-text post search | No | Yes | Yes |
 | [Telegraph](https://telegra.ph/api) | Create attractive blogs easily, to share | `apiKey` | Yes | Unknown |
 | [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth` | Yes | Unknown |
 | [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth` | Yes | Yes |


### PR DESCRIPTION
**API**: tgden — https://tgden.com/en/api-docs

A free, public, read-only catalog of what exists on Telegram: channels, group chats and bots, with subscriber/member counts, categories, languages and full-text search over posts. No account, no API key, no signup — it answers "what public Telegram communities exist about X", which the official Bot/MTProto APIs cannot (they only see what the authenticated user already has access to).

Live example, no auth:

```
curl 'https://tgden.com/api/catalog?limit=2'
```

- **Auth**: No — fully free, no key, no tier gate.
- **HTTPS**: Yes.
- **CORS**: Unknown — reported honestly; browser preflight currently returns no `Access-Control-Allow-Origin`. I will open a follow-up PR to flip this to `Yes` once it is enabled, rather than claim it now.

Entry added alphabetically in the **Social** section, between `Telegram MTProto` and `Telegraph`. Single-line diff.