### PR TITLE
Add PennyOCR (OCR API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Monday](https://api.developer.monday.com/docs) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth` | Yes | Unknown |
 | [OCR.Space](https://ocr.space/ocrapi) | OCR text extraction from images and PDFs with a free tier | `apiKey` | Yes | Unknown |
+| [PennyOCR](https://pennyocr.com/docs/) | OCR PDFs and images to markdown or plain text, 100 free pages/month | `apiKey` | Yes | Yes |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
 | [PDFFleet](https://pdffleet.com) | HTML and URL to PDF API with templates and a free tier | `apiKey` | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds [PennyOCR](https://pennyocr.com/docs/) — an OCR API converting PDFs and images to markdown (tables preserved) or plain text. Auth: `apiKey` (Bearer). HTTPS: yes. CORS: yes. Free tier: 100 pages/month, no card.

Disclosure: I'm the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)