### PR TITLE
Add Brazil CNPJ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ API | Description | Auth | HTTPS | CORS |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
+| [Brazil CNPJ](https://cnpj.wiki/docs) | Query Brazilian companies by CNPJ with full Receita Federal registry data, no key required | No | Yes | Yes |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
 | [CPFHub](https://cpfhub.io) | Brazilian CPF lookup — returns full name, birth date, and gender for any CPF | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds a free, keyless API for looking up Brazilian companies by CNPJ (the national business registry number), sourced from the Receita Federal open data release.

- **Endpoint:** `GET https://api.cnpj.wiki/v1/cnpj/:cnpj`
- **Docs:** https://cnpj.wiki/docs
- **OpenAPI:** https://api.cnpj.wiki/v1/openapi.json
- **Auth:** none — no signup, no API key
- **CORS:** enabled (`Access-Control-Allow-Origin: *`), so it works from the browser
- **Rate limit:** 60 req/min per IP

Try it:

```
curl https://api.cnpj.wiki/v1/cnpj/00000000000191
```

Returns the full registry record: legal name, trade name, registration status, main and secondary CNAE activities, legal nature, address, and partners.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
