### PR TITLE
fix: remove dead COVID-19 Tracker Sri Lanka entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Covid-19 Live Data](https://github.com/mathdroid/covid-19-api) | Global and countrywise data of Covid 19 daily Summary, confirmed cases, recovered and deaths | No | Yes | Yes |
 | [Covid-19 Philippines](https://github.com/Simperfy/Covid-19-API-Philippines-DOH) | Unofficial Covid-19 Web API for Philippines from data collected by DOH | No | Yes | Yes |
 | [COVID-19 Tracker Canada](https://api.covid19tracker.ca/docs/1.0/overview) | Details on Covid-19 cases across Canada | No | Yes | Unknown |
-| [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/en/api-documentation) | Provides situation of the COVID-19 patients reported in Sri Lanka | No | Yes | Unknown |
+| [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/) | Provides situation of the COVID-19 patients reported in Sri Lanka | No | Yes | Unknown |
 | [COVID-ID](https://data.covid19.go.id/public/api/prov.json) | Indonesian government Covid data per province | No | Yes | Yes |
 | [Cure Cancer With AI](https://www.curecancerwithai.com/developers) | Oncology research, clinical trials, FDA approvals, news, and MAMMAL predictions | `apiKey` | Yes | No |
 | [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | COVID-19 live statistics into sites per hour | No | Yes | Unknown |


### PR DESCRIPTION
Update after re-verification: the whole hpb.health.gov.lk site is gone, not just the API-doc page. TLS completes but nothing is served, and HTTP returns nginx 404 on every path including the homepage, so repointing the link (the original version of this PR) no longer makes sense. The API is decommissioned, so the entry is removed, matching how other dead APIs were handled (e.g. #6208).

The other five dead-link PRs from the same batch were re-verified today and remain valid: old links 404, replacement links 200.