### PR TITLE
Add ScanMalware API

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NoPhishy](https://rapidapi.com/Amiichu/api/exerra-phishing-check/) | Check links to see if they're known phishing attempts | `apiKey` | Yes | Yes |
 | [Phisherman](https://phisherman.gg/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
 | [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes | Yes |
+| [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | Yes | Yes |
 | [URLhaus](https://urlhaus-api.abuse.ch/) | Bulk queries and Download Malware Samples | No | Yes | Yes |
 | [URLScan.io](https://urlscan.io/about-api/) | Scan and Analyse URLs | `apiKey` | Yes | Unknown |
 | [VirusTotal](https://docs.virustotal.com/reference/overview) | VirusTotal File/URL Analysis | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds ScanMalware to `Anti-Malware`, alphabetically between Scanii and URLhaus.

Free sandboxed URL scanner. Submit a URL, it renders in an instrumented browser and returns a phishing/malware verdict along with network requests, detected technologies, TLS/JARM fingerprints, YARA matches and a screenshot. The public archive, 549,422 scans as of today, is searchable by domain, IP, ASN, JARM and favicon hash.

Field values, all checked live today:

**Auth: `No`**

```
curl 'https://scanmalware.com/api/v1/recent?limit=1'
```

Returns `200` and data with no credentials. 600 req/min anonymous, 3000 with a key.

**HTTPS: `Yes`**

**CORS: `Yes`**

```
curl -sD- -o/dev/null 'https://scanmalware.com/api/v1/recent?limit=1' -H 'Origin: https://example.com'
```

Returns `access-control-allow-origin: *`, and a preflight `OPTIONS` returns `200`.

Docs at https://scanmalware.com/api-docs (OpenAPI JSON plus Swagger UI).

Checklist: description is 95 characters, the name carries no TLD and does not end in "API", one link, single commit, columns padded one space either side, `/db` untouched, targeted at `master`. Searched existing PRs and issues for "scanmalware" first, no duplicate.

Full disclosure: I run ScanMalware (Triop AB, Sweden). The same row was reviewed and merged at marcelscruz/public-apis#1104 if that is useful context.
