### PR TITLE
Add AGPC Domain Check to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [mailboxlayer](https://mailboxlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Email address validation | `apiKey` | Yes | Unknown |
+| [AGPC Domain Check](https://guild.tradeuniquecapital.com/api) | Check a domain's SPF, DKIM, DMARC and MX with a graded shareable report | No | Yes | Yes |
 | [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |


### PR DESCRIPTION
Adds AGPC Domain Check to the Email category. Free API, no key, no signup: GET https://guild.tradeuniquecapital.com/api/check?domain=example.com — SPF (RFC 7208 lookup limit), DKIM selectors, DMARC enforce-vs-monitor, external rua (RFC 7489), MX/null-MX (RFC 7505). Graded A-F with a permanent shareable report URL. HTTPS yes, auth none, CORS yes. OpenAPI: https://guild.tradeuniquecapital.com/openapi.json