### PR TITLE
Add FEMA Flood Zone Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FBI Wanted](https://www.fbi.gov/wanted/api) | Access information on the FBI Wanted program | No | Yes | Unknown |
 | [FEC](https://api.open.fec.gov/developers/) | Information on campaign donations in federal elections | `apiKey` | Yes | Unknown |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
+| [FEMA Flood Zone Lookup](https://flood-zone-lookup-fema.netlify.app/api-docs.html) | FEMA flood zone, Special Flood Hazard Area status and FIRM panel for any US address | No | Yes | Yes |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the FEMA Flood Zone Lookup API to the Government section.

**What it does.** Returns the FEMA flood zone, Special Flood Hazard Area status and FIRM panel for any US address. Answers "is this address in a flood zone, and which one" from FEMA's National Flood Hazard Layer.

**Free, keyless, CORS open.** No account, no API key. `Access-Control-Allow-Origin: *`, so it works client-side.

```
curl "https://flood-zone-lookup-fema.netlify.app/flood-zone?address=1600%20Pennsylvania%20Ave%20NW,%20Washington,%20DC%2020500"
```

Docs: https://flood-zone-lookup-fema.netlify.app/api-docs.html
OpenAPI: https://flood-zone-lookup-fema.netlify.app/openapi.json

Auth `No`, HTTPS `Yes`, CORS `Yes`, all verified against the live endpoint today. Entry is placed alphabetically between Federal Register and Food Standards Agency.