### PR TITLE
Add Salary Explorer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,6 +1320,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JobDataLake](https://www.jobdatalake.com/docs) | 1M+ enriched job listings from 20,000+ companies with salary, skills, seniority | `apiKey` | Yes | Yes |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [Salary Explorer](https://salarywiki.com/api) | U.S. occupation wages by state and metro, cost-of-living adjusted | No | Yes | Yes |
 | [TechRole Index](https://techrole.ru/open-data-daily) | Russian IT profession, vacancy publication and salary aggregates | No | Yes | Yes |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Free JSON endpoint for U.S. occupational wage data from the BLS Occupational Employment and Wage Statistics survey, plus a cost-of-living adjusted figure derived from BEA state price levels.

No key and no registration. HTTPS and CORS were both confirmed against a live response rather than assumed. Source data is public domain under 17 U.S.C. §105.

- Docs: https://salarywiki.com/api
- OpenAPI 3.1: https://salarywiki.com/openapi.json
- Example: https://salarywiki.com/api/v1/salary?soc=29-1141&area=48

Added to Jobs between Reed and TechRole Index, alphabetical order kept. One entry, description 65 characters.