### PR TITLE
Add CycleCalcs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1623,6 +1623,7 @@ API | Description | Auth | HTTPS | CORS |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
+| [CycleCalcs](https://www.cyclecalcs.com/api.html) | Interpreted astronomy: sun and moon times, moon phases, planets, eclipses, seasons | No | Yes | Yes |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |
 | [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
 | [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | High Energy Physics info. system | No | Yes | Unknown |


### PR DESCRIPTION
Adds CycleCalcs to **Science & Math**, placed alphabetically between CORE and GBIF.

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [CycleCalcs](https://www.cyclecalcs.com/api.html) | Interpreted astronomy: sun and moon times, moon phases, planets, eclipses, seasons | No | Yes | Yes |

A read-only astronomy API of 29 endpoints returning interpreted answers rather than raw ephemeris: moon phase and illumination, sunrise/sunset and twilight, planet positions and visibility, rise and set times, eclipses, lunar nodes and libration, seasons, retrograde stations, conjunctions, sidereal time, dark-sky windows, and a one-call sky snapshot for a location and moment.

**Every claim in the row is verifiable right now:**

- **Auth: No** - the free tier needs no key, no signup and no card. `curl https://www.cyclecalcs.com/v2/moon` returns 200.
- **HTTPS: Yes**
- **CORS: Yes** - responses carry `Access-Control-Allow-Origin: *`, so it works client-side.

Documentation is at [/api.html](https://www.cyclecalcs.com/api.html), with a per-endpoint [reference](https://www.cyclecalcs.com/api/reference.html), an [OpenAPI description](https://www.cyclecalcs.com/v2/openapi.json), and RFC 9457 problem documents for errors. Every response states its reference frame, epoch, time scale and refraction model, and the [accuracy page](https://www.cyclecalcs.com/api/accuracy.html) publishes measured residuals.

Not a marketing submission: the free tier is a published floor that only ever rises, no tier changes an answer, and the computed values are dedicated to the public domain under CC0.

---

- [x] One link added
- [x] Alphabetical ordering preserved within the section
- [x] Table columns padded with one space either side
- [x] Description under 100 characters (82)
- [x] Name does not end in "API" and carries no TLD
- [x] Single commit
- [x] Targets `master`
- [x] Searched existing PRs and issues for duplicates
