### PR TITLE
Add XFlux API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth` | Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth` | Yes | Unknown |
 | [xfetch](https://xfetch.io) | Read API for X/Twitter search, profiles, tweets, and social graph | `apiKey` | Yes | Yes |
+| [XFlux](https://www.xfluxapi.com/docs/api) | Read X/Twitter profiles, search, timelines; account monitors with signed webhooks | `apiKey` | Yes | No |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
## Summary
Adds XFlux — read REST API for X/Twitter (profiles, search, timelines) with account monitors and signed HTTP webhooks.

## Free tier
- 1,000 API calls/month
- 1 account monitor
- Self-serve signup, no credit card

## Documentation
https://www.xfluxapi.com/docs/api

## Auth
Bearer API key (`Authorization: Bearer xflux_...`)
