### PR TITLE
Add Atomic Mail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [mailboxlayer](https://mailboxlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Email address validation | `apiKey` | Yes | Unknown |
 | [AGPC Domain Check](https://guild.tradeuniquecapital.com/api) | Check a domain's SPF, DKIM, DMARC and MX with a graded shareable report | No | Yes | Yes |
+| [Atomic Mail](https://atomic-mail.github.io/atomic-mail-agentic/) | Email for AI agents: programmatic inbox creation and send/receive over JMAP | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Atomic Mail** to the **Email** category.

Atomic Mail is a free email service with an HTTP/JMAP API. An agent (or app) can create an inbox programmatically and send/receive mail over the open **JMAP** standard (RFC 8620/8621); custom domains are supported.

- Entry links to the API documentation: https://atomic-mail.github.io/atomic-mail-agentic/
- Auth: `apiKey` — JMAP requests use a bearer capability token (OAuth 2.0 is also available for human-authorized apps)
- HTTPS: Yes · CORS: Unknown

Checklist:
- One link added, in alphabetical order within the Email section (between AGPC Domain Check and Cloudmersive Validate)
- Name has no `API` suffix and no TLD; links to documentation, not a landing page
- Description is 75 chars (≤100), starts capitalized, no trailing punctuation
- 5 columns, single-space padding, no trailing whitespace; single squashed commit