### PR TITLE
Add Animica API

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Blockchain
 | API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [Animica](https://explorer.animica.org/api/openapi.json) | Post-quantum proof-of-work L1 explorer: head, blocks, txs, addresses, rich list, supply, mining info | No | Yes | Yes |
 | [Bitquery](https://graphql.bitquery.io/ide) | Onchain GraphQL APIs & DEX APIs | `apiKey` | Yes | Yes |
 | [Blockscout](https://dev.blockscout.com/) | Multichain block explorer REST API (with Etherscan-compatible JSON-RPC) | `apiKey` | Yes | No |
 | [Chainlink](https://chain.link/developer-resources) | Build hybrid smart contracts with Chainlink | No | Yes | Unknown |


### PR DESCRIPTION
Adds the Animica explorer API to **Blockchain**.

Free, no auth, CORS enabled (`access-control-allow-origin: *`). REST endpoints for a live post-quantum proof-of-work L1 blockchain: `/api/head`, `/api/blocks`, `/api/block/:hashOrHeight`, `/api/tx/:hash`, `/api/address/:bech32`, `/api/richlist`, `/api/circulating-supply`, `/api/mining/info`, documented by an OpenAPI document (51 paths) at the linked URL. Base URL: https://explorer.animica.org/api

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
