### PR TITLE
Add Racing Alpha to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
+| [Racing Alpha](https://racingalpha.co.uk/developers) | AI win-probability scores, fair prices and draw-bias stats for UK & Irish horse racing | No | Yes | Yes |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

---

Adds **Racing Alpha** to Sports & Fitness: a free API serving derived signals for UK & Irish horse racing — model win-probability scores, de-overrounded fair prices, value flags, draw-bias aggregates, trainer/jockey combo stats, and a public database-frozen tips ledger with closing-line value.

- Free: 50 req/day keyless per IP, 1,000/day with a free key (no card)
- HTTPS + open CORS
- OpenAPI 3.1: https://racingalpha.co.uk/api/v1/openapi.json
- Docs: https://racingalpha.co.uk/developers
- Try it: `curl https://racingalpha.co.uk/api/v1/today`

Disclosure: I run Racing Alpha; this PR was prepared with AI assistance. The API is free and has no paid product behind the listed endpoints.
