### PR TITLE
Add Seismic Risk by Address API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
+| [Seismic Risk by Address](https://seismic-risk-usgs.netlify.app/api-docs.html) | Earthquake hazard, ASCE 7 Seismic Design Category and design ground motions for a US address | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
 | [SpaceX](https://api.spacex.land/graphql/) | GraphQL, Company, Ships, launchpad and launch data | No | Yes | Unknown |


### PR DESCRIPTION
Adds the Seismic Risk by Address API to the Science & Math section.

**What it does.** Returns USGS earthquake hazard values for a US address or coordinate: the ASCE 7 Seismic Design Category and the design ground motions. Answers "how much seismic hazard is at this location" rather than "what earthquakes happened", which is what the existing USGS entries cover.

**Free, keyless, CORS open.** No account, no API key. `Access-Control-Allow-Origin: *`, so it works client-side.

```
curl "https://seismic-risk-usgs.netlify.app/seismic-risk?lat=37.7749&lon=-122.4194"
```

Docs: https://seismic-risk-usgs.netlify.app/api-docs.html
OpenAPI: https://seismic-risk-usgs.netlify.app/openapi.json

Auth `No`, HTTPS `Yes`, CORS `Yes`, all verified against the live endpoint today. Entry is placed alphabetically between Remote Calc and SHARE. Built on the USGS Seismic Design Web Services, which already has sibling entries in this section.