### PR TITLE
Add CompoundPulse Proof API (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |
 | [BriefTape](https://brieftape.com) | Real-time AI-summarized SEC filings, Fed, FDA and BLS data, ticker-tagged | `apiKey` | Yes | Yes |
 | [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown | |
+| [CompoundPulse Proof](https://www.compoundpulse.io/api/proof/NVDA) | Dated verdict, invalidation level and the scored factors behind it. No key, no signup | No | Yes | Yes | |
 | [CongressInvests](https://congressinvests.com) | Real-time U.S. congressional stock trade disclosures from Senate EFD and House Clerk | `apiKey` | Yes | Yes | |
 | [Dino.markets](https://dino.markets/docs) | Matched Kalshi and Polymarket prediction-market data, cross-venue spreads | `apiKey` | Yes | No | |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |


### PR DESCRIPTION
Adds a keyless finance endpoint to the Finance section.

Returns a dated verdict, the price level that invalidates the idea, and every scored factor behind it, for US stocks, major ETFs and major crypto pairs.

- **No auth, no signup.** HTTPS, CORS `*`
- Example: `curl https://www.compoundpulse.io/api/proof/NVDA`
- The publisher also publishes its own calibration — how often the score is wrong — at https://www.compoundpulse.io/research, and a full trade record including losses at https://www.compoundpulse.io/track

Checked against CONTRIBUTING.md before opening:
- Alphabetical placement (between Citi and CongressInvests)
- 6-column format matching neighbouring rows
- Description 85 chars (under the 100 limit)
- `scripts/validate/format.py` reports **557 errors before and after** this change — zero introduced
- Link returns 200