### PR TITLE
Add monerometrics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
 | [Mexc](https://www.mexc.com/api-docs) | Cryptocurrency info, place order | `apiKey` | Yes | Unknown |
+| [monerometrics](https://monerometrics.net) | Reorg-aware Monero (XMR) network metrics, mining-pool centralization and chain reorganizations | No | Yes | Yes |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the **monerometrics** API to the Cryptocurrency section.

- Public, free, read-only REST API for Monero (XMR) network metrics: chain reorganizations, orphan blocks, network hashrate, block time, mempool, and mining-pool centralization (largest-pool share, Nakamoto coefficient).
- Docs: https://monerometrics.net · OpenAPI: https://api.monerometrics.net/openapi.json
- Auth: No · HTTPS: Yes · CORS: Yes

Entry placed alphabetically; only the added line changes, validated against scripts/validate/format.py.