### PR TITLE
Add BRAINIALL to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1321,6 +1321,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI Economics Tools](https://piszczek.pl/tools/api) | Token cost, LLM energy, agent-hour and Proof-Adjusted Autonomy calculators by Michał Piszczek | No | Yes | Yes |
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [BRAINIALL](https://github.com/fasuizu-br/brainiall-transcription-skill) | PT-BR and Spanish audio transcription with diarization and SRT/VTT | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
 | [DeepAI](https://deepai.org/) | Provides AI-powered APIs for text generation, image processing, and more | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds the BRAINIALL transcription API documentation to Machine Learning.

Validation performed before submission:
- repository test suite: 31 passed, 88 subtests
- link validator: documentation URL reachable
- HTTPS and CORS: verified
- one concise alphabetical entry; no duplicate BRAINIALL entry found

The API supports PT-BR and Spanish transcription with diarization and SRT/VTT output. Authentication is by API key.