### PR TITLE
Add Diagrams.so to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
 | [CountAPI](https://countapi.xyz) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey` | Yes | Yes |
+| [Diagrams.so](https://diagrams.so/developers) | Generate editable draw.io architecture diagrams from text or infrastructure code | `apiKey` | Yes | No |
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |


### PR DESCRIPTION
Adds Diagrams.so to the **Development** category, alphabetically between Databricks and DigitalOcean Status.

```
| [Diagrams.so](https://diagrams.so/developers) | Generate editable draw.io architecture diagrams from text or infrastructure code | `apiKey` | Yes | No |
```

A REST API that turns a text description, a Terraform directory or Kubernetes manifests into an architecture diagram, returned as a native draw.io file or SVG.

**On the free-access requirement:** there is a genuine free tier, not a trial. Every plan including Free can call the API on the same credit balance the web app uses, and the first call does not fail for payment. Reads are free entirely: fetching diagrams, listing versions, pulling warnings, exporting and searching the public gallery cost nothing.

**Field values, each checked rather than assumed:**

- `Auth`: `apiKey`, a bearer token created from the account settings
- `HTTPS`: Yes
- `CORS`: **No.** A preflight from an outside origin returns no `access-control-allow-origin` header, so the API is server-side only from a browser's perspective. Reported honestly rather than as Unknown.

Docs: https://diagrams.so/developers · OpenAPI spec: https://api.diagrams.so/api/v2/openapi.json

I ran `scripts/validate/format.py` locally before and after this change. The error count is identical at 557 either side, so this entry introduces nothing new, and no error is reported against the added line.