### PR TITLE
Add-SchemaShield-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown | |
+| [SchemaShield](https://rapidapi.com/kaiasistentedavid/api/schema-change-risk) | Read-only preflight for breaking schema changes and downstream query impact | `apiKey` | Yes | Unknown | |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
 | [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes | |
 | [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
## What changed

Adds SchemaShield to the Data Validation category.

## Why

SchemaShield provides a read-only preflight for breaking schema changes and downstream query impact. It has a free tier, uses an API key through RapidAPI, and is served over HTTPS.

## Checks

- Confirmed the URL is not already present in the upstream README
- Confirmed the entry is alphabetically placed and `git diff --check` passes
- Confirmed the public listing documents the free tier and API-key access
- The repository's format script reports only pre-existing header-row errors; the new line is not among them
- The link script could not run locally because its `requests` dependency is not installed; repository CI remains authoritative

AI assistance was used to draft and validate this one-line documentation contribution. The submitted URL and claims were reviewed before submission.
