### PR TITLE
Add PDFGate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OCR.Space](https://ocr.space/ocrapi) | OCR text extraction from images and PDFs with a free tier | `apiKey` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
 | [PDFFleet](https://pdffleet.com) | HTML and URL to PDF API with templates and a free tier | `apiKey` | Yes | Yes |
+| [PDFGate](https://pdfgate.com/documentation) | Generate PDFs, add form and signature fields, and send documents for e-signature | `apiKey` | Yes | Unknown |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PolyDoc](https://polydoc.tech) | HTML/URL to PDF and screenshots, plus Factur-X/ZUGFeRD e-invoices; free tier | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds PDFGate to **Documents & Productivity** (alphabetical, between PDFFleet and Pocket).

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [PDFGate](https://pdfgate.com/documentation) | Generate PDFs, add form and signature fields, and send documents for e-signature | `apiKey` | Yes | Unknown |

One link added, alphabetical order preserved, columns padded per the format.