### PR TITLE
Add Typical Weather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,6 +2148,7 @@ API | Description | Auth | HTTPS | CORS |
 | [RainViewer](https://www.rainviewer.com/api.html) | Radar data collected from different websites across the Internet | No | Yes | Unknown |
 | [Storm Glass](https://stormglass.io/) | Global marine weather from multiple sources | `apiKey` | Yes | Yes |
 | [Tomorrow](https://docs.tomorrow.io) | Weather API Powered by Proprietary Technology | `apiKey` | Yes | Unknown |
+| [Typical Weather](https://typical-weather-api.netlify.app/api-docs.html) | Typical monthly weather for any US ZIP from NOAA 1991-2020 US Climate Normals | No | Yes | Yes |
 | [US Weather](https://www.weather.gov/documentation/services-web-api) | US National Weather Service | No | Yes | Yes |
 | [Visual Crossing](https://www.visualcrossing.com/weather-api) | Global historical and weather forecast data | `apiKey` | Yes | Yes |
 | [weather-api](https://github.com/robertoduessmann/weather-api) | A RESTful free API to check the weather | No | Yes | No |


### PR DESCRIPTION
Adds the Typical Weather API to the Weather section.

**What it does.** Returns typical monthly weather for any US ZIP from the NOAA 1991-2020 US Climate Normals: average temperature and precipitation by month. Answers "what is the weather usually like here in March" rather than "what is the forecast", which the existing Weather entries already cover.

**Free, keyless, CORS open.** No account, no API key. `Access-Control-Allow-Origin: *`, so it works client-side.

```
curl "https://typical-weather-api.netlify.app/typical-weather?zip=80202"
```

Docs: https://typical-weather-api.netlify.app/api-docs.html
OpenAPI: https://typical-weather-api.netlify.app/openapi.json

Auth `No`, HTTPS `Yes`, CORS `Yes`, all verified against the live endpoint today. Entry is placed alphabetically between Tomorrow and US Weather.