### PR TITLE
feat: add AerisWeather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2145,6 +2145,7 @@ API | Description | Auth | HTTPS | CORS |
 | [7Timer!](http://www.7timer.info/doc.php?lang=en) | Weather, especially for Astroweather | No | No | Unknown |
 | [AccuWeather](https://developer.accuweather.com/apis) | Weather and forecast data | `apiKey` | No | Unknown |
 | [Aemet](https://opendata.aemet.es/centrodedescargas/inicio) | Weather and forecast data from Spain | `apiKey` | Yes | Unknown |
+| [AerisWeather](https://www.aerisweather.com/support/docs/api/) | Weather and forecast data with severe weather alerts | `apiKey` | Yes | Yes |
 | [APIXU](https://www.apixu.com/doc/request.aspx) | Weather | `apiKey` | Yes | Unknown |
 | [AQICN](https://aqicn.org/api/) | Air Quality Index Data for over 1000 cities | `apiKey` | Yes | Unknown |
 | [AviationWeather](https://www.aviationweather.gov/dataserver) | NOAA aviation weather forecasts and observations | No | Yes | Unknown |


### PR DESCRIPTION
feat: add AerisWeather API

AerisWeather provides weather and forecast data with severe weather alerts.
Docs: https://www.aerisweather.com/support/docs/api/
Category: Weather, Auth: apiKey, HTTPS: Yes, CORS: Yes
Inserted alphabetically after Aemet.
