### PR TITLE
Add Galaxy Mind API

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |
+| [Galaxy Mind](https://galaxymind.space/docs/api) | Directory of online merchants that accept Bitcoin, filterable by country and category | No | Yes | Yes |
 | [Gateio](https://www.gate.io/api2) | API provides spot, margin and futures trading operations | `apiKey` | Yes | Unknown |
 | [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |
 | [Hirak Exchange Rates](https://rates.hirak.site/) | Exchange rates between 162 currency & 300 crypto currency update each 5 min, accurate, no limits | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds one entry to the Cryptocurrency section.

`https://galaxymind.space/api/vendors.json` returns a directory of online merchants that accept Bitcoin, filterable by `country`, `category`, `platform` and `since`. Docs: https://galaxymind.space/docs/api

The section currently covers price, exchange, node and chain data. This entry covers which merchants accept Bitcoin, which is not represented yet.

Checklist against the four columns, all verified live:

- Auth: `No` — no key or header required
- HTTPS: `Yes`
- CORS: `Yes` — responds `access-control-allow-origin: *`
- Free: yes, no tier or quota

Placed alphabetically between EXMO and Gateio. Description is 85 characters. `scripts/validate/format.py` reports the same 557 lines before and after this change, so it adds no new format errors.