### PR TITLE
Add GlotFiles to Documents & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
 | [DocStruct](https://docstruct.pages.dev) | AI extraction of invoices, receipts, bank statements & contracts into structured JSON/CSV | No | Yes | Yes |
 | [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
+| [GlotFiles](https://app.glotfiles.dev/docs) | Generate polyglot files valid in multiple formats simultaneously | `apiKey` | Yes | No |
 | [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
 | [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
 | [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds GlotFiles to the Documents & Productivity section.

GlotFiles generates polyglot files — single files that are simultaneously valid in multiple formats (PDF+HTML, PDF+Image, Image+ZIP, and others).

- **Documentation:** https://app.glotfiles.dev/docs (OpenAPI spec at `/api/v1/openapi.json`)
- **Auth:** `apiKey` — free registration, no payment details required
- **Free tier:** 10 requests/day, 10 MB max file size
- **HTTPS:** Yes
- **CORS:** No — `Access-Control-Allow-Origin` is only sent for the project's own origins, so arbitrary browser origins are not supported

Entry is placed alphabetically between Flowdash and Html2PDF. `scripts/validate/format.py` reports no new issues against the base branch.
