### PR TITLE
Add Strait of Hormuz Ship Monitor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1965,6 +1965,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | No |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
+| [Strait of Hormuz Ship Monitor](https://hormuz.data-tracking.net/llms.txt) | Live AIS vessel traffic, crossings and oil flow through the Strait of Hormuz | No | Yes | No |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |
 | [TransitLand](https://www.transit.land/documentation/datastore/api-endpoints.html) | Transit Aggregation | No | Yes | Unknown |
 | [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx) | Marta | No | No | Unknown |


### PR DESCRIPTION
Adds **Strait of Hormuz Ship Monitor** to the **Transportation** category (alphabetical position, between Schiphol Airport and Tankerkoenig).

Free, no-auth JSON API for live and historical ship traffic through the Strait of Hormuz — AIS positions polled every 30 minutes for ~950 vessels across the Persian Gulf and Gulf of Oman, with strait-crossing detection, vessel type/flag/DWT details, daily historical series, and estimated oil-flow volumes.

- Documentation link points at the machine-readable endpoint reference (`llms.txt`); a human-oriented reference lives at https://github.com/marco83g-dotcom/hormuz-api
- Auth: No (no key, no registration)
- HTTPS: Yes
- CORS: No
- The API has been publicly available since March 2026 and serves external consumers today.

Checklist:
- [x] One entry per pull request
- [x] Alphabetical order within the category
- [x] Description under 100 characters, capitalized, no trailing period
- [x] Link goes to API documentation
