### PR TITLE
Add Magento Watch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
+| [Magento Watch](https://magento.watch) | Release and end-of-life dates plus system requirements for Magento, Adobe Commerce and Mage-OS | No | Yes | Yes |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [Micro-SaaS AI Suite](https://microsaas-agent-api.vercel.app/openapi.json) | 8 serverless AI APIs for sentiment analysis, copy generation, email verification, & OCR | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Magento Watch** to the `Development` category — a free, no-auth JSON API for Magento ecosystem version lifecycle data: release dates, end-of-life dates, and PHP/MySQL/OpenSearch/Redis system requirements for Magento Open Source, Adobe Commerce and Mage-OS.

Docs: https://magento.watch/api

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

`scripts/validate/format.py` reports no new errors against `master`.