### PR TITLE
Add 14 Main Stars API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1513,6 +1513,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Personality
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [14 Main Stars](https://www.14mainstars.com/api-docs) | Zi Wei Dou Shu and BaZi natal charts from birth date, time and place, true-solar-time corrected | No | Yes | Yes |
 | [Advice Slip](http://api.adviceslip.com/) | Generate random advice slips | No | Yes | Unknown |
 | [AstroWay](https://api.astroway.info/docs/) | Astrology, natal charts, Human Design, Vedic and horoscopes on the Swiss Ephemeris | `apiKey` | Yes | Yes |
 | [Biriyani As A Service](https://biriyani.anoram.com/) | Biriyani images placeholder | No | Yes | No |


### PR DESCRIPTION
Adds **14 Main Stars** to the Personality section.

| Field | Value |
| --- | --- |
| Docs | https://www.14mainstars.com/api-docs |
| Auth | No — no key, no signup |
| HTTPS | Yes |
| CORS | Yes |

**What it does.** Casts a Zi Wei Dou Shu (紫微斗数) natal chart and BaZi (八字) Four Pillars from a birth date, time and place — main star, all twelve palaces, the Four Pillars, the Day Master and the five-element distribution. Birthplace is required because the chart is corrected to true solar time, so a companion endpoint resolves a place name to the id the chart endpoint expects.

**Why it belongs here.** The Personality section already lists astrology APIs, but the existing natal-chart entry requires an `apiKey`. This one has no authentication at all, returns JSON, sets CORS headers, and ships an OpenAPI 3.1 schema at `/api/public/openapi.json`.

**On the free-access rule.** The API is entirely free and always will be — it is the calculation layer, and calculation is what the site gives away. There is no paid tier of this endpoint, no key to buy, and no device to purchase. The site sells written interpretation reports, which this API does not return and is not a trial of. It is rate limited to 20 chart requests per minute per IP, and stores nothing that is sent to it.

Quick check:

```
curl "https://www.14mainstars.com/api/public/chart?date=1993-11-04&hour=21&minute=15&gender=male&cityId=kl&lang=en"
```

Format check: entry sits first in Personality (numeric names lead, matching `0x`, `24 Pull Requests`, `4chan` elsewhere in the list), description is 95 characters, one link, single squashed commit, targeted at `master`.