### PR TITLE
Add Sparepilot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1744,6 +1744,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
+| [Sparepilot](https://sparepilot.com/developers) | Spare parts catalog, OEM cross-references & price comparison for garden power equipment | `apiKey` | Yes | Unknown |
 | [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth` | Yes | Unknown |
 | [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |
 


### PR DESCRIPTION
Adds **Sparepilot** — a public API for garden power equipment spare parts: OEM cross-references, part identification, machine↔part compatibility, and multi-source price comparison. Free tier (100 req/day) with public read endpoints; docs at https://sparepilot.com/developers

- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md).
- [x] My addition is ordered alphabetically.
- [x] My submission has a useful description.
- [x] The description does not have more than 100 characters.
- [x] The description does not start with "A" or "An".
- [x] My submission has a valid HTTPS link.
- [x] My submission has all the required fields (Auth, HTTPS, CORS).
- [x] Only one link is added per Pull Request.
- [x] The link added is to the API itself, not a website with the API.