### PR TITLE
Add VidWords API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2126,6 +2126,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TVDB](https://thetvdb.com/api-information) | Television data | `apiKey` | Yes | Unknown |
 | [TVMaze](http://www.tvmaze.com/api) | TV Show Data | No | No | Unknown |
 | [uNoGS](https://rapidapi.com/unogs/api/unogsng) | Unofficial Netflix Online Global Search, Search all netflix regions in one place | `apiKey` | Yes | Yes |
+| [VidWords](https://vidwords.com/api-docs) | YouTube transcripts and subtitles as TXT, SRT, VTT or DOCX, plus AI video analysis | `apiKey` | Yes | No |
 | [Vimeo](https://developer.vimeo.com/) | Vimeo Developer API | `OAuth` | Yes | Unknown |
 | [Watchmode](https://api.watchmode.com/) | API for finding out the streaming availability of movies & shows | `apiKey` | Yes | Unknown |
 | [Web Series Quotes Generator](https://github.com/yogeshwaran01/web-series-quotes) | API generates various Web Series Quote Images | No | Yes | Yes |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Adds one entry to **Video**, between `uNoGS` and `Vimeo`.

```
| [VidWords](https://vidwords.com/api-docs) | YouTube transcripts and subtitles as TXT, SRT, VTT or DOCX, plus AI video analysis | `apiKey` | Yes | No |
```

**Disclosure:** I maintain this API.

**Why it qualifies under CONTRIBUTING:** there is a real free tier, not a trial —
25 transcripts/month, 15 AI summaries and 10 analysis minutes, with **no card required**,
and the API token is included on the free plan (`Authorization: Basic <token>`). Nothing has
to be purchased first. The list currently has no YouTube-transcript API; the closest entry,
`BRAINIALL`, is PT-BR/Spanish audio transcription.

**Field notes:** `Auth` is `apiKey` (a token in the `Authorization` header). `HTTPS` is Yes.
`CORS` is **No** — verified, the API sends no `Access-Control-Allow-Origin`, so it is
server-side only. Docs: https://vidwords.com/api-docs

Happy to adjust wording, category or drop it if you consider it out of scope.
