### PR TITLE
Add CuttingToolsAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
+| [CuttingToolsAI](https://cuttingtoolsai.eu/api) | Cross-brand carbide insert grade equivalents by ISO application class | No | Yes | Yes |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [EOSL](https://eosl.ai/api/) | Hardware end-of-sale and end-of-service-life dates by part number, source-linked | No | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |


### PR DESCRIPTION
Adds CuttingToolsAI to the Open Data category.

- Free public JSON API for cross-brand carbide (cutting tool) grade equivalence lookups by ISO application class
- No auth, no signup, HTTPS, CORS enabled
- Docs: https://cuttingtoolsai.eu/api
- Example: https://cuttingtoolsai.eu/api/xref?grade=GC4325

Thank you for maintaining this list!