### PR TITLE
Add State of ATS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,7 @@ API | Description | Auth | HTTPS | CORS |
 | [JobDataLake](https://www.jobdatalake.com/docs) | 1M+ enriched job listings from 20,000+ companies with salary, skills, seniority | `apiKey` | Yes | Yes |
 | [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [State of ATS](https://withresumeai.com/developers) | Which applicant tracking system each of 738 large employers uses, verified against the live portal | No | Yes | Yes |
 | [TechRole Index](https://techrole.ru/open-data-daily) | Russian IT profession, vacancy publication and salary aggregates | No | Yes | Yes |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds one entry to **Jobs**.

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [State of ATS](https://withresumeai.com/developers) | Which applicant tracking system each of 738 large employers uses, verified against the live portal | No | Yes | Yes |

### What it returns

Which applicant tracking system (Workday, Greenhouse, SuccessFactors, iCIMS, Taleo…) runs the careers portal of a given large employer. 738 employers, 704 verified against the live portal, 551 of which publish the `apply_host` an application actually lands on — so any row can be checked in a browser rather than taken on trust. There is also a feed of confirmed vendor migrations.

```
curl https://withresumeai.com/api/v1/ats?q=nike
curl https://withresumeai.com/api/v1/ats/changes
```

### On the "not a marketing tool" rule

Fair to ask, so directly: there is no paid tier of this API, no key, no rate-limit upsell and no signup. The full dataset is MIT-licensed and also published as a CSV on GitHub, so nothing here is gated behind a product. It is served by a commercial site, which is why I am flagging it rather than hoping nobody notices.

### Checklist

- [x] Free, no auth — unauthenticated `GET` returns the complete dataset
- [x] HTTPS
- [x] CORS — `Access-Control-Allow-Origin: *`
- [x] Documented — https://withresumeai.com/developers, OpenAPI at `/api/v1/ats/openapi.json`
- [x] Alphabetical placement in Jobs (after Reed)
- [x] Description 98 characters
- [x] One link, single squashed commit, targets `master`
- [x] `scripts/validate/format.py` reports the same 563 pre-existing issues before and after; this entry adds none