### PR TITLE
Add KrakenKeys API

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes | Yes |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes | Yes |
 | [Jservice](http://jservice.io) | Jeopardy Question Database | No | No | Unknown |
+| [KrakenKeys](https://krakenkeys.com/api-docs) | Steam game key price comparison across 20+ stores, deals, and price history | `apiKey` | Yes | No |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds KrakenKeys - a free read REST API for Steam game key prices (search, price comparison across 20+ stores, deals, price history). Helps users find the best deals on Steam games. 

## Free tier
- Fully free, no paid tier
- Self-serve signup, no credit card

## Documentation

https://krakenkeys.com/api-docs

## Auth

Bearer API key (Authorization: Bearer <key>)
