### PR TITLE
Add Formula 1 and motorsport API entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,20 +1799,26 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey` | Yes | Yes |
+| [API-Football](https://www.api-football.com/) | 1,200+ football competitions, livescore, standings, teams, odds, fixtures, events, line-ups, players, statistics, predictions | `apiKey` | Yes | Yes |
 | [ApiMedic](https://apimedic.com/) | ApiMedic offers a medical symptom checker API primarily for patients | `apiKey` | Yes | Unknown |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |
+| [BallDontLie EPL](https://epl.balldontlie.io/) | Premier League teams, rosters, standings, matches, lineups, player match stats, odds, player props | `apiKey` | Yes | Yes |
 | [Bet Better](https://betbetter.world/api/) | Sports model win probabilities and fair odds across 13 leagues | No | Yes | Yes |
+| [Big Balls Sports Data](https://bigballsdata.com/premier-league-api) | Real-time Premier League scores, odds, confirmed lineups, match stats including xG; free tier 1,000–2,000 req/day | `apiKey` | Yes | Yes |
 | [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey` | Yes | No |
 | [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Yes | Unknown |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes | Yes |
 | [CollegeFootballData.com](https://collegefootballdata.com) | Unofficial detailed American college football statistics, records, and results API | `apiKey` | Yes | Unknown |
 | [DiscGolf](https://discgolfapi.com/docs/) | Structured disc golf course data | No | Yes | Yes |
+| [Enetpulse Premier League](https://enetpulse.com/premier-league-api/) | JSON feed for real-time and historical Premier League data: match events, player stats, live commentary | `apiKey` | Yes | Yes |
 | [Ergast F1](http://ergast.com/mrd/) | F1 data from the beginning of the world championships in 1950 | No | Yes | Unknown |
+| [Fantasy Premier League API](https://www.oanor.com/api/fpl-api) | Official Fantasy Premier League (FPL) data as an API; free tier 100 calls/month | `apiKey` | Yes | Yes |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
+| [iSportsAPI EPL](https://www.isportsapi.com/en/products/detail/football-api-product-83.html) | 22–24 endpoints for Premier League: livescores, schedules, results, league profile, match stats | `apiKey` | Yes | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |
 | [Lumify](https://lumify.ai/docs) | Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports | `apiKey` | Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
@@ -1833,7 +1839,8 @@ API | Description | Auth | HTTPS | CORS |
 | [Racemate](https://racemate.io/api/) | Free JSON API for F1 driver standings, season results, race-by-race classifications, constructor stats | No | No | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
-| [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
+| [Premier League Standings](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
+| [Premier-League-API (unofficial)](https://github.com/tarun7r/Premier-League-API) | Unofficial Flask API scraping Premier League site: player stats, fixtures, tables, results | No | No | Yes |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
@@ -1844,10 +1851,12 @@ API | Description | Auth | HTTPS | CORS |
 | [Sportmonks Cricket](https://docs.sportmonks.com/cricket/) | Live cricket score, player statistics and fantasy API | `apiKey` | Yes | Unknown |
 | [Sportmonks Football](https://docs.sportmonks.com/football/) | Football score/schedule, news api, tv channels, stats, history, display standing e.g. epl, la liga | `apiKey` | Yes | Unknown |
 | [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |
+| [Statorium EPL](https://statorium.com/english-premier-league-api) | Premier League stats, live scores, odds, standings, top scorers; endpoints: Matches, Live Matches, Today's Matches | `apiKey` | Yes | Yes |
 | [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
 | [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
 | [TheRundown](https://therundown.io/) | Real-time sports data: odds, scores, stats & prediction markets, 30+ leagues, 18+ sportsbooks | `apiKey` | Yes | Yes |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey` | Yes | Yes |
+| [TheStatsAPI Football](https://www.thestatsapi.com/football-api) | Fixtures, results, standings, player & match stats, odds, xG across 1,000+ competitions including Premier League | `apiKey` | Yes | Yes |
 | [TourneyRadar](https://tourneyradar-api.vercel.app) | Upcoming chess tournaments from 140+ national federations worldwide | No | Yes | Unknown |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1822,6 +1822,15 @@ API | Description | Auth | HTTPS | CORS |
 | [Odds-API](https://docs.odds-api.io) | Real-time sports betting odds from 265+ bookmakers across 34 sports via REST and WebSocket | `apiKey` | Yes | Yes |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
+| [FastF1](https://github.com/theOehrly/Fast-F1) | Python library for F1 timing, telemetry, weather, sessions, and strategy analysis | No | Yes | Yes |
+| [Jolpica-F1](https://api.jolpi.ca/ergast/) | Ergast-compatible F1 API; community standard for historical F1 data since Ergast shutdown | No | No | Yes |
+| [F1DB](https://github.com/chris1610/f1data) | Open-source all-time F1 database (CSV/JSON/SQL/SQLite) covering drivers, constructors, circuits, results, grids, fastest laps, pit stops | No | No | Yes |
+| [Sportmonks F1](https://www.sportmonks.com/formula-one-api/) | Live classification, gaps, intervals, lap times, tyres, drivers, constructors as JSON | `apiKey` | Yes | Yes |
+| [Orange Cat Blacktop](https://ocblacktop.com/api) | Professional REST API for F1, NASCAR, IndyCar, MotoGP, Formula E, WRC, FIA WEC; schedules, results, standings, live race-weekend data | `apiKey` | Yes | Yes |
+| [PitStop Data](https://pitstopdata.com/) | F1 lap times, sector splits, pit stop strategy, tire compounds, championship standings | `apiKey` | Yes | Yes |
+| [Hyprace](https://developers.hyprace.com/) | Fast, reliable F1 API: race results, driver standings, session data, historical F1 data | `apiKey` | Yes | Yes |
+| [The Data Driver](https://thedatadriver.app/api-docs) | 90+ endpoints for F1: historical data since 1950, real-time telemetry, ML predictions | `apiKey` | Yes | Yes |
+| [Racemate](https://racemate.io/api/) | Free JSON API for F1 driver standings, season results, race-by-race classifications, constructor stats | No | No | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |


### PR DESCRIPTION

Add several Formula 1 and motorsport API entries to the Sports & Fitness section in the README.

## Changes
- Added 10 Formula 1 / motorsport-related API entries
- Kept the table format consistent with project conventions
- Maintained the existing section structure and naming style