### PR TITLE
Add titelia API

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Sugra](https://sugra.ai) | One API for market data, economics, commodities, climate, and global news. LLM-ready JSON | `apiKey` | Yes | Yes | |
 | [Tax Data](https://apilayer.com/marketplace/tax_data-api) | Instant VAT number and tax validation across the globe | `apiKey` | Yes | Unknown | |
 | [TickerLayer](https://tickerlayer.com) | Real-time and historical market data for stocks, forex, crypto and more | `apiKey` | Yes | Unknown | |
+| [titelia](https://titelia.com/en/api) | Which funds hold a listed company, and what a fund holds, from filings and reports | No | Yes | Yes | |
 | [Top 5 Stocks](https://top5stocks.netlify.app/developers) | Daily AI-ranked stock and crypto watchlists | No | Yes | Unknown | |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes | |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds `titelia` to **Finance**.

It answers which funds hold a listed company, and what any fund holds - read from the filings funds make to their regulators (SEC, CVM, CNMV, Finansinspektionen, SEBI) and from the annual reports European funds publish themselves, which is the half that is not otherwise republished.

- Docs: https://titelia.com/en/api
- Contract: https://titelia.com/api/openapi.json (OpenAPI 3.1)
- Auth: none, no account, no quota to apply for. HTTPS and CORS: yes.
- Free, in full, with no paid tier to upsell.

Example: https://titelia.com/api/company/FR0000120073?limit=5