### PR TITLE
Add auregistre API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,7 +1465,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AcreLens](https://www.acrelens.com) | Land suitability scoring API for any US property: off-grid, rural, recreational, investment | `apiKey` | Yes | Unknown |
 | [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
-| [auregistre](https://auregistre.fr/api) | Every value the French official gazette recorded for a company, with its announcement | No | Yes | Yes |
+| [auregistre](https://auregistre.fr/api) | What changed in a French company and when, with a watch and insolvency counts | No | Yes | Yes |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1465,6 +1465,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AcreLens](https://www.acrelens.com) | Land suitability scoring API for any US property: off-grid, rural, recreational, investment | `apiKey` | Yes | Unknown |
 | [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
+| [auregistre](https://auregistre.fr/api) | Every value the French official gazette recorded for a company, with its announcement | No | Yes | Yes |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |


### PR DESCRIPTION
Adds `auregistre` to **Open Data**, next to OpenCorporates and Registrum.

It publishes what the French official gazette (BODACC) has recorded for a company over time - every share capital, name, legal form, registered office and stated activity it printed, each with its date and a link to the announcement that published it. Nothing is inferred or scored.

- Docs: https://auregistre.fr/api
- Contract: https://auregistre.fr/api/openapi.json (OpenAPI 3.1)
- Auth: none, no account, no quota to apply for. HTTPS and CORS: yes.
- Free, in full, with no paid tier to upsell.

Example: https://auregistre.fr/api/company/794598813/timeline