### PR TITLE
Add GovGazette API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
+| [GovGazette](https://govgazette.com/agents) | Search U.S. federal contract opportunities, awards, and vendors | No | Yes | Yes |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
 | [Indian Mandi Prices](https://mandi-api.vercel.app/docs) | Free, keyless daily wholesale mandi prices for 5 Indian states, sourced from data.gov.in | No | Yes | Yes |
 | [Indian Pincode](https://indianpincode.com/) | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1186,7 +1186,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
-| [GovGazette](https://govgazette.com/agents) | Search U.S. federal contract opportunities, awards, and vendors | No | Yes | Yes |
+| [GovGazette](https://govgazette.com/agents?utm_source=public_apis&utm_medium=directory&utm_campaign=govgazette_agent_launch_2026_08) | Search U.S. federal contract opportunities, awards, and vendors | No | Yes | Yes |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
 | [Indian Mandi Prices](https://mandi-api.vercel.app/docs) | Free, keyless daily wholesale mandi prices for 5 Indian states, sourced from data.gov.in | No | Yes | Yes |
 | [Indian Pincode](https://indianpincode.com/) | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data | No | Yes | Yes |


### PR DESCRIPTION
Adds GovGazette to the Government section.

The public API provides keyless, CORS-enabled access to U.S. federal contract opportunities, award history, and vendor records. Documentation and the OpenAPI 3.1 document are live at https://govgazette.com/agents?utm_source=public_apis&utm_medium=directory&utm_campaign=govgazette_agent_launch_2026_08 and https://govgazette.com/api/agent/openapi.json.