### PR TITLE
Add Pakistan Fuel Prices API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,6 +1257,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
 | [OpenMercantil](https://openmercantil.es/api/documentacion) | Spanish company public data and BORME event timelines | No | Yes | Yes |
 | [OpenRegistry](https://openregistry.sophymarine.com) | Real-time queries to 27 national company registries (UK, FR, DE, IT, ES, KR + 21 more) | `OAuth` | Yes | Unknown |
+| [Pakistan Fuel Prices](https://oilprices.pk/fuel-price-api-pakistan) | Official OGRA petrol, diesel, kerosene and LPG prices for Pakistan, updated daily | No | Yes | Yes |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [Tollmint](https://api.tollmint.com) | Advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK | No | Yes | Yes |


### PR DESCRIPTION
Adds a free, keyless API for the official petroleum prices notified by Pakistan's Oil and Gas Regulatory Authority (OGRA) — petrol, diesel, kerosene and LPG.

| Field | Value |
| --- | --- |
| Docs | https://oilprices.pk/fuel-price-api-pakistan |
| Auth | No — no key, no registration |
| HTTPS | Yes |
| CORS | Yes, `Access-Control-Allow-Origin: *` |
| Section | Government |

```bash
curl https://oilprices.pk/api/latest
curl "https://oilprices.pk/api/price-history?product=Petrol&year=2026&limit=5"
```

Fully free with no paid tier, no device purchase and no rate limit. The data is a compilation of public government notifications, published under CC BY 4.0, and also mirrored as JSON/CSV at https://github.com/quantanow/pakistan-fuel-prices.

Checklist:
- Entry added to `Government`, in alphabetical order (between OpenRegistry and PRC Exam Schedule). Closest existing precedent is Indian Mandi Prices, which is government-sourced commodity pricing in the same section.
- One link in this PR.
- Description is 81 characters.
- `scripts/validate/format.py` reports no new findings against this change (identical output before and after, 557 pre-existing on master).
- Searched open PRs and issues; no existing entry or duplicate submission for this API.