### PR TITLE
Add Frost Dates & Planting Zone API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2129,6 +2129,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | Weather | `apiKey` | Yes | Yes |
 | [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
 | [Foreca](https://developer.foreca.com) | Weather | `OAuth` | Yes | Unknown |
+| [Frost Dates & Planting Zone](https://garden-frost-planting-api.netlify.app/api-docs.html) | USDA hardiness zone, average frost dates and a frost-anchored planting calendar by US ZIP | No | Yes | Yes |
 | [Hail History](https://hail-history-noaa.netlify.app/api-docs.html) | Radar-detected hail history for any US address from NOAA NEXRAD Level-III hail detections, by year | No | Yes | Yes |
 | [HG Weather](https://hgbrasil.com/status/weather) | Provides weather forecast data for cities in Brazil | `apiKey` | Yes | Yes |
 | [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data | No | Yes | Unknown |


### PR DESCRIPTION
Adds the Frost Dates & Planting Zone API to the Weather section.

**What it does.** Returns the USDA hardiness zone, average last-spring and first-autumn frost dates, and a planting calendar anchored to those frost dates, for any US ZIP. Answers "when can I plant here" rather than "what is the forecast".

**Free, keyless, CORS open.** No account, no API key. `Access-Control-Allow-Origin: *`, so it works client-side.

```
curl "https://garden-frost-planting-api.netlify.app/frost-dates?zip=80202"
curl "https://garden-frost-planting-api.netlify.app/planting-calendar?zip=80202"
```

Docs: https://garden-frost-planting-api.netlify.app/api-docs.html
OpenAPI: https://garden-frost-planting-api.netlify.app/openapi.json

Auth `No`, HTTPS `Yes`, CORS `Yes`, all verified against the live endpoints today. Entry is placed alphabetically between Foreca and Hail History.