### PR TITLE
Add OdiRouter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
 | [Not Human Search](https://nothumansearch.ai/openapi.yaml) | AI tool discovery with agentic scoring for 8,600+ tools and MCP servers | No | Yes | Yes |
+| [OdiRouter](https://odirouter.ai?utm_source=public-apis&channel=github) | OpenAI-compatible LLM gateway with 50 free requests per day | `apiKey` | Yes | Unknown |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1335,7 +1335,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
 | [Not Human Search](https://nothumansearch.ai/openapi.yaml) | AI tool discovery with agentic scoring for 8,600+ tools and MCP servers | No | Yes | Yes |
-| [OdiRouter](https://odirouter.ai?utm_source=public-apis&channel=github) | OpenAI-compatible LLM gateway with 50 free requests per day | `apiKey` | Yes | Unknown |
+| [OdiRouter](https://odirouter.ai/) | OpenAI-compatible LLM gateway with 50 free requests per day | `apiKey` | Yes | Unknown |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds OdiRouter to the Machine Learning category.

OdiRouter provides an OpenAI-compatible LLM gateway with 50 free requests per day.

## Verification

- Website: https://odirouter.ai/
- Free model catalog: https://odirouter.ai/models?category=Free
- API key page: https://odirouter.ai/dashboard/api-keys
- API documentation: https://odirouter.ai/docs/get-started/introduction
- Base URL: https://api.odirouter.ai/v1
- Auth: apiKey
- HTTPS: Yes
- CORS: Unknown
- Free tier: 50 requests/day
