### PR TITLE
Add Web Metadata & Contact Extractor API to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Utilorax](https://utilorax.com/api) | 203 JSON endpoints: hashing, encoding, unit conversion, text, dates and file conversion | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
+| [Web Metadata & Contact Extractor](https://rapidapi.com/josejuanjocoding/api/web-metadata-and-contact-extractor) | Extract SEO metadata, contact emails, social links, and tech stack (<200ms) | `apiKey` | Yes | Yes |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
### API Description
**Web Metadata & Contact Extractor** is an ultra-fast (<200ms) REST API that extracts SEO/OpenGraph metadata, public contact signals (emails, phone numbers), social profiles across 20 platforms, tech stack signatures (40+ frameworks/CMS), Schema.org JSON-LD/product data, graded security headers, and clean AI-ready Markdown from any URL, all from a single request.

- **API Link**: https://rapidapi.com/josejuanjocoding/api/web-metadata-and-contact-extractor
- **Auth**: `apiKey` (RapidAPI Key header)
- **HTTPS**: Yes
- **CORS**: Yes
- **Free Tier Available**: Yes

### Checklist
- [x] The PR title follows the `Add [API] to [Category]` format.
- [x] The added link is inserted in its alphabetically correct location.
- [x] The added link is not preceded or followed by an empty line.
- [x] The description begins with a capital letter and doesn't end with punctuation.
- [x] Each field in the added link matches the guidelines in the `CONTRIBUTING` page.
- [x] The link is added to the bottom of the correct category.
- [x] The category the link is added to is sorted correctly.
- [x] I have read and agree with the [contribution guidelines](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md).