### PR TITLE
Fix OrbitalWiki entry: Auth is No, not apiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,7 +1642,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
 | [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
-| [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
+| [OrbitalWiki](https://www.orbitalwiki.com/developers) | Catalog of 16,000+ satellites with the source cited for every field: orbital elements, operators, NORAD/COSPAR IDs | No | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
Correction to an existing entry in Science & Math, added in #6651. I maintain the API and got the `Auth` column wrong in that PR.

**The correction**

```diff
-| [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
+| [OrbitalWiki](https://www.orbitalwiki.com/developers) | Catalog of 16,000+ satellites with the source cited for every field: orbital elements, operators, NORAD/COSPAR IDs | No | Yes | Yes |
```

**Why `Auth: No` is the right value**

The public endpoints take no credentials at all:

```
$ curl -s -o /dev/null -w '%{http_code}' 'https://www.orbitalwiki.com/api/v1/satellites?limit=1'
200
```

A key exists but only raises the rate limit, which matches how NASA and other entries in this section are listed. Listing it as `apiKey` tells readers they need to sign up before they can call it, and they do not.

**Two smaller fixes in the same line**

- URL now points at `www.`, which is the canonical host. The old one served a 308 redirect on every request.
- Description says what the entry actually offers instead of "free tier included", which read as marketing. Every field in a response names the source it came from (CelesTrak, GCAT, Wikidata or SatNOGS) and returns `unknown` where the sources are silent, rather than filling the gap with a guess. That is the part a reader scanning this table would want to know.