### PR TITLE
Add APITube API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,6 +1432,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Mediastack](https://mediastack.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Free, Simple REST API for Live News & Blog Articles | `apiKey` | Yes | Unknown |
+| [APITube](https://docs.apitube.io/platform/news-api) | Real-time and historical news from 500,000+ sources with sentiment, entities and topics as JSON | `apiKey` | Yes | Yes |
 | [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
 | [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
 | [Currents](https://currentsapi.services/) | Real-time and historical global news with multilingual support | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds APITube to the **News** section.

**What it is:** a news API that returns articles from 500,000+ sources as structured JSON. Every article ships enriched — sentiment score, extracted entities (people, organizations, locations, brands), IPTC categories, topics and industries — so there is no HTML to parse on the client side.

- **Docs:** https://docs.apitube.io/platform/news-api
- **Main endpoint:** `GET /v1/news/everything` with 65+ filter parameters (keywords, language, country, source domain, source rank, sentiment range, entity ID, date range) combinable in one request. Other endpoints: `/v1/news/top-headlines`, `/v1/news/story`, `/v1/news/trends`, `/v1/news/stream` (Server-Sent Events).
- **Auth:** `apiKey` — passed as an `api_key` query parameter, an `X-API-Key` header or `Authorization: Bearer`.
- **HTTPS:** Yes.
- **CORS:** Yes — verified with a cross-origin GET; the API responds with `Access-Control-Allow-Origin: *`.
- **Free access:** free tier is permanent — 100 requests/day, no credit card, no trial clock. Paid plans exist on top of it, same as the other commercial entries already listed in this section (GNews, NewsData, Currents, MarketAux).

Disclosure: I work on APITube, so this is a self-promotional submission. Posting it because the free tier is unlimited in time and usable without payment, which is what CONTRIBUTING asks for — happy to close it if maintainers see it differently.

Placement note: the row goes right below the pinned Mediastack sponsor entry and above `Associated Press`, which is the correct alphabetical position among the regular entries.

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (95)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests (no existing mention of APITube)
- [x] Any category I am creating has the minimum requirement of 3 items (no new category)
- [x] All changes have been squashed into a single commit
