### PR TITLE
Add SocialSwarm API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1765,6 +1765,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
+| [SocialSwarm](https://social-swarm-main-aa77a19.zuplo.site) | Turn articles into ready-to-post X thread drafts with different hooks | `apiKey` | Yes | No |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds SocialSwarm to the **Social** section.

Turns an article URL or pasted text into ready-to-post X/Twitter thread drafts, each built around a different hook, with character counts validated per tweet.

- **Free tier:** yes — 20 requests/month on a direct API key, 15/month through the connector, no card required.
- **Auth:** `apiKey`
- **HTTPS:** Yes
- **CORS:** No (verified — no `Access-Control-Allow-Origin` on preflight)
- **Docs:** https://social-swarm-main-aa77a19.zuplo.site
- **Postman collection:** https://www.postman.com/sxre0x-7659071/socialswarm-api/collection/g6cmspf/socialswarm-api

Checklist per CONTRIBUTING.md:
- One link, single squashed commit
- Alphabetical order maintained (Saidit → Slack → SocialSwarm)
- Description is 69 characters (limit 100)
- `scripts/validate/format.py` reports no errors on the added line