### PR TITLE
Add CosmyDay Astrology API

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Anycrap](https://anycrap.shop/developers) | 35,000+ absurdist AI-generated product concepts with names, descriptions, and images | `apiKey` | Yes | Yes |
 | [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
 | [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
+| [CosmyDay Astrology](https://cosmyday.com/api-docs) | Natal charts and sky events computed from Swiss Ephemeris | No | Yes | Yes |
 | [Excuser](https://excuser.herokuapp.com/) | Get random excuses for various situations | No | Yes | Unknown |
 | [Fun Fact](https://api.aakhilv.me) | A simple HTTPS api that can randomly select and return a fact from the FFA database | No | Yes | Yes |
 | [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |


### PR DESCRIPTION
Adds CosmyDay Astrology to Entertainment.

- Free, no key, no account
- HTTPS: yes
- CORS: yes
- Docs: https://cosmyday.com/api-docs

Natal chart calculation and sky-event dates computed from the Swiss Ephemeris. One API per PR, alphabetical placement, description under 100 characters.