### PR TITLE
Add AmberOne API

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ API | Description | Auth | HTTPS | CORS |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
+| [AmberOne](https://scubamike124.github.io/amberone-api/) | Turn any website into a build-ready Android, iOS, PWA or Electron app project | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds AmberOne to **Development**.

Turns a URL into a build-ready Android, iOS, PWA, Electron or Capacitor project.

- **Docs:** https://scubamike124.github.io/amberone-api/
- **OpenAPI 3.1:** https://hq.amberoneai.com/api/v1/openapi.json (public, no key needed)
- **Source & SDKs:** https://github.com/scubamike124/amberone-api (MIT)

**Free tier:** yes — 3 wraps/month, and keys beginning `wrap_test_` run the
full pipeline without being billed, so the API can be evaluated end to end
for free.

**Auth:** `apiKey` (Bearer token).
**HTTPS:** yes.
**CORS:** no — verified. The spec endpoint sends `Access-Control-Allow-Origin: *`,
but the data endpoints deliberately do not, because calling them from a browser
would expose the caller's key.

Alphabetical placement and the 100-character description limit both checked.