### PR TITLE
Add Monetos Crypto Signal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
 | [Mexc](https://www.mexc.com/api-docs) | Cryptocurrency info, place order | `apiKey` | Yes | Unknown |
 | [monerometrics](https://monerometrics.net) | Reorg-aware Monero (XMR) network metrics, mining-pool centralization and chain reorganizations | No | Yes | Yes |
+| [Monetos Crypto Signal](https://github.com/MoneyKalle/crypto-signal-api) | Real-time crypto signals, funding rates & cross-venue pricing (free tier) | No | Yes | Yes |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the Monetos Crypto Signal API to the Cryptocurrency section.

Free tier (100 req/day, no API key). Provides real-time trading signals, funding rates, cross-venue pricing, on-chain DEX flow and market summary.

Docs: https://github.com/MoneyKalle/crypto-signal-api