### PR TITLE
Add RedditAPIs to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,6 +1749,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PostLake](https://postlake.dev/docs/) | One API to publish, schedule, and read analytics across every major social network | `apiKey` | Yes | No |
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Yes | Unknown |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |
+| [RedditAPIs](https://www.redditapis.com/) | Reddit data API: subreddit listings, post/comment/community/user search, comment trees, top posts | `apiKey` | Yes | Unknown |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Add RedditAPIs to the Social section.

RedditAPIs is a Reddit data API: subreddit listings, post/comment/community/user search, comment trees, and top posts. Checked the existing Reddit entry in this section for overlap: that entry is the official Reddit API (OAuth); this is a third-party read API (apiKey), not a duplicate.

- Site: https://www.redditapis.com
- Docs: https://docs.redditapis.com

Sorted alphabetically after Reddit and before Revolt. Voice matches existing entries (factual, single-sentence, no marketing language).
