### PR TITLE
Add Iconify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art | `apiKey` | No | Unknown |
 | [Icon Horse](https://icon.horse) | Favicons for any website, with fallbacks | No | Yes | Yes |
 | [Iconfinder](https://developer.iconfinder.com) | Icons | `apiKey` | Yes | Unknown |
+| [Iconify](https://iconify.design/docs/api/) | Search and fetch SVG icons from 200+ open source icon sets | No | Yes | Yes |
 | [Icons8](https://img.icons8.com/) | Icons (find "search icon" hyperlink in page) | No | Yes | Unknown |
 | [Lordicon](https://lordicon.com/) | Icons with predone Animations | No | Yes | Yes |
 | [Metropolitan Museum of Art](https://metmuseum.github.io/) | Met Museum of Art | No | Yes | No |


### PR DESCRIPTION
Adds [Iconify](https://iconify.design/docs/api/) to **Art & Design**.

Iconify is a free, open source icon API serving SVG icons from 200+ icon sets (Material Symbols, MDI, Font Awesome, Bootstrap Icons, Phosphor, etc.) through a single HTTP interface. It offers icon search (`/search`), collection listing (`/collections`), and direct SVG delivery (`/mdi/home.svg`).

Verified against the live API before submitting:

- **Auth: No** — `GET https://api.iconify.design/mdi/home.svg` returns `200` with no credentials
- **HTTPS: Yes** — serves over HTTPS
- **CORS: Yes** — responds with `Access-Control-Allow-Origin: *`
- `/collections` currently returns 236 icon sets

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically (between `Iconfinder` and `Icons8`)
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (58)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category)
- [x] All changes have been squashed into a single commit

`scripts/validate/format.py` reports the same error count on this branch as on `master` (557 pre-existing), so this entry introduces no new format violations.
