### PR TITLE
Add Wiseek Filing Impact API (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |
 | [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets Stock Comments Sentiment Analysis | No | Yes | Unknown | |
+| [Wiseek Filing Impact](https://wiseek.ai/datasets/#api) | How SEC filings move stocks: importance scores vs measured next-session excess moves, JSON/CSV, CC BY 4.0 | No | Yes | Yes |
 | [Yahoo Finance](https://www.yahoofinanceapi.com/) | Real time low latency Yahoo Finance API for stock market, crypto currencies, and currency exchange | `apiKey` | Yes | Yes | |
 | [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth` | Yes | Yes | |
 | [Zelothorn](https://zelothorn.com/developers) | Plain-English explanations of US public companies with SEC filings and earnings data | No | Yes | Yes | |


### PR DESCRIPTION
Adds the Wiseek Filing Impact open-data API: free, keyless, CORS-open JSON/CSV endpoints measuring how SEC filings move US stocks (real-time importance scores vs next-session excess moves, per-event archive, reproduction recipe). Static edge-cached files; OpenAPI spec at https://wiseek.ai/datasets/openapi.json; catalog at https://wiseek.ai/datasets/index.json. CC BY 4.0, DOI 10.5281/zenodo.22047734.

- Auth: No
- HTTPS: Yes
- CORS: Yes

Disclosure: I run Wiseek; the API and data are free and openly licensed.