### PR TITLE
Add ipwhois API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipgeolocation](https://ipgeolocation.io/) | IP Geolocation AP with free plan 30k requests per month | `apiKey` | Yes | Yes |
 | [IPInfoDB](https://www.ipinfodb.com/api) | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address | `apiKey` | Yes | Unknown |
 | [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
+| [ipwhois](https://ipwhois.io/documentation) | IP geolocation with country, city, coordinates, ISP, timezone and flag data | No | Yes | Yes |
 | [Kakao Maps](https://apis.map.kakao.com) | Kakao Maps provide multiple APIs for Korean maps | `apiKey` | Yes | Unknown |
 | [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
 | [Kiprio UK Postcode](https://kiprio.com/v1/postcode) | UK postcode lookup with lat/lon, district, ward, constituency | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## What API did you add?

- **API**: ipwhois
- **Description**: IP geolocation with country, city, coordinates, ISP, timezone and flag data
- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes
- **Category**: Geocoding

## Checklist

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been squashed into a single commit

## Verification

- API documentation: https://ipwhois.io/documentation
- No authentication required (free to use)
- HTTPS supported
- CORS supported (verified with `Origin` header test, returns `access-control-allow-origin: *`)
- Returns rich JSON: IP, country, city, coordinates, ISP, timezone, flag, calling code, borders, and more
- Example: `curl https://ipwho.is/8.8.8.8` returns geolocation data for Google's DNS