### PR TITLE
Add Meteostat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2157,6 +2157,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IPMA](https://api.ipma.pt/open-data/) | Portuguese weather and climate data | No | Yes | Unknown |
 | [Meltema](https://meltema.com/docs) | Multi-model weather: GFS, ECMWF AIFS/IFS and a 31-member GEFS ensemble, keyless point forecasts | No | Yes | No |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
+| [Meteostat](https://dev.meteostat.net/) | Weather station data, historical and forecast | No | Yes | Yes |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
 | [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds [Meteostat](https://dev.meteostat.net/) to the Weather category.

Meteostat provides weather station data, historical observations and forecasts from 10,000+ stations worldwide via an open API (keyless for hourly data, no auth required for basic use). Fits alphabetically between Meteorologisk Institutt and Micro Weather.
