### PR TITLE
Add kanari API

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Yes | Unknown |
 | [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |
+| [kanari](https://kanari.io/en/api) | Real-time worldwide wildfire detections, water bomber tracking and open fire archive | No | Yes | Yes |
 | [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Yes | Unknown |
 | [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Yes | Unknown |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
**What does this PR do?**
Adds the kanari API to the Environment section (alphabetical order).

**Description**
[kanari](https://kanari.io/en/api) is a free, real-time worldwide wildfire API: satellite-detected fire clusters (NASA FIRMS/VIIRS, NOAA GOES read from the raw feed, Meteosat MTG), AI-verified witness reports, live firefighting aircraft positions, and a continuously updated open archive (CSV + JSON, CC BY 4.0). No key, no account, HTTPS, CORS enabled.

- Documentation: https://kanari.io/en/api
- Example: `GET https://kanari.io/api/events?hours=24`

**Checklist**
- [x] One API addition per PR
- [x] Alphabetical order within the section
- [x] HTTPS, documented, publicly accessible without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)