### PR TITLE
Update Orizn Visa entry in Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1967,9 +1967,9 @@ API | Description | Auth | HTTPS | CORS |
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
-| [Orizn Visa](https://visa.orizn.app) | Visa requirements for 199 countries, 39K+ passport-destination pairs in 15 languages | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [OpenVan](https://openvan.camp/docs) | Fuel prices for 121 countries, food cost index & vanlife weather scores for RV travel | No | Yes | Yes |
+| [Orizn Visa](https://visa.orizn.app) | Visa requirements for 199 passports and 232 destinations, in 15 languages | `apiKey` | Yes | Yes |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | No |


### PR DESCRIPTION
The existing Orizn Visa entry is out of date and out of alphabetical order.

**Coverage:** the entry says `199 countries, 39K+ passport-destination pairs`. The dataset now covers **199 passports across 232 destinations**, after adding non-sovereign territories that most visa datasets return as 404 (Aruba, Curaçao, Cayman Islands, Greenland, Guam, Gibraltar, Falklands, Saint-Barthélemy…). The pair count is dropped from the description rather than restated, so it does not go stale again.

**Ordering:** the row sits between `Open Charge Map` and `OpenSky Network`. Alphabetically it belongs after `OpenVan`. Moved.

No new link added — this edits the existing row only. Description is 73 characters.