### PR TITLE
Add Bright Sky weather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,6 +2148,7 @@ API | Description | Auth | HTTPS | CORS |
 | [APIXU](https://www.apixu.com/doc/request.aspx) | Weather | `apiKey` | Yes | Unknown |
 | [AQICN](https://aqicn.org/api/) | Air Quality Index Data for over 1000 cities | `apiKey` | Yes | Unknown |
 | [AviationWeather](https://www.aviationweather.gov/dataserver) | NOAA aviation weather forecasts and observations | No | Yes | Unknown |
+| [Bright Sky](https://brightsky.dev/) | JSON API for DWD weather data with current and historical observations for Germany | No | Yes | Yes |
 | [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | Weather | `apiKey` | Yes | Yes |
 | [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
 | [Foreca](https://developer.foreca.com) | Weather | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Add Bright Sky weather API

Adds Bright Sky (https://brightsky.dev/) — a free JSON API for DWD
(Deutscher Wetterdienst) weather data with current and historical
observations for Germany. No auth required, HTTPS and CORS supported.
Placed alphabetically in Weather category.
