### PR TITLE
Add Blacktop Motorsport API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ApiMedic](https://apimedic.com/) | ApiMedic offers a medical symptom checker API primarily for patients | `apiKey` | Yes | Unknown |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |
 | [Bet Better](https://betbetter.world/api/) | Sports model win probabilities and fair odds across 13 leagues | No | Yes | Yes |
+| [Blacktop Motorsport API](https://ocblacktop.com/api) | Motorsport results, schedules, standings and driver data for F1, NASCAR, IndyCar, MotoGP and more | `apiKey` | Yes | No |
 | [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey` | Yes | No |
 | [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Yes | Unknown |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds the Blacktop Motorsport API to the Sports & Fitness category.

Free tier: 7,500 requests/month, no credit card required. Covers motorsport results, schedules, standings, and driver/team data across Formula 1, NASCAR (1949+), IndyCar, MotoGP, WRC, WEC, and more. OpenAPI docs at https://ocblacktop.com/api.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
