### PR TITLE
Add quivad API

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |
+| [quivad](https://www.quivad.com/api) | Net short positions disclosed to nineteen market regulators, since 2010 | No | Yes | Yes | |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |


### PR DESCRIPTION
Adds `quivad` to **Finance**.

It serves the net short positions disclosed to the nineteen market regulators that publish them - France, Belgium, Netherlands, Germany, Austria, Spain, Italy, Poland, the United Kingdom, Sweden, Norway, Ireland, Denmark, Finland, Greece, Luxembourg, Japan, Australia and the United States - going back to 2010, where a register publishes only what is open today.

- Docs: https://www.quivad.com/api
- Contract: https://www.quivad.com/api/openapi.json (OpenAPI 3.1)
- Auth: none, no account, no quota to apply for. HTTPS and CORS: yes.
- Free, in full, with no paid tier to upsell. The whole base is one request away at /api/positions.jsonl.gz.

Example: https://www.quivad.com/api/moves?limit=5