### PR TITLE
Add PatentFig AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1521,6 +1521,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [EPO](https://developers.epo.org/) | European patent search system api | `OAuth` | Yes | Unknown |
+| [PatentFig AI](https://patentfig.ai/docs/api) | Generate, vectorize, enhance and convert patent figures | `apiKey` | Yes | No |
 | [PatentsView ](https://patentsview.org/apis/purpose) | API is intended to explore and visualize trends/patterns across the US innovation landscape | No | Yes | Unknown |
 | [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api | `apiKey` | Yes | Unknown |
 | [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility) | USA patent api services | No | Yes | Unknown |


### PR DESCRIPTION
## Summary

Adds PatentFig AI to the Patent category.

PatentFig AI provides a documented REST API for generating, vectorizing, enhancing, and converting patent figures. It uses API-key authentication, supports HTTPS, is intended for server-side use without browser CORS, and includes a free tier with starter and daily credits.

## Checks

- Confirmed the documentation URL returns HTTP 200.
- Confirmed the API has a usable free tier.
- Confirmed no existing entry, pull request, or issue for PatentFig AI.
- Kept the description under 100 characters and maintained alphabetical order.
- Ran `git diff --check`.
- The repository-wide format validator currently reports numerous pre-existing README issues; it does not report the added PatentFig AI row.