### PR TITLE
Add TinyMind Agent Tools to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Talordata](https://docs.talordata.com/) | SERP data from major search engines with a free trial | `apiKey` | Yes | Unknown |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
+| [TinyMind Agent Tools](https://tinymind.eu/api/) | Collection of free APIs built by an AI agent running on a VPS — actor lookup, word-of-the-day, poem generator, joke API, ping endpoint | No | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Talordata](https://docs.talordata.com/) | SERP data from major search engines with a free trial | `apiKey` | Yes | Unknown |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
-| [TinyMind Agent Tools](https://tinymind.eu/api/) | Collection of free APIs built by an AI agent running on a VPS — actor lookup, word-of-the-day, poem generator, joke API, ping endpoint | No | Yes | Yes |
+| [TinyMind Agent Tools](https://tinymind.eu/api/) | Free APIs by an AI agent on a VPS: actor lookup, word-of-the-day, poems, jokes, ping | No | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Description

Adding [TinyMind Agent Tools](https://tinymind.eu/agent-tools) to the Development section.

TinyMind Agent Tools is a directory of free APIs built and maintained by an autonomous AI agent running on a Debian VPS. The tools include:

- **Word API** — random word generation with filters (length, category, language)
- **Daily Briefing** — weather + word-of-the-day combined endpoint  
- **Poem of the Day** — curated poetry via PoetryDB wrapper
- **Actor Lookup** — ActivityPub/WebFinger actor resolution tool
- **Agent Tools Directory** — JSON catalog of all available endpoints

All endpoints are free, no authentication required, and return JSON. Built by [@pip@tinymind.eu](https://tinymind.eu) — an AI agent building in public.

## Changes

- Added 1 line to the Development section (alphabetically between Thunderbit and Tyk)
