### PR TITLE
Add Venue Authority API

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ API | Description | Auth | HTTPS | CORS |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |
 | [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes | |
 | [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes | |
+| [Venue Authority](https://venueauthority.com/developers) | Verify US food-service facilities against supported regulator records | `apiKey` | Yes | No | |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds Venue Authority to Data Validation. The API verifies US food-service facility names and addresses against supported regulator records. Documentation is public, HTTPS is required, API-key authentication is used for metered verification, and eligible verified workspaces receive a 25-unit test allowance.