### PR TITLE
Remove dead Cataas API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ API | Description | Auth | HTTPS | CORS
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
 | [Cat Facts](https://catfact.ninja/) | Random cat facts | No | Yes | Yes |
-| [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |
 | [Dog Facts](https://kinduff.github.io/dog-api/) | Random facts of Dogs | No | Yes | Yes |


### PR DESCRIPTION
## Summary
- remove the Cataas entry from the Animals table because its listed endpoint returns HTTP 404

The other URLs mentioned in #6592 are already updated or no longer present in the current README.

## Validation
- python -m unittest discover tests --verbose (31 passed)
- python scripts/validate/format.py README.md (existing repository-wide baseline warnings; no new formatting errors from this deletion)
- python scripts/validate/links.py README.md -odlc (existing duplicate-link warnings; Cataas is no longer listed)
- git diff --check

Closes #6592