### PR TITLE
Add Dados B3 API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
-| [Dados B3](https://dadosb3.com/docs) | Auditable fundamentals and point-in-time multiples for Brazilian listed companies and real-estate funds (FIIs), from CVM/B3 open data | `apiKey` | Yes | Yes | |
+| [Dados B3](https://dadosb3.com/docs) | Auditable fundamentals and point-in-time multiples for Brazilian listed companies and real-estate funds (FIIs), from CVM/B3 open data | `apiKey` | Yes | Yes |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
+| [Dados B3](https://dados-b3.onrender.com) | Brazilian stock exchange (B3) fundamentals with public methodology | `apiKey` | Yes | Unknown | |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
-| [Dados B3](https://dados-b3.onrender.com) | Brazilian stock exchange (B3) fundamentals with public methodology | `apiKey` | Yes | Unknown | |
+| [Dados B3](https://dadosb3.com/docs) | Auditable fundamentals and point-in-time multiples for Brazilian listed companies and real-estate funds (FIIs), from CVM/B3 open data | `apiKey` | Yes | Yes | |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **Dados B3** to Finance (alphabetical order, between CongressInvests and Dino.markets).

Fundamental data API for the Brazilian stock exchange (B3): ROIC, ROE, margins, point-in-time multiples, with public methodology. Free tier (API key, no card). HTTPS. Sources: CVM (open data) and B3.