### PR TITLE
Add RenderPing to Development APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Development
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [RenderPing](https://renderping.theking.qzz.io) | Website screenshot & PDF rendering API with full-page, viewport and element capture | `apiKey` | Yes | Yes |
 | [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Secure User-Agent String Lookup JSON API | `OAuth` | Yes | Unknown |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |


### PR DESCRIPTION
Adds [RenderPing](https://renderping.theking.qzz.io) to the **Development** section.

RenderPing is a website screenshot & PDF rendering API rendered by real Chromium: full-page or custom viewport, element capture, hide-selector cleanup, cookies/headers for authenticated pages, sync + async with webhooks and signed result URLs. Free tier: 50 renders/month (`apiKey` auth). OpenAPI 3.1 spec: https://renderping.theking.qzz.io/openapi.json