### PR TITLE
Add biquote to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
-| [biquote](https://biquote.io/docs/) | Real-time forex, gold, crypto and index CFD prices, OHLC and economic calendar | No | Yes | Yes | |
+| [biquote](https://biquote.io/docs/) | Real-time forex, gold, crypto and index CFD prices, OHLC and economic calendar | No | Yes | Yes |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -857,6 +857,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
+| [biquote](https://biquote.io/docs/) | Real-time forex, gold, crypto and index CFD prices, OHLC and economic calendar | No | Yes | Yes | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
## What API does this PR add?

**[biquote](https://biquote.io/docs/)** — free real-time market data: forex, gold/metals, crypto and index CFD prices from a MetaTrader 5 feed, plus OHLC candles and a 54-country economic calendar.

- **Auth:** No (no API key, no signup; 15,000 requests/min per IP)
- **HTTPS:** Yes
- **CORS:** Yes (any origin)

Try it: `curl https://biquote.io/api/EURUSD`

## Checklist

- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or PRs
- [x] Any category I am creating has the minimum requirement of 3 items