### PR TITLE
Add Football Charts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1837,6 +1837,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
+| [Football Charts](https://www.football-charts.com/developers) | Tables, results, model probabilities and Monte Carlo season projections for 93 leagues | `apiKey` | Yes | Yes |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds the football-charts.com developer API to Sports & Fitness.

**What it is:** free REST API for 93 football leagues (top flights, lower divisions and women's leagues) — league tables, results, fixtures, model probabilities and daily Monte Carlo season projections.

- Docs: https://www.football-charts.com/developers
- Root: https://footballcharts-backend.onrender.com/api/v1/ (open, no key)
- Free key by email, no card: `POST /api/v1/keys/register/`
- Free tier: all 93 leagues, current + previous season, 5,000 req/day
- HTTPS: yes · CORS: `access-control-allow-origin: *` · Auth: `apiKey` (Bearer)

Checklist:
- [x] One API per pull request
- [x] Alphabetical order within the section
- [x] Description under 100 characters (86)
- [x] Name omits TLD and does not end in "API"
- [x] Free tier, no purchase required