### PR TITLE
Add 0xArchive API

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Coinlayer](https://coinlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
+| [0xArchive](https://docs.0xarchive.io/) | Real-time and historical Hyperliquid and Lighter market data | `apiKey` | Yes | No |
 | [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [Alpha (Mossland)](https://alpha.moss.land/developers) | Korean crypto channel stance + RAG Q&A + canonical entity/topic/event store | No | Yes | Yes |


### PR DESCRIPTION
## Summary

Adds 0xArchive to the **Cryptocurrency** category with a direct link to its developer documentation.

0xArchive provides real-time and historical market data for Hyperliquid and Lighter through REST and WebSocket.

## API details

- **Documentation:** https://docs.0xarchive.io/
- **Free tier:** Always free, with 50k credits/month, 15 requests/second, 10 WebSocket subscriptions, and a 90-day maximum span per request
- **Authentication:** `X-API-Key`
- **HTTPS:** Yes
- **CORS:** No for arbitrary third-party origins; approved 0xArchive origins are allowlisted
- **Disclosure:** I am submitting on behalf of 0xArchive

## Verification

- Documentation, pricing, and OpenAPI URLs return `200`
- No existing 0xArchive entry, issue, or pull request was found
- The description is 60 characters and passes the repository's entry formatter
- The repository link validator passes the added line
- All 31 validator unit tests pass
- `scripts/validate/format.py` reports the same 557 pre-existing errors on this branch as on `master`, so this entry introduces no new format violations

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically, after `0x` and before `1inch`
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] I am not creating a new category
- [x] All changes have been squashed into a single commit
