### PR TITLE
Add Scoopkit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,6 +1434,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖 | `apiKey` | Yes | Unknown |
 | [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |
 | [NPR One](http://dev.npr.org/api/) | Personalized news listening experience from NPR | `OAuth` | Yes | Unknown |
+| [Scoopkit](https://scoopkit.dev) | AI-industry news deduplicated into structured events, not articles | `apiKey` | Yes | Yes |
 | [Spaceflight News](https://spaceflightnewsapi.net) | Spaceflight related news 🚀 | No | Yes | Yes |
 | [The Guardian](http://open-platform.theguardian.com/) | Access all the content the Guardian creates, categorised by tags and section | `apiKey` | Yes | Unknown |
 | [The Old Reader](https://github.com/theoldreader/api) | RSS reader | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Scoopkit to the News section — a REST API that deduplicates AI-industry news coverage into structured events (the primary resource is the event, not the raw article). Free tier: magic-link signup, 100 requests/day. HTTPS, CORS enabled, API-key auth.