### PR TITLE
fix(scripts): use raw string regex patterns to resolve Python 3.12 SyntaxWarnings

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(anchor + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]
@@ -254,7 +254,7 @@ def check_file_format(lines: List[str]) -> List[str]:
 def main(filename: str) -> None:
 
     with open(filename, mode='r', encoding='utf-8') as file:
-        lines = list(line.rstrip() for line in file)
+        lines = [line.rstrip() for line in file]
 
     file_format_err_msgs = check_file_format(lines)
 

--- a/scripts/validate/links.py
+++ b/scripts/validate/links.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-
+import random
 import re
 import sys
-import random
 from typing import List, Tuple
 
 import requests
@@ -216,7 +214,7 @@ def start_duplicate_links_checker(links: List[str]) -> None:
     has_duplicate_link, duplicates_links = check_duplicate_links(links)
 
     if has_duplicate_link:
-        print(f'Found duplicate links:')
+        print('Found duplicate links:')
 
         for duplicate_link in duplicates_links:
             print(duplicate_link)


### PR DESCRIPTION
### Summary
- Fixes Python 3.12 `SyntaxWarning: invalid escape sequence` in `scripts/validate/format.py` by converting regex patterns to raw string literals (`r'...'`).
- Modernizes list comprehension and organizes imports in validation scripts.

### Validation
- `pytest scripts/tests/` -> 31 passed in 0.07s with 0 warnings.