### PR TITLE
Add Marketplace Fee Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1703,6 +1703,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | Manage shop and interact with listings | `OAuth` | Yes | Unknown |
 | [Flipkart Marketplace](https://seller.flipkart.com/api-docs/FMSAPI.html) | Product listing management, Order Fulfilment in the Flipkart Marketplace | `OAuth` | Yes | Yes |
 | [Lazada](https://open.lazada.com/doc/doc.htm) | Retrieve product ratings and seller performance metrics | `apiKey` | Yes | Unknown |
+| [Marketplace Fee Data](https://www.sellerscalc.com/data) | Seller fee schedules for 21 e-commerce marketplaces and payment processors as JSON | No | Yes | Yes |
 | [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Marketplace Fee Data** to the Shopping category.

Free, no-key JSON API of US seller fee schedules for 21 e-commerce marketplaces and payment processors (Amazon, eBay, Etsy, Walmart, TikTok Shop, Mercari, Poshmark, Depop, Vinted, Grailed, StockX, GOAT, PayPal, Stripe, Square, Shopify and others). CORS enabled, no auth, no rate limit, licensed CC BY 4.0.

- Docs: https://www.sellerscalc.com/data
- Directory: https://www.sellerscalc.com/data/index.json
- All platforms: https://www.sellerscalc.com/data/fees.json
- Per platform: https://www.sellerscalc.com/data/fees/amazon.json
- Source data (CC BY 4.0): https://github.com/sevendaysnow/marketplace-fee-data

Rates are re-verified quarterly against each platform's published fee schedule.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit