### PR TITLE
Add TopTier Devs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
 | [TinyMind Agent Tools](https://tinymind.eu/api/) | Free APIs by an AI agent on a VPS: actor lookup, word-of-the-day, poems, jokes, ping | No | Yes | Yes |
+| [TopTier Devs](https://top-tier-devs.vercel.app/) | Curated directory of exceptional developers, engineers, and creators | No | Yes | Yes |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Utilorax](https://utilorax.com/api) | 203 JSON endpoints: hashing, encoding, unit conversion, text, dates and file conversion | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

- Add TopTier Devs to the Development APIs list
- Link to https://top-tier-devs.vercel.app/
- Mark the endpoint as unauthenticated, HTTPS-enabled, and CORS-enabled

## Validation

- Verified the endpoint responds successfully
- `git diff --check` passes
- Full repository validator has pre-existing failures and missing local `requests` dependency