### PR TITLE
fix(scripts): use raw string literals for regexes and list comprehension in format.py

### DIFF
--- a/scripts/validate/format.py
+++ b/scripts/validate/format.py
@@ -24,9 +24,9 @@ num_segments = 5
 min_entries_per_category = 3
 max_description_length = 100
 
-anchor_re = re.compile(anchor + '\s(.+)')
-category_title_in_index_re = re.compile('\*\s\[(.*)\]')
-link_re = re.compile('\[(.+)\]\((http.*)\)')
+anchor_re = re.compile(re.escape(anchor) + r'\s(.+)')
+category_title_in_index_re = re.compile(r'\*\s\[(.*)\]')
+link_re = re.compile(r'\[(.+)\]\((http.*)\)')
 
 # Type aliases
 APIList = List[str]
@@ -254,7 +254,7 @@ def check_file_format(lines: List[str]) -> List[str]:
 def main(filename: str) -> None:
 
     with open(filename, mode='r', encoding='utf-8') as file:
-        lines = list(line.rstrip() for line in file)
+        lines = [line.rstrip() for line in file]
 
     file_format_err_msgs = check_file_format(lines)
 


### PR DESCRIPTION
### Summary
- In `scripts/validate/format.py`, convert regular expression patterns to raw string literals (`r'...'`) and use `re.escape(anchor)` to eliminate `SyntaxWarning: invalid escape sequence` on Python 3.12+.
- Use idiomatic list comprehension instead of `list(...)` on generator.
- Verified all 31 unit tests pass cleanly with `python3 -m unittest discover scripts/tests/`.