### PR TITLE
Add Hail History API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2118,6 +2118,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | Weather | `apiKey` | Yes | Yes |
 | [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
 | [Foreca](https://developer.foreca.com) | Weather | `OAuth` | Yes | Unknown |
+| [Hail History](https://hail-history-noaa.netlify.app/api-docs.html) | Radar-detected hail history for any US address from NOAA NEXRAD Level-III hail detections, by year | No | Yes | Yes |
 | [HG Weather](https://hgbrasil.com/status/weather) | Provides weather forecast data for cities in Brazil | `apiKey` | Yes | Yes |
 | [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data | No | Yes | Unknown |
 | [IPMA](https://api.ipma.pt/open-data/) | Portuguese weather and climate data | No | Yes | Unknown |


### PR DESCRIPTION
Adds the Hail History API to the Weather section.

**What it does.** Returns radar-detected hail history for any US address, by year, from NOAA NEXRAD Level-III hail detection products. Answers "has hail ever hit this address, and when" rather than "what is the forecast", which is a gap in the current Weather list.

**Free, keyless, CORS open.** No account, no API key, no rate limit. `Access-Control-Allow-Origin: *`, so it works client-side.

```
curl "https://hail-history-noaa.netlify.app/hail-history?address=1625%2013th%20St,%20Lubbock,%20TX%2079401"
```

Docs: https://hail-history-noaa.netlify.app/api-docs.html
OpenAPI: https://hail-history-noaa.netlify.app/openapi.json
Source: https://github.com/ThryveBaseline/hail-api

Auth `No`, HTTPS `Yes`, CORS `Yes`, all verified against the live endpoint today. Entry is placed alphabetically between Foreca and HG Weather. `scripts/validate/format.py` reports nothing on the added line.
