### PR TITLE
Add FrameThrower API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,6 +1601,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Duply](https://duply.co/docs#getting-started-api) | Generate, Edit, Scale and Manage Images and Videos Smarter & Faster | `apiKey` | Yes | Yes |
 | [DynaPictures](https://dynapictures.com/docs/) | Generate Hundreds of Personalized Images in Minutes | `apiKey` | Yes | Yes |
 | [Flickr](https://www.flickr.com/services/api/) | Flickr Services | `OAuth` | Yes | Unknown |
+| [FrameThrower](https://framethrower.ai/developers) | Film stills from 5,489 films, searchable by lighting, lens, shot size, colour and mood | `apiKey` | Yes | Yes |
 | [Getty Images](http://developers.gettyimages.com/en/) | Build applications using the world's most powerful imagery | `OAuth` | Yes | Unknown |
 | [Gfycat](https://developers.gfycat.com/api/) | Jiffier GIFs | `OAuth` | Yes | Unknown |
 | [Giphy](https://developers.giphy.com/docs/) | Get all your gifs | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds FrameThrower to **Photography**.

A REST API over a cinematography reference library — film stills indexed frame by frame on lighting, lens character, shot size, camera angle, colour palette and mood. Plain-language, image and colour search over the same index.

- Docs: https://framethrower.ai/developers
- OpenAPI: https://framethrower.ai/api/v1/openapi.json
- Auth: `apiKey` (personal access token) · HTTPS: yes · CORS: `Access-Control-Allow-Origin: *`, verified

**Free tier:** $2 of credits on signup, no card required — a search is 2 credits, so that is 500 free calls before anything is owed. No rate limits.

Checklist:
- One link, one commit
- Alphabetical between Flickr and Getty Images
- Description 86 characters
- Name does not end in "API", no TLD
- Targets `master`