### PR TITLE
fix: update dead arXiv API user manual link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,7 +1642,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
-| [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
+| [arXiv](https://info.arxiv.org/help/api/user-manual.html) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [CycleCalcs](https://www.cyclecalcs.com/api.html) | Interpreted astronomy: sun and moon times, moon phases, planets, eclipses, seasons | No | Yes | Yes |


### PR DESCRIPTION
Re-filing after my earlier fork was accidentally deleted (which auto-closed the original PR #6917). The fix is the same one-liner.

Line 1700 in README.md points at `https://arxiv.org/help/api/user-manual`. It still loads, but it now 301-redirects to `https://info.arxiv.org/help/api/user-manual.html`. Updated to the post-redirect target so the link lands directly on the canonical page (I verified the new URL returns 200 directly).

If you'd rather keep the original URL and rely on the redirect, go ahead and close this, happy either way.