### PR TITLE
Add DreamThreads API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DeepAI](https://deepai.org/) | Provides AI-powered APIs for text generation, image processing, and more | `apiKey` | Yes | Yes |
 | [Deepcode](https://www.deepcode.ai) | AI for code review | No | Yes | Unknown |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
+| [DreamThreads](https://mydreamthreads.xyz/dream-interpretation-api) | Parse dreams into structured entities, emotions, agency, threat, and outcomes | No | Yes | Yes |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [GoldBean](https://goldbean-api.xyz/docs) | OCR, Translation, NLP & ERNIE LLM via Baidu AI (free tier available) | `apiKey` | Yes | Unknown |
 | [Groq](https://console.groq.com/docs/quickstart) | Fast AI inference API with free tier, supports Llama, Mixtral, Gemma models | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## What this adds

- Documentation: https://mydreamthreads.xyz/dream-interpretation-api
- Free public dream parser: `POST /api/v1/dreamgraph/public/parse`
- No API key required
- Rate limits: 12 requests/minute and 100 requests/day per client
- HTTPS and wildcard CORS verified
- Dream text is processed in memory and is not stored
- OpenAPI specification is linked from the documentation page

## Verification

- [x] Submission follows the contribution format
- [x] Entry is alphabetized in Machine Learning
- [x] Description is 77 characters and has no ending punctuation
- [x] Public endpoint returned HTTP 200
- [x] `Access-Control-Allow-Origin: *` confirmed
- [x] One API link added to the directory README