### PR TITLE
Add PegaRex to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1960,6 +1960,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Orizn Visa](https://visa.orizn.app) | Visa requirements for 199 countries, 39K+ passport-destination pairs in 15 languages | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [OpenVan](https://openvan.camp/docs) | Fuel prices for 121 countries, food cost index & vanlife weather scores for RV travel | No | Yes | Yes |
+| [PegaRex](https://pegarex.com.br/api/docs) | Search 1.8M+ live Brazilian used-car and motorcycle listings aggregated from 96 marketplaces, with FIPE reference prices | No | Yes | Yes |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds **PegaRex** — search over 1.8M+ live Brazilian used-car and motorcycle listings aggregated from 96 marketplaces, enriched with FIPE reference prices.

- **Docs (Swagger):** https://pegarex.com.br/api/docs
- **OpenAPI spec:** https://pegarex.com.br/api/openapi.json
- **Auth:** none · **HTTPS:** yes · **CORS:** open (`*`)

Inserted alphabetically in the Transportation section, between `OpenVan` and `Railway Transport for France`. One row added, no other changes.