### PR TITLE
Add Profitelligence to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [Profitelligence](https://profitelligence.com/docs/api) | Form 4 insider trades, AI-summarized SEC 8-K filings, 13F holdings and market signals | `apiKey` | Yes | Yes | |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
**What does this PR do?**
Adds Profitelligence to the Finance section (alphabetical position).

- Docs: https://profitelligence.com/docs/api
- REST API over first-party SEC data: Form 4 insider transactions, AI-summarized 8-K filings, 13F institutional holdings, OHLC, and FRED indicators
- Auth: `apiKey` (free tier, no credit card); HTTPS: Yes; CORS: Yes
- Also available to AI agents as an MCP server (`io.github.profitelligence/mcp-server` in the official MCP registry)

Checklist:
- [x] Alphabetical order within the category
- [x] Description is short and ends without a period
- [x] Auth, HTTPS, CORS fields filled