### PR TITLE
Add PlayerElo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
+| [PlayerElo](https://playerelo.football/api-access) | Player-level Elo ratings, predictions and history for 176 football leagues | `apiKey` | Yes | Unknown |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |


### PR DESCRIPTION
Adds **PlayerElo** to Sports & Fitness (alphabetically, between Padel Snipe and Premier League Standings).

- Player-level Elo ratings, match predictions and full rating history across 176 football competitions.
- Free tier: 500 requests/month, no credit card. HTTPS, Bearer-token (apiKey) auth, JSON.
- Docs: https://playerelo.football/api-access

Format checked: one link, description under 100 chars, alphabetical order, free tier available.