### PR TITLE
Add ERstat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,6 +1258,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cure Cancer With AI](https://www.curecancerwithai.com/developers) | Oncology research, clinical trials, FDA approvals, news, and MAMMAL predictions | `apiKey` | Yes | No |
 | [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | COVID-19 live statistics into sites per hour | No | Yes | Unknown |
 | [Edamam](https://developer.edamam.com/) | Food and nutrition data API with recipe search | `apiKey` | Yes | Unknown |
+| [ERstat](https://erstat.ca/developers) | Live Canadian emergency room closures and service disruptions, by province | `apiKey` | Yes | Yes |
 | [FoodData Central](https://fdc.nal.usda.gov/) | National Nutrient Database for Standard Reference | `apiKey` | Yes | Unknown |
 | [Healthcare.gov](https://www.healthcare.gov/developers/) | Educational content about the US Health Insurance Marketplace | No | Yes | Unknown |
 | [Humanitarian Data Exchange](https://data.humdata.org/) | Humanitarian Data Exchange (HDX) is open platform for sharing data across crises and organisations | No | Yes | Unknown |


### PR DESCRIPTION
Adds [ERstat](https://erstat.ca/developers) to **Health**.

- Live Canadian emergency room closures and service disruptions as JSON, plus per-province coverage of live wait-time reporting. Aggregated from official health-authority sources in every province; no government or agency publishes this as one national record.
- Free tier: full access to live data with a free API key (`X-API-Key`), for non-commercial use with attribution.
- HTTPS: yes. CORS: yes (wildcard origin on read endpoints).
- OpenAPI spec: https://erstat.ca/api/v1/openapi.json
- Checked previous PRs/issues for duplicates: none found.