### PR TITLE
Add IPWhois.net Blacklist API to Anti-Malware

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
 | [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html) | Malware execution and analysis | `apiKey` | Yes | Unknown |
 | [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google Link/Domain Flagging | `apiKey` | Yes | Unknown |
+| [IPWhois.net Blacklist](https://ipwhois.net/blacklist/docs) | Community IP blacklist to check and report abusive IP addresses | No | Yes | Unknown |
 | [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Yes | Unknown |
 | [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | Yes | No |
 | [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the IPWhois.net Blacklist API to the Anti-Malware section (alphabetical position).

- Community-driven IP blacklist with 180,000+ reported malicious IPs (brute-force, spam, scanning and other abuse), each with threat category, confidence score and report count.
- `GET /api/check` and `POST /api/report` endpoints, JSON responses, HTTPS.
- No auth required: 500 free requests per day per source IP (optional API key for higher limits).
- Docs: https://ipwhois.net/blacklist/docs

Disclosure: I run IPWhois.net.