### PR TITLE
Add StoriesFly API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1805,6 +1805,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
 | [SocialSwarm](https://social-swarm-main-aa77a19.zuplo.site) | Turn articles into ready-to-post X thread drafts with different hooks | `apiKey` | Yes | No |
+| [StoriesFly](https://storiesfly.com/developers) | Anonymous Instagram stories, profiles, highlights and follower activity tracking | `apiKey` | Yes | Yes |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
 | [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds StoriesFly to the Social section.

- **Free tier:** yes — 25 requests/day without payment, rate-limit state returned in `X-RateLimit-*` headers.
- **Auth:** `apiKey` via `X-Api-Key` header, key issued at https://storiesfly.com/developers
- **HTTPS:** yes
- **CORS:** yes (`Access-Control-Allow-Origin: *`, verified with a preflight request)
- **Docs:** https://storiesfly.com/developers · OpenAPI 3.0.3 spec at https://storiesfly.com/api/docs/openapi
- **Placement:** Social, following the guidance in CONTRIBUTING that Instagram-related APIs belong there.

Disclosure: I run this service.