### PR TITLE
Add LottoLens PH API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,7 @@ API | Description | Auth | HTTPS | CORS |
 | [K-Data Gate](https://kdata-gate.vercel.app/docs) | Korean market data: K-beauty/K-food products, Naver trends, stocks, real estate, weather | `apiKey` | Yes | Unknown |
 | [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |
 | [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
+| [LottoLens PH](https://remo65588-boop.github.io/lottolens-ph-public-data/api/) | Fixed Philippine PCSO historical results and normal draw schedules | No | Yes | Yes |
 | [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |
 | [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
 | [MostExpensiveWatches](https://mostexpensivewatches.net/api) | Documented luxury watch auction records, live listings, valuations and price indices | No | Yes | Yes |


### PR DESCRIPTION
## Why this belongs in Open Data

- Free, read-only, no-auth static JSON endpoints
- HTTPS and CORS verified on the public documentation and endpoint URLs
- 13,457 fixed Philippine PCSO historical result rows plus nine normal draw schedules
- OpenAPI 3.1 documentation, source provenance, checksums, versioning, and responsible-use limits

## Disclosure

I am submitting this on behalf of LottoLens PH. The dataset concerns lottery draw records, but LottoLens PH does not sell tickets or accept wagers. The API is for verification, teaching, and reproducible descriptive analysis; it is not a prediction service. There is no paid tier or purchase requirement. Maintainers may close this PR if the subject is outside the directory scope.

## Validation

- Entry-specific format validation: pass
- Documentation URL: HTTP 200
- Auth: No
- HTTPS: Yes
- CORS: Yes
- One link added; description is under 100 characters

Note: the repository-wide validator currently reports pre-existing formatting and duplicate-link findings on upstream master; the new entry itself returns no format errors.