### PR TITLE
Add GreenCalculus API

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API calculates the impact of common carbon-intensive activities in real time | `apiKey` | Yes | Unknown |
 | [CO2 Offset](https://co2offset.io/api.html) | API calculates and validates the carbon footprint | No | Yes | Unknown |
 | [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Yes | Unknown |
+| [GreenCalculus](https://greencalculus.com/developers/) | GHG emission factors and carbon calculations, each with its source cell, data version and citation | `apiKey` | Yes | Yes |
 | [gridcarbon](https://gridcarbon.dev) | Hourly grid carbon intensity in gCO2eq/kWh for 45 zones in Europe, the US and Great Britain | No | Yes | Yes |
 | [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API calculates the impact of common carbon-intensive activities in real time | `apiKey` | Yes | Unknown |
 | [CO2 Offset](https://co2offset.io/api.html) | API calculates and validates the carbon footprint | No | Yes | Unknown |
 | [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Yes | Unknown |
-| [GreenCalculus](https://greencalculus.com/developers/) | GHG emission factors and carbon calculations, each with its source cell, data version and citation | `apiKey` | Yes | Yes |
+| [GreenCalculus](https://greencalculus.com/developers/) | Emission factors with their exact source cell, data version and citation; no key needed to read | No | Yes | Yes |
 | [gridcarbon](https://gridcarbon.dev) | Hourly grid carbon intensity in gCO2eq/kWh for 45 zones in Europe, the US and Great Britain | No | Yes | Yes |
 | [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds GreenCalculus to **Environment**.

Greenhouse-gas emission factors and carbon footprint calculations over REST. Every value is returned with the source it came from and the version of the dataset, so a result can be cited and re-run to the same number later.

| Field | Value | Basis |
|---|---|---|
| Auth | `apiKey` | Bearer key; free tier, no card required, and several endpoints need no key at all |
| HTTPS | Yes | HTTPS only |
| CORS | Yes | verified — `access-control-allow-origin: *` on `api.greencalculus.com/v1/factors` |

Docs: https://greencalculus.com/developers

Checklist against CONTRIBUTING:

- Placed alphabetically in Environment, between *Danish data service Energi* and *GrünstromIndex*
- Description is 94 characters (limit 100)
- Name carries no TLD and does not end in "API"
- Columns padded with one space either side
- One link, one commit, targeting `master`
- Searched existing issues and PRs first — no prior GreenCalculus entry