### PR TITLE
Add SMMScout: open SMM panel dataset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1500,7 +1500,8 @@ API | Description | Auth | HTTPS | CORS |
 
 **[⬆ Back to Index](#index)**
 <br >
-<br >
+<br >| [SMMScout](https://smmscout.com/api/panels.json) | Open SMM panel dataset: 106 panels with Scout Scores, measured API latency, service counts and dated flags | No | Yes | Yes |
+
 ### Open Source Projects
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|


### PR DESCRIPTION
Adds the SMMScout open data API (https://smmscout.com/api/panels.json) to the Open Data category: 106 SMM panels with published Scout Scores, measured latency, service counts, dated flags. No auth, HTTPS, CORS yes. Dataset mirrored at github.com/RelayStack/smmscout-data.