### PR TITLE
Add Phone Specs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # APILayer Unified Suite in now Live! 🎉 🥳
+| [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database with chipset, camera, battery, display data for 164+ phones | No | Yes | Yes |
 
 [APILayer unified suite](https://apilayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo) allows you to integrate production-grade REST APIs using **One Account, One Dashboard, and One API key.** Whether you need to geocode an address, validate an email, fetch a flight, pull stock market data, or scrape a search result.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # APILayer Unified Suite in now Live! 🎉 🥳
-| [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database with chipset, camera, battery, display data for 164+ phones | No | Yes | Yes |
 
 [APILayer unified suite](https://apilayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo) allows you to integrate production-grade REST APIs using **One Account, One Dashboard, and One API key.** Whether you need to geocode an address, validate an email, fetch a flight, pull stock market data, or scrape a search result.
 
@@ -627,6 +626,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenQR](https://openqr.uk/api) | Generate QR codes and manage dynamic (editable) QR codes with scan analytics | `apiKey` | Yes | Yes |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
+| [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database for 263 devices | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyForge](https://proxyforge.dev) | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h | No | Yes | Yes |


### PR DESCRIPTION
Add the Phone Specs API — a free REST API that provides detailed smartphone specifications for 164+ phones across 24 brands. Includes chipset, camera, battery, display, dimensions, and more.

- Docs: https://phone-specs-api-production.up.railway.app/docs
- Demo: https://phone-specs-api-production.up.railway.app/
- Source: https://github.com/rinehartwang1979/phone-specs-api