### PR TITLE
Add Firecrawl API

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dotsweep](https://dotsweep.com/docs) | Domain availability across 1200+ TLDs with registration and renewal prices | No | Yes | Yes |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
+| [Firecrawl](https://docs.firecrawl.dev) | Context layer for web data with search, scrape, crawl and map, returning clean Markdown or JSON | `apiKey` | Yes | Yes |
 | [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | Provide numerous capabilities for important testing and monitoring methods for websites | `apiKey` | Yes | Unknown |
 | [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |
 | [GETPing](https://www.getping.info) | Trigger an email notification with a simple GET request | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items — *N/A, no new category is created*
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

### Summary

Adds a single entry for Firecrawl to the **Development** section:

```
| [Firecrawl](https://docs.firecrawl.dev) | Context layer for web data with search, scrape, crawl and map, returning clean Markdown or JSON | `apiKey` | Yes | Yes |
```

One line added, nothing else touched (1 file, +1/-0).

**Why Development:** Firecrawl serves web data to applications — search, scrape, crawl and
map endpoints that return Markdown or JSON. Every comparable entry already lives in
Development (ScraperApi, ScrapingAnt, ScrapeNinja, ZenRows, Webclaw, Thunderbit,
ProxyCrawl), so per CONTRIBUTING's "section most in line with the services offered" this
belongs there.

**Duplicate check (per CONTRIBUTING):** #6320 is open and proposes the same API under
Machine Learning. It has been unreviewed since June. This PR differs deliberately in
placement — Development rather than Machine Learning — for the reason above, and in that
each column value below was verified against the live API instead of asserted. Happy to
close whichever one maintainers prefer.

### Field values, each verified rather than assumed

| Field | Value | How it was verified |
| --- | --- | --- |
| Auth | `apiKey` | `POST /v2/crawl` and `POST /v2/map` unauthenticated return `401` with `Authorization: Bearer YOUR_API_KEY`. A keyless tier covers `search` and `scrape` only, so full use of the API requires a key |
| HTTPS | Yes | Requests to `api.firecrawl.dev` served over TLS; response line `HTTP/2 200` |
| CORS | Yes | Live response headers include `access-control-allow-origin: *` (checked with `Origin: https://example.com`) |
| Free tier | Yes | firecrawl.dev/pricing, Free Plan: 1,000 credits/month, "No cost, no card" — satisfies CONTRIBUTING's free-tier requirement. A keyless tier also exists with no signup at all |
| Docs | https://docs.firecrawl.dev | Returns `200` in this repo's own link validator |

Description is 95 characters, capitalized, no trailing punctuation. Alphabetical
placement: between `ExtendsClass JSON Storage` and `GeekFlare` (the Development section
had no `F` entry).

Only one value is listed in the `Auth` column because CONTRIBUTING permits exactly one of
`OAuth` / `apiKey` / `X-Mashape-Key` / `User-Agent` / `No`, and `scripts/validate/format.py`
rejects a combined value.

### Verification (run locally against this branch)

- **`python scripts/validate/links.py <additions>`** ✅ exit 0 — "No duplicate links", 1
  link checked and working. This is what CI's `scripts/github_pull_request.sh` runs
  against the PR diff.
- **`cd scripts && python -m unittest discover tests/`** ✅ — 31 tests, OK.
- **`python scripts/validate/format.py README.md`** ⚠️ exits 1 both **with and without**
  this change. Ran it on `master` untouched and on this branch: both report 563 errors,
  and after normalizing line numbers the two outputs are **identical**. Every reported
  error is pre-existing and this entry adds none — it is not flagged at all.
- **Live API calls** ✅ — `POST /v2/scrape` and `POST /v2/search` returned `HTTP/2 200`
  with real content and response-only fields (`scrapeId`, `creditsUsed`, `cacheState`),
  confirming genuine responses rather than cached or mocked replies.

### Notes for reviewers

- The "Call this API" (Postman) column does not exist in the Development table — it has
  five columns — so there was nothing to fill.
- CI's `github_pull_request.sh` greps the diff with `egrep "\+"`, which also pulls in
  unchanged context lines containing a `+` (e.g. "1200+ TLDs", "90+ services"). Locally
  that made `isitdownstatus.com` fail with a `429` rate-limit. It is unrelated to this
  change; the added link alone validates clean.
- The daily `validate_links.yml` job sweeps every link in the README; only the newly added
  link was validated here, not the full sweep.
