### PR TITLE
Add Statlyte to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,6 +1339,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
+| [Statlyte](https://statlyte.com/api) | Live pricing, context windows and model ids for major LLM APIs | No | Yes | Yes |
 | [TensorFeed](https://tensorfeed.ai/developers) | Real-time AI news, model pricing, service status, and agent activity feeds | No | Yes | Yes |
 | [Time Door](https://timedoor.io) | A time series analysis API | `apiKey` | Yes | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds one entry to **Machine Learning**, inserted alphabetically between SkyBiometry and TensorFeed.

```
| [Statlyte](https://statlyte.com/api) | Live pricing, context windows and model ids for major LLM APIs | No | Yes | Yes |
```

Current prices, context windows and API identifiers for 110 models across 8 providers, re-read from each vendor's own published pricing page every three hours with the source URL recorded. Solves the stale hardcoded model table every LLM app ends up with.

Against the checklist:
- **Free** — the whole dataset is open and stays open; no account, no key, no trial
- **Auth: No** — verified: `curl https://statlyte.com/api/v1/models` returns data with no credentials
- **HTTPS: Yes** · **CORS: Yes** — `access-control-allow-origin: *`
- Description 62 chars, no TLD in the name, does not end in "API"
- One link, single squashed commit, alphabetical order maintained, targeting `master`

Not a marketing submission: there is a paid tier for historical data, but the endpoint listed here is unauthenticated and free with no upsell in the response.