### PR TITLE
Add SciDraw AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
+| [SciDraw AI](https://sci-draw.com/docs/api) | Generate, edit and convert scientific figures | `apiKey` | Yes | No |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
 | [SpaceX](https://api.spacex.land/graphql/) | GraphQL, Company, Ships, launchpad and launch data | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds SciDraw AI to the Science & Math category.

SciDraw AI provides a documented REST API for generating, editing, and converting scientific figures. It uses API-key authentication, supports HTTPS, is intended for server-side use without browser CORS, and includes free starter and daily credits.

## Checks

- Confirmed the documentation URL returns HTTP 200.
- Confirmed the API has a usable free tier.
- Confirmed no existing entry, pull request, or issue for SciDraw AI.
- Kept the description under 100 characters and maintained alphabetical order.
- Ran `git diff --check`.
- The repository-wide format validator currently reports numerous pre-existing README issues; it does not report the added SciDraw AI row.