### PR TITLE
Add eeemoji API

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
 | [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth` | Yes | Unknown |
 | [DummyImage](https://dummyimage.com/) | Generate placeholder images with custom size, colors and text | No | Yes | Unknown |
+| [eeemoji](https://eeemoji.com/api) | Emoji metadata: names, keywords, categories, shortcodes and skin-tone variants | No | Yes | Yes |
 | [EmojiHub](https://github.com/cheatsnake/emojihub) | Get emojis by categories and groups | No | Yes | Yes |
 | [Europeana](https://pro.europeana.eu/resources/apis/search) | European Museum and Galleries content | `apiKey` | Yes | Unknown |
 | [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art | `apiKey` | No | Unknown |


### PR DESCRIPTION
Free emoji metadata API. No auth, HTTPS, CORS enabled, public Postman collection at https://eeemoji.com/api/v1/postman.json and an OpenAPI 3.1 spec at https://eeemoji.com/api/v1/openapi.json.