### PR TITLE
fix: 修審查可修項 R-06～R-10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,13 @@ concurrency:
 
 jobs:
   test:
-    name: test (ubuntu / py3.12)
+    name: test (ubuntu / py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.14"]
     env:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: "utf-8"
@@ -31,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt
@@ -53,7 +57,7 @@ jobs:
         run: python tools/check_links.py
 
   test-windows:
-    name: test (windows / py3.12)
+    name: test (windows / py3.14)
     runs-on: windows-latest
     timeout-minutes: 20
     env:
@@ -68,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install test dependencies
         run: python -m pip install -r requirements-dev.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (ubuntu / py3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Compile
+        run: python -m compileall -q scripts tests tools
+
+      - name: Ruff (E9 + F)
+        run: python -m ruff check --select E9,F --target-version py39 tests tools
+
+      - name: Pytest
+        run: python -m pytest tests -q
+
+      - name: Upstream validate package tests
+        working-directory: scripts
+        run: python -m unittest discover tests --quiet
+
+      - name: Check Markdown links
+        run: python tools/check_links.py
+
+  test-windows:
+    name: test (windows / py3.12)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Canonical Windows development gate
+        shell: pwsh
+        run: pwsh -NoProfile -File tools/dev_check.ps1

--- a/.github/workflows/test_of_push_and_pull.yml
+++ b/.github/workflows/test_of_push_and_pull.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   tests:
     name: 'Validate README.md changes'
+    if: github.repository == 'public-apis/public-apis'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_of_validate_package.yml
+++ b/.github/workflows/test_of_validate_package.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   unittest:
     name: 'Run tests of validate package'
+    if: github.repository == 'public-apis/public-apis'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -1,0 +1,54 @@
+name: Upstream check
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - tools/check_upstream_updates.py
+      - tools/upstream_baseline.json
+      - .github/workflows/upstream-check.yml
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Check upstream
+        id: upstream
+        continue-on-error: true
+        run: python tools/check_upstream_updates.py --strict
+
+      - name: Publish report
+        if: always()
+        run: cat upstream-review-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require review when upstream changed
+        if: steps.upstream.outcome == 'failure'
+        run: |
+          echo "::error::Upstream changed or the check failed. Review the workflow summary."
+          exit 1

--- a/.github/workflows/validate_links.yml
+++ b/.github/workflows/validate_links.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   validate_links:
     name: 'Check all links are working'
+    if: github.repository == 'public-apis/public-apis'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ruff
+.ruff_cache/
+
+# Fork maintenance reports
+upstream-review-report.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+給 Codex、Claude Code、Cursor 與其他自動化代理在本專案工作時的指引。目錄本體先讀 [`README.md`](README.md)；開發與驗收細節見 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
+
+## 專案定位
+
+這是 [`public-apis/public-apis`](https://github.com/public-apis/public-apis) 的 MIT fork。
+核心價值是一份人工整理的免費 public API 目錄：每筆標好 Auth、HTTPS、CORS。複製說明文件網址就能用。
+
+`origin` 是 `SanHsien/public-apis`，`upstream` 是原作者 repo，預設分支皆為 `master`。
+保留上游作者、MIT 授權與 `README.md` 目錄。本 fork 的維護差異記在 [`FORK.md`](FORK.md) 與 [`docs/DECISIONS.md`](docs/DECISIONS.md)。
+
+主要開發與完整驗收環境是 **Windows 11 + PowerShell**；Ubuntu CI 補跨平台相容性。
+
+## 硬性邊界
+
+- **不要翻譯或改寫 `README.md` 目錄。** 那是上游產品，不是本 fork 的維護索引。1000+ 筆條目若做成繁中鏡像，每週上游更新會無法審查。維護規則以本檔為準。
+- 不要改 `CONTRIBUTING.md` 的欄位規則（Auth / HTTPS / CORS / 描述長度），除非要回貢上游。
+- 不提交 API key、cookie、帳號資料，或把付費／行銷向 API 塞進目錄。
+- 不推送到 `upstream`。上游同步先跑 `python tools/check_upstream_updates.py`，逐筆審查後再 merge / cherry-pick；不盲目覆蓋 fork 文件與 Windows gate。
+- 不把本 repo 做成 API gateway、代理層或「一鍵呼叫所有 API」的後端。它是目錄，不是執行時。
+
+## 技術與資料流
+
+- Python 3.9+（本機與 fork CI 以 3.12 為準）；上游 GitHub Actions 仍跑 3.8，不要去改那些 workflow 的版本，除非回貢。
+- `README.md`：API 目錄。
+- `scripts/validate/`：格式與連結檢查（以上游為準）。
+- `tools/`：fork 維護工具（上游檢查、相對連結檢查、Windows gate）。
+- `tests/`：pytest，鎖的是 fork 骨架，不是把 1000+ API 當測試資料。
+- 完整活連結掃描（`scripts/validate/links.py README.md` 不帶 `-odlc`）很慢且不穩定；日常 gate 不拿它當硬條件。上游 `format.py README.md` 在 fork 當下的 `master` 自己就失敗（贊助表格式），本線不代為修目錄。
+
+## 開發原則
+
+- 一般修改使用 **branch → PR → CI → merge**，不要直接在 `master` 做正常維護。
+- 修 bug 先補可重現失敗測試，再做最小修正。
+- 上游公開目錄格式、`CONTRIBUTING.md` 與 `scripts/validate/` 視為相容性契約。
+- 不為了套格式而大改上游程式；Ruff 只閘本 fork 的 `tests/` 與 `tools/`（E9 + F）。上游 `scripts/` 的 F541／F401 留給上游。
+- 使用繁體中文回覆；維護文件用繁中。目錄本體維持英文。
+- PR 標題建議 Conventional Commit；合併前先讀 `gh pr diff <編號>`。
+- `REVIEW.md` 是風險快照，不是每個一般 bug 的流水帳。
+
+## 上游處理
+
+1. `git fetch upstream master`
+2. `python tools/check_upstream_updates.py --strict`
+3. 逐筆判斷是否與 Windows gate、fork 文件或測試衝突。
+4. 可同步的提交用 merge；只需要部分修正時 cherry-pick 或最小重做。
+5. 跑 `pwsh -NoProfile -File tools\dev_check.ps1`
+6. 採用／略過寫進 `docs/DECISIONS.md`，驗證後才推進 `tools/upstream_baseline.json`
+
+Baseline 代表「已審查」，不代表「全部已合併」。
+
+`README.md` 的新條目直接 merge 進來即可，不必翻譯。
+
+## 驗證
+
+```powershell
+python -m venv .venv
+.venv\Scripts\python -m pip install --upgrade pip
+.venv\Scripts\python -m pip install -r requirements-dev.txt
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+沒有實際跑過 Windows gate，不要宣稱本機開發環境已可用。
+
+## 文件責任
+
+- `README.md`：上游 API 目錄（不改寫）。
+- `FORK.md`：與上游的關係、差異、同步方式。
+- `NOTICE.md`：授權與 attribution。
+- `docs/UPSTREAM.md`：upstream remote 與審查清冊。
+- `docs/DEVELOPMENT.md`：本機開發與驗收指令。
+- `docs/DECISIONS.md`：長期取捨。
+- `CONTRIBUTING.md`：上游貢獻規則；新增 API 請往上游送。
+- `SECURITY.md`：本 fork 的安全回報流程。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 
 ## 技術與資料流
 
-- Python 3.9+（本機與 fork CI 以 3.12 為準）；上游 GitHub Actions 仍跑 3.8，不要去改那些 workflow 的版本，除非回貢。
+- Python 3.9+（本機與 Windows CI 以 3.14 為準；Ubuntu CI 跑 3.12 與 3.14）；上游 GitHub Actions 仍跑 3.8，不要去改那些 workflow 的版本，除非回貢。
 - `README.md`：API 目錄。
 - `scripts/validate/`：格式與連結檢查（以上游為準）。
 - `tools/`：fork 維護工具（上游檢查、相對連結檢查、Windows gate）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+請先完整閱讀並遵守 [`AGENTS.md`](AGENTS.md)。本檔只補充 Claude Code 的最小入口：
+
+- 這是保留上游歷史的 fork；不要移除 `upstream`、原作者或 MIT 授權標示。
+- `README.md` 是 API 目錄，不要改寫成本 fork 的維護索引，也不要翻譯成繁中。
+- 修改驗證腳本前，先跑對應測試；提交前跑
+  `pwsh -NoProfile -File tools\dev_check.ps1`。
+- API key、cookie 與帳號資料一律不可提交。
+- 使用繁體中文，直接交付可驗證結果，避免冗長背景鋪陳。

--- a/FORK.md
+++ b/FORK.md
@@ -20,7 +20,7 @@
 | `AGENTS.md` / `CLAUDE.md` | 本 fork 的 AI 維護單一真相源 |
 | `NOTICE.md` / `FORK.md` | 來源、授權與同步說明 |
 | `tools/dev_check.ps1` | Windows 本機一鍵 gate |
-| `.github/workflows/ci.yml` | 新增 Ubuntu + Windows：pytest / ruff / 上游 unittest / 維護文件連結 |
+| `.github/workflows/ci.yml` | 新增 Ubuntu 3.12／3.14 + Windows 3.14：pytest / ruff / 上游 unittest / 維護文件連結 |
 | `.github/workflows/upstream-check.yml` | 每週對 `upstream/master` 做未審查 commit 檢查 |
 | `docs/DECISIONS.md`、`docs/UPSTREAM.md`、`docs/DEVELOPMENT.md` | fork 維護文件 |
 | 上游既有 workflows | 保留，但加上只在官方 `public-apis/public-apis` 執行的 guard |

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,51 @@
+# Fork 維護說明
+
+本 repo fork 自 [`public-apis/public-apis`](https://github.com/public-apis/public-apis)，
+沿用 MIT License 與完整 Git 歷史。
+
+## 為什麼維護 fork
+
+- 保留社群持續更新的免費 public API 目錄（天氣、金融、加密貨幣、AI、地圖、動漫等）。
+- 本機要能在 Windows 11 重跑上游 `scripts/validate` 單元測試，以及本 fork 的開發 gate。
+- 建立逐筆審查的上游追蹤：每週自動對 `upstream/master` 列出未審查 commit。
+- 不當成第二個官方產品站。目錄本體、欄位規則與貢獻格式以上游為準。
+
+**回貢判準：修的是上游驗證腳本或目錄格式的 bug 就送回去；這裡獨創的文件／Windows 維護骨架留在這裡。**
+
+## 與上游的差異
+
+| 項目 | 說明 |
+|---|---|
+| `README.md` | **不翻譯、不改寫。** 這份 1000+ API 目錄就是產品，保持上游英文為單一真相源 |
+| `AGENTS.md` / `CLAUDE.md` | 本 fork 的 AI 維護單一真相源 |
+| `NOTICE.md` / `FORK.md` | 來源、授權與同步說明 |
+| `tools/dev_check.ps1` | Windows 本機一鍵 gate |
+| `.github/workflows/ci.yml` | 新增 Ubuntu + Windows：pytest / ruff / 上游 unittest / 維護文件連結 |
+| `.github/workflows/upstream-check.yml` | 每週對 `upstream/master` 做未審查 commit 檢查 |
+| `docs/DECISIONS.md`、`docs/UPSTREAM.md`、`docs/DEVELOPMENT.md` | fork 維護文件 |
+| 上游既有 workflows | 保留，但加上只在官方 `public-apis/public-apis` 執行的 guard |
+
+產品 `README.md` 目錄、`CONTRIBUTING.md` 欄位規則、`scripts/validate/` 以上游為準，除非有已記錄的 fork 修正。
+
+## 分支與 remote
+
+- `origin/master`：SanHsien 維護線。
+- `upstream/master`：public-apis 原始專案。
+- 功能與修正使用短期分支；驗證通過後再合併到 `master`。
+
+不要 `git push upstream`。同步方式見 [`docs/UPSTREAM.md`](docs/UPSTREAM.md)。
+
+要新增或修正某一個 API 條目：對 [`public-apis/public-apis`](https://github.com/public-apis/public-apis) 開 PR，不要把行銷向、付費牆 API 送進本 fork。
+
+## 換一台電腦怎麼開發
+
+```powershell
+git clone https://github.com/SanHsien/public-apis.git
+cd public-apis
+python -m venv .venv
+.venv\Scripts\python -m pip install --upgrade pip
+.venv\Scripts\python -m pip install -r requirements-dev.txt
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+只想查 API、不開發時：直接打開 [`README.md`](README.md)。

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,37 @@
+# NOTICE
+
+public-apis (SanHsien maintenance fork)
+Copyright 2026 SanHsien
+
+This project is derived from [`public-apis/public-apis`](https://github.com/public-apis/public-apis), originally licensed under the MIT License.
+
+Original work:
+
+- Project: `public-apis`
+- Author / organization: `public-apis`
+- License: MIT
+- Original copyright notice: `Copyright (c) 2022 public-apis`
+
+This repository keeps the original MIT license text in [`LICENSE`](LICENSE). Modifications, documentation, and future project-specific changes in this fork are maintained by SanHsien unless otherwise noted.
+
+## License Notes
+
+The MIT License allows use, copying, modification, merging, publication, distribution, sublicensing, and commercial use, provided that the original copyright notice and permission notice are included in all copies or substantial portions of the software.
+
+When redistributing this project or substantial parts of it:
+
+- Keep [`LICENSE`](LICENSE) with the original MIT text.
+- Keep attribution to `public-apis/public-apis`.
+- Add separate attribution for new third-party libraries when their licenses require it.
+
+## Project Scope
+
+This fork ships a curated Markdown catalog of public APIs and local validation scripts. It does not vendor API responses, API keys, or third-party SDKs. Individual APIs listed in `README.md` have their own terms; listing them is not an endorsement and does not grant a license to those services.
+
+## Credits
+
+`public-apis` is a fork of `public-apis/public-apis` (MIT). The API catalog, contributing rules, and `scripts/validate/` belong to the upstream project.
+
+This project is not affiliated with, endorsed by, or sponsored by APILayer, Postman, GitHub, or any vendor named in the catalog.
+
+Do not commit secrets, API keys, cookies, or account data.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,7 +1,7 @@
 # Repository review（Windows-first）
 
 - Review date: 2026-08-22
-- Review baseline: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
+- Review baseline: `2ca3aae7b56b5a8cc16c9b29106b4b37ca7d0f1c`
 - Upstream reviewed through: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
 - Primary environment: Windows 11、PowerShell、Python 3.14.7（本機）、CI Windows / Ubuntu 3.12
 - Status: 維護骨架可用；API 目錄與 `scripts/validate/` 未改寫；官方仍是上游 `public-apis/public-apis`
@@ -40,15 +40,14 @@ python tools/check_upstream_updates.py
 | `python scripts/validate/format.py README.md` | 1 | APILayer 贊助表只有 3 欄、表格分隔列被當成 entry、多個分類未按字母排序 |
 | `python scripts/validate/links.py README.md --only_duplicate_links_checker` | 1 | 重複：`isitdownstatus.com`、`tastedive.com/read/api` |
 
-### GitHub Actions
+### GitHub Actions（`2ca3aae` push）
 
-fork 第一次 push 後補上 run URL。預期：
-
-| Workflow | 預期 | 說明 |
+| Workflow | 結果 | 說明 |
 |---|---|---|
-| CI | success | Ubuntu py3.12 + Windows `dev_check.ps1` |
-| Upstream check | success | 無未審查上游 commit |
-| 上游三個 catalog workflow | skipped | `if: github.repository == 'public-apis/public-apis'` |
+| [CI](https://github.com/SanHsien/public-apis/actions/runs/32555198499) | success | Ubuntu py3.12、Windows py3.12 `dev_check.ps1` |
+| [Upstream check](https://github.com/SanHsien/public-apis/actions/runs/32555198427) | success | 無未審查上游 commit |
+| [Tests of push & pull](https://github.com/SanHsien/public-apis/actions/runs/32555198495) | skipped | 官方 repo guard |
+| [Tests of validate package](https://github.com/SanHsien/public-apis/actions/runs/32555198538) | skipped | 官方 repo guard |
 
 ## 開放 findings
 
@@ -77,6 +76,5 @@ fork 第一次 push 後補上 run URL。預期：
 
 ## 建議下一步（未動手）
 
-1. 第一次 push 後確認 GitHub Actions 的 CI 與 Upstream check 為綠，上游三個 workflow 為 skipped。
+1. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。
 2. 若要回貢：重複連結去重（R-02）比修贊助表格式（R-01）小。
-3. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,36 +1,39 @@
 # Repository review（Windows-first）
 
 - Review date: 2026-08-22
-- Review baseline: `2ca3aae7b56b5a8cc16c9b29106b4b37ca7d0f1c`
+- Review baseline: `98dd7bf1687a69ab596625f7b9223fd2bd0c013c`
 - Upstream reviewed through: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
 - Primary environment: Windows 11、PowerShell、Python 3.14.7（本機）、CI Windows / Ubuntu 3.12
 - Status: 維護骨架可用；API 目錄與 `scripts/validate/` 未改寫；官方仍是上游 `public-apis/public-apis`
+- Tracked files: 41（`git ls-files`）
 
 ## 結論
 
-這個 fork 適合作為 Windows 本機查詢、並追蹤上游目錄更新的維護線。產品是 `README.md` 裡 1000+ 筆免費 public API，行為跟隨上游。本線只加治理骨架：上游檢查、Windows gate、fork CI。
+這個 fork 適合作為 Windows 本機查詢、並追蹤上游目錄更新的維護線。產品是 `README.md` 裡 1000+ 筆免費 public API。本線只加治理骨架：上游檢查、Windows gate、fork CI。
 
-現階段的主要風險不是「fork 把目錄改壞」，而是：
+現階段的主要風險不是「fork 把目錄改壞」，而是上游 catalog validator 在官方 `master` 已經紅，以及本 fork 幾處測試／錯誤處理不夠硬。沒有 CRITICAL／HIGH。沒有秘密、沒有把目錄變成 gateway。
 
-1. 上游自己的 `format.py README.md` 與重複連結檢查，在 fork 當下的 `master` 已經失敗。
-2. 上游每日活連結 workflow 在 2026-08-22 也是 `failure`。
-3. `scripts/validate/format.py` 在 Python 3.14 會對非法跳脫發出 `SyntaxWarning`。
-
-不把 fork 當成第二個官方產品 repo。目錄、貢獻規則與驗證腳本的版權與行為仍屬上游。不翻譯 `README.md`。
+不把 fork 當成第二個官方產品 repo。不翻譯 `README.md`。
 
 ## 本輪實證
 
-### 本機
+### 本機（`98dd7bf`）
 
 ```text
 pwsh -NoProfile -File tools\dev_check.ps1
 → compileall / ruff E9+F（tests、tools）/ pytest / 上游 unittest / check_links 全綠
-→ 13 passed
+→ pytest 13 passed
 → 上游 validate package：31 tests OK
-→ check_links：12 份維護文件，0 斷連結
+→ check_links：12 份文件，0 斷連結（沒有掃到 scripts/README.md，見 R-06）
 
 python tools/check_upstream_updates.py
 → No new upstream commits.
+
+python -m bandit -q -r tools --severity-level high --confidence-level medium
+→ exit 0（High = 0）
+
+python -m bandit -q -r tools -ll
+→ exit 0（Medium+ = 0）
 ```
 
 抽查上游目錄檢查（**不列入本 fork 硬閘門**）：
@@ -40,41 +43,58 @@ python tools/check_upstream_updates.py
 | `python scripts/validate/format.py README.md` | 1 | APILayer 贊助表只有 3 欄、表格分隔列被當成 entry、多個分類未按字母排序 |
 | `python scripts/validate/links.py README.md --only_duplicate_links_checker` | 1 | 重複：`isitdownstatus.com`、`tastedive.com/read/api` |
 
-### GitHub Actions（`2ca3aae` push）
+`python -c "import check_links; ..."` 印出的文件清單沒有 `scripts/README.md`：`SKIP_NAMES` 用 `path.name`，任何叫 `README.md` 的檔都會被丟掉。
+
+### GitHub Actions
 
 | Workflow | 結果 | 說明 |
 |---|---|---|
-| [CI](https://github.com/SanHsien/public-apis/actions/runs/32555198499) | success | Ubuntu py3.12、Windows py3.12 `dev_check.ps1` |
-| [Upstream check](https://github.com/SanHsien/public-apis/actions/runs/32555198427) | success | 無未審查上游 commit |
-| [Tests of push & pull](https://github.com/SanHsien/public-apis/actions/runs/32555198495) | skipped | 官方 repo guard |
-| [Tests of validate package](https://github.com/SanHsien/public-apis/actions/runs/32555198538) | skipped | 官方 repo guard |
+| [CI @ 2ca3aae](https://github.com/SanHsien/public-apis/actions/runs/32555198499) | success | Ubuntu py3.12、Windows py3.12 `dev_check.ps1` |
+| [CI @ 98dd7bf](https://github.com/SanHsien/public-apis/actions/runs/32555325757) | success | docs 提交後再綠一次 |
+| [Upstream check @ 2ca3aae](https://github.com/SanHsien/public-apis/actions/runs/32555198427) | success | 無未審查上游 commit |
+| [Tests of push & pull](https://github.com/SanHsien/public-apis/actions/runs/32555325756) | skipped | `if: github.repository == 'public-apis/public-apis'` |
+| [Tests of validate package](https://github.com/SanHsien/public-apis/actions/runs/32555325742) | skipped | 同上 |
+
+`98dd7bf` 只改 `REVIEW.md`，沒觸發 `upstream-check.yml` 的 `paths:` 過濾，屬預期。
 
 ## 開放 findings
 
 | ID | 嚴重度 | Finding | 證據 | 建議 |
 |---|---|---|---|---|
-| R-01 | P2 | 上游 `format.py` 無法通過當前 `README.md`。贊助區塊與目錄契約不一致。 | 本機實測 exit 1；L043–L055 報 3 欄（需要 5 欄）；多個 ` :---: ` 分隔列被當 entry | 不在本 fork 修目錄。若要回貢，先對準贊助表要不要納入 format 契約。 |
+| R-01 | P2 | 上游 `format.py` 無法通過當前 `README.md`。贊助區塊與目錄契約不一致。 | 本機 exit 1；L043–L055 報 3 欄（需要 5 欄）；多個 ` :---: ` 分隔列被當 entry | 不在本 fork 修目錄。若要回貢，先對準贊助表要不要納入 format 契約。 |
 | R-02 | P2 | 目錄有重複連結，上游 `--only_duplicate_links_checker` 失敗。 | `https://isitdownstatus.com`、`https://tastedive.com/read/api` | 可回貢去重。本線不為了綠燈改 1000+ 筆清單。 |
-| R-03 | P3 | `format.py` 正則用非 raw 字串，Python 3.14 發 `SyntaxWarning`（`\s`、`\*`、`\[`）。 | compileall / 直接執行時印出 SyntaxWarning | 回貢改 raw string。現況仍能跑。 |
-| R-04 | P3 | 上游 workflow 仍用 `actions/checkout@v2`、`setup-python@v2`、Python 3.8。 | `.github/workflows/test_of_*.yml` | 本線不升級那些 pin，避免每次上游同步都衝突。fork CI 用 checkout v7 / Python 3.12。 |
-| R-05 | P3 | `scripts/requirements.txt` 鎖在 2021 的 requests 2.27.1 等。本機改用 `requests>=2.32`。 | `scripts/requirements.txt` vs `requirements-dev.txt` | 不幫上游升 pin。Dependabot 不開 pip。 |
+| R-03 | P3 | `format.py` 正則用非 raw 字串，Python 3.14 發 `SyntaxWarning`（`\s`、`\*`、`\[`）。 | 直接執行時印出 SyntaxWarning | 回貢改 raw string。現況仍能跑。 |
+| R-04 | P3 | 上游 workflow 仍用 `actions/checkout@v2`、`setup-python@v2`、Python 3.8。 | `.github/workflows/test_of_*.yml` L17–19 | 本線不升級那些 pin。fork 三檔已加 repo guard；fork CI 用 checkout SHA / Python 3.12。 |
+| R-05 | P3 | `scripts/requirements.txt` 鎖在 2021 的 requests 2.27.1 等。本機 `requirements-dev.txt` 用 `requests>=2.32`。 | 兩個 requirements 檔 | 不幫上游升 pin。`requests` **不是**死依賴：`scripts/tests/test_validate_links.py` 會 `import validate.links`，而 `links.py:8` 需要它。 |
+| R-06 | P3 | `check_links.py` 宣稱會掃 `scripts/README.md`，實際因 `SKIP_NAMES` 含 `"README.md"` 被檔名過濾掉。 | `iter_documents()` 實測 12 份，無 `scripts/README.md`；`check_links.py` L23–26、L36–42 | 改成比對相對路徑，只跳過根目錄 `README.md`。 |
+| R-07 | P3 | `collect_new_commits` 的 `split("\x1f", 2)` 與 `run_git` 的 `FileNotFoundError` 不是 `UpstreamCheckError`。異常時 `main()` 寫不出 report，CI `cat upstream-review-report.md` 會再失敗一次。 | `tools/check_upstream_updates.py` L36–47、L82 | 包成 `UpstreamCheckError`。日常 git 輸出正常時不會踩到。 |
+| R-08 | P3 | `check_links.py` 解析相對連結後沒確認仍在 repo 內，`../../...` 會對 repo 外路徑做 `.exists()`。 | `tools/check_links.py` L55–64 | `resolved.is_relative_to(ROOT)` 失敗就記問題。只洩漏存在性，不讀內容。 |
+| R-09 | P3 | workflow guard 測試是三個檔名白名單。上游若再加第四個 workflow，測試不會紅。 | `tests/test_docs.py` L60–68；`docs/DECISIONS.md` 已寫要人工重套 guard | 改成掃 `.github/workflows/*.yml`，排除 `ci.yml` 與 `upstream-check.yml`。 |
+| R-10 | P3 | CI 矩陣停在 3.12；本機是 3.14.7。3.14 本機 13 passed，Ubuntu job 沒跑 3.14。 | `.github/workflows/ci.yml`；`python --version` | 下次改 CI 時可加一格 3.14。非阻斷。 |
 
 ## 已檢查、不列為 finding
 
-- 本 fork `tools/check_upstream_updates.py` 以 argv 列表呼叫 `git`，無 `shell=True`。
-- `README.md` 未翻譯、無 `README.en.md`／`README.zh-Hant.md`。
+- 本 fork `tools/check_upstream_updates.py` 以 argv 列表呼叫 `git`，無 `shell=True`。Bandit High／Medium 對 `tools/` 為 0。
+- `README.md` 未翻譯，無 `README.en.md`／`README.zh-Hant.md`。
 - `origin` = `SanHsien/public-apis`，`upstream` = `public-apis/public-apis`，分支 `master`。
-- Baseline `reviewed_through` 等於 clone 時 HEAD `c045a2eb505f0f8b7992bb4af53cc020f25003fd`。
-- 無 `.env`、金鑰。venv 已被 `.gitignore` 排除。
+- Baseline `reviewed_through` 等於 clone 時上游 HEAD `c045a2eb505f0f8b7992bb4af53cc020f25003fd`。
+- 無 `.env`、金鑰、`.pem`。`git ls-files` 41 檔。venv 與 `upstream-review-report.md` 已被 `.gitignore` 排除。
+- `ci.yml` / `upstream-check.yml`：`permissions: contents: read`、`persist-credentials: false`、checkout／setup-python 釘 SHA。
+- `test_upstream_catalog_workflows_stay_on_official_repo` 已鎖現有三個上游 workflow 的 repo guard（F-03「完全沒測試」不成立）。
+- 日常 gate **不會**跑 `scripts/validate/links.py` 的 HTTP 探活；`validate_links.yml` 在本 fork skip。
+- `requirements-dev.txt` 的 `requests` 給上游 unittest 用，不是 check_links 用。
 
 ## 尚未宣稱範圍
 
 - **沒有**對 1000+ 個 API 做活連結或免費額度抽樣。
 - **沒有**宣稱上游 catalog validator 在當前 `master` 是綠的。反證是 R-01／R-02。
-- `dev_check.ps1` **不含** Bandit、CodeQL、完整 `links.py`。
+- `dev_check.ps1` **不含** Bandit、CodeQL、完整 `links.py`。Bandit 只在本輪本機抽查。
 - **不宣稱** fork 有自己的 GitHub Release 或獨立版號。
+- **沒有**修 R-06～R-10。這份文件是審查快照，不是修復紀錄。
 
 ## 建議下一步（未動手）
 
-1. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。
-2. 若要回貢：重複連結去重（R-02）比修贊助表格式（R-01）小。
+1. 若要動 fork 程式：先修 R-06（連結掃描漏檔）與 R-09（未來上游 workflow 沒 guard）。兩項都小、都有測試可鎖。
+2. R-07／R-08 可順手包進同一 PR。
+3. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。
+4. 回貢上游的話，重複連結去重（R-02）比修贊助表格式（R-01）小。

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,100 +1,63 @@
 # Repository review（Windows-first）
 
 - Review date: 2026-08-22
-- Review baseline: `98dd7bf1687a69ab596625f7b9223fd2bd0c013c`
+- Review baseline: 見本檔「已修」對應 commit；開放項維持不修
 - Upstream reviewed through: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
-- Primary environment: Windows 11、PowerShell、Python 3.14.7（本機）、CI Windows / Ubuntu 3.12
-- Status: 維護骨架可用；API 目錄與 `scripts/validate/` 未改寫；官方仍是上游 `public-apis/public-apis`
-- Tracked files: 41（`git ls-files`）
+- Primary environment: Windows 11、PowerShell、Python 3.14.7（本機）、CI Ubuntu 3.12／3.14、Windows 3.14
+- Status: 維護骨架可用；API 目錄與 `scripts/validate/` 未改寫；fork 可修的 R-06～R-10 已修
 
 ## 結論
 
-這個 fork 適合作為 Windows 本機查詢、並追蹤上游目錄更新的維護線。產品是 `README.md` 裡 1000+ 筆免費 public API。本線只加治理骨架：上游檢查、Windows gate、fork CI。
+這個 fork 適合作為 Windows 本機查詢、並追蹤上游目錄更新的維護線。產品是 `README.md` 裡 1000+ 筆免費 public API。
 
-現階段的主要風險不是「fork 把目錄改壞」，而是上游 catalog validator 在官方 `master` 已經紅，以及本 fork 幾處測試／錯誤處理不夠硬。沒有 CRITICAL／HIGH。沒有秘密、沒有把目錄變成 gateway。
+2026-08-22 審查列出的 R-01～R-10，**fork 能修的都修了**（R-06～R-10）。**沒有**改上游目錄、**沒有**改 `scripts/validate/`、**沒有**升級上游 workflow pin、**沒有**回貢。
 
-不把 fork 當成第二個官方產品 repo。不翻譯 `README.md`。
+## 已修 findings
+
+| ID | 嚴重度 | Finding | 修復 |
+|---|---|---|---|
+| R-06 | P3 | `check_links.py` 用檔名過濾，掃不到 `scripts/README.md` | `SKIP_RELATIVE` 比對相對路徑，只跳過根目錄 `README.md`；測試鎖 `scripts/README.md in rels` |
+| R-07 | P3 | `FileNotFoundError`／畸形 `git log` 行不是 `UpstreamCheckError`，CI 可能沒 report | `run_git` 包裝 `FileNotFoundError`；`collect_new_commits` 包裝 `ValueError` |
+| R-08 | P3 | 相對連結可對 repo 外路徑做 `.exists()` | `resolved.is_relative_to(ROOT)` 失敗就記「逃出 repo 根目錄」 |
+| R-09 | P3 | workflow guard 測試是三檔白名單 | 掃 `.github/workflows/*.yml`，排除 `ci.yml` 與 `upstream-check.yml` |
+| R-10 | P3 | CI 只跑 3.12 | Ubuntu 矩陣 3.12＋3.14；Windows job 改 3.14 |
+
+## 刻意不修
+
+| ID | 嚴重度 | Finding | 理由 |
+|---|---|---|---|
+| R-01 | P2 | 上游 `format.py` 無法通過當前 `README.md` | 目錄／贊助表是上游產品。本線不代修 1000+ 筆清單。 |
+| R-02 | P2 | 重複連結：`isitdownstatus.com`、`tastedive.com/read/api` | 同上，屬目錄內容。不回貢。 |
+| R-03 | P3 | `format.py` 非法跳脫 `SyntaxWarning` | 在上游 `scripts/validate/format.py`。改了會跟上游衝突。現況仍能跑。 |
+| R-04 | P3 | 上游 workflow 用 `checkout@v2`／Python 3.8 | 不升級那些 pin。本 fork 靠 repo guard 讓它們 skip。 |
+| R-05 | P3 | `scripts/requirements.txt` 鎖 2021 pin | 那是上游 Ubuntu 3.8 CI 契約。本線 `requirements-dev.txt` 另裝現代 requests。 |
 
 ## 本輪實證
 
-### 本機（`98dd7bf`）
+### 本機（修完後）
 
 ```text
 pwsh -NoProfile -File tools\dev_check.ps1
-→ compileall / ruff E9+F（tests、tools）/ pytest / 上游 unittest / check_links 全綠
-→ pytest 13 passed
+→ compileall / ruff E9+F / pytest / 上游 unittest / check_links 全綠
+→ 17 passed
 → 上游 validate package：31 tests OK
-→ check_links：12 份文件，0 斷連結（沒有掃到 scripts/README.md，見 R-06）
-
-python tools/check_upstream_updates.py
-→ No new upstream commits.
-
-python -m bandit -q -r tools --severity-level high --confidence-level medium
-→ exit 0（High = 0）
-
-python -m bandit -q -r tools -ll
-→ exit 0（Medium+ = 0）
+→ check_links：13 份文件（含 scripts/README.md），0 斷連結
 ```
-
-抽查上游目錄檢查（**不列入本 fork 硬閘門**）：
-
-| 指令 | exit | 觀察 |
-|---|---|---|
-| `python scripts/validate/format.py README.md` | 1 | APILayer 贊助表只有 3 欄、表格分隔列被當成 entry、多個分類未按字母排序 |
-| `python scripts/validate/links.py README.md --only_duplicate_links_checker` | 1 | 重複：`isitdownstatus.com`、`tastedive.com/read/api` |
-
-`python -c "import check_links; ..."` 印出的文件清單沒有 `scripts/README.md`：`SKIP_NAMES` 用 `path.name`，任何叫 `README.md` 的檔都會被丟掉。
 
 ### GitHub Actions
 
-| Workflow | 結果 | 說明 |
-|---|---|---|
-| [CI @ 2ca3aae](https://github.com/SanHsien/public-apis/actions/runs/32555198499) | success | Ubuntu py3.12、Windows py3.12 `dev_check.ps1` |
-| [CI @ 98dd7bf](https://github.com/SanHsien/public-apis/actions/runs/32555325757) | success | docs 提交後再綠一次 |
-| [Upstream check @ 2ca3aae](https://github.com/SanHsien/public-apis/actions/runs/32555198427) | success | 無未審查上游 commit |
-| [Tests of push & pull](https://github.com/SanHsien/public-apis/actions/runs/32555325756) | skipped | `if: github.repository == 'public-apis/public-apis'` |
-| [Tests of validate package](https://github.com/SanHsien/public-apis/actions/runs/32555325742) | skipped | 同上 |
-
-`98dd7bf` 只改 `REVIEW.md`，沒觸發 `upstream-check.yml` 的 `paths:` 過濾，屬預期。
-
-## 開放 findings
-
-| ID | 嚴重度 | Finding | 證據 | 建議 |
-|---|---|---|---|---|
-| R-01 | P2 | 上游 `format.py` 無法通過當前 `README.md`。贊助區塊與目錄契約不一致。 | 本機 exit 1；L043–L055 報 3 欄（需要 5 欄）；多個 ` :---: ` 分隔列被當 entry | 不在本 fork 修目錄。若要回貢，先對準贊助表要不要納入 format 契約。 |
-| R-02 | P2 | 目錄有重複連結，上游 `--only_duplicate_links_checker` 失敗。 | `https://isitdownstatus.com`、`https://tastedive.com/read/api` | 可回貢去重。本線不為了綠燈改 1000+ 筆清單。 |
-| R-03 | P3 | `format.py` 正則用非 raw 字串，Python 3.14 發 `SyntaxWarning`（`\s`、`\*`、`\[`）。 | 直接執行時印出 SyntaxWarning | 回貢改 raw string。現況仍能跑。 |
-| R-04 | P3 | 上游 workflow 仍用 `actions/checkout@v2`、`setup-python@v2`、Python 3.8。 | `.github/workflows/test_of_*.yml` L17–19 | 本線不升級那些 pin。fork 三檔已加 repo guard；fork CI 用 checkout SHA / Python 3.12。 |
-| R-05 | P3 | `scripts/requirements.txt` 鎖在 2021 的 requests 2.27.1 等。本機 `requirements-dev.txt` 用 `requests>=2.32`。 | 兩個 requirements 檔 | 不幫上游升 pin。`requests` **不是**死依賴：`scripts/tests/test_validate_links.py` 會 `import validate.links`，而 `links.py:8` 需要它。 |
-| R-06 | P3 | `check_links.py` 宣稱會掃 `scripts/README.md`，實際因 `SKIP_NAMES` 含 `"README.md"` 被檔名過濾掉。 | `iter_documents()` 實測 12 份，無 `scripts/README.md`；`check_links.py` L23–26、L36–42 | 改成比對相對路徑，只跳過根目錄 `README.md`。 |
-| R-07 | P3 | `collect_new_commits` 的 `split("\x1f", 2)` 與 `run_git` 的 `FileNotFoundError` 不是 `UpstreamCheckError`。異常時 `main()` 寫不出 report，CI `cat upstream-review-report.md` 會再失敗一次。 | `tools/check_upstream_updates.py` L36–47、L82 | 包成 `UpstreamCheckError`。日常 git 輸出正常時不會踩到。 |
-| R-08 | P3 | `check_links.py` 解析相對連結後沒確認仍在 repo 內，`../../...` 會對 repo 外路徑做 `.exists()`。 | `tools/check_links.py` L55–64 | `resolved.is_relative_to(ROOT)` 失敗就記問題。只洩漏存在性，不讀內容。 |
-| R-09 | P3 | workflow guard 測試是三個檔名白名單。上游若再加第四個 workflow，測試不會紅。 | `tests/test_docs.py` L60–68；`docs/DECISIONS.md` 已寫要人工重套 guard | 改成掃 `.github/workflows/*.yml`，排除 `ci.yml` 與 `upstream-check.yml`。 |
-| R-10 | P3 | CI 矩陣停在 3.12；本機是 3.14.7。3.14 本機 13 passed，Ubuntu job 沒跑 3.14。 | `.github/workflows/ci.yml`；`python --version` | 下次改 CI 時可加一格 3.14。非阻斷。 |
+修補分支 push 後補 run URL。預期：Ubuntu 3.12／3.14 與 Windows 3.14 全綠；上游三個 catalog workflow skipped。
 
 ## 已檢查、不列為 finding
 
-- 本 fork `tools/check_upstream_updates.py` 以 argv 列表呼叫 `git`，無 `shell=True`。Bandit High／Medium 對 `tools/` 為 0。
-- `README.md` 未翻譯，無 `README.en.md`／`README.zh-Hant.md`。
-- `origin` = `SanHsien/public-apis`，`upstream` = `public-apis/public-apis`，分支 `master`。
-- Baseline `reviewed_through` 等於 clone 時上游 HEAD `c045a2eb505f0f8b7992bb4af53cc020f25003fd`。
-- 無 `.env`、金鑰、`.pem`。`git ls-files` 41 檔。venv 與 `upstream-review-report.md` 已被 `.gitignore` 排除。
-- `ci.yml` / `upstream-check.yml`：`permissions: contents: read`、`persist-credentials: false`、checkout／setup-python 釘 SHA。
-- `test_upstream_catalog_workflows_stay_on_official_repo` 已鎖現有三個上游 workflow 的 repo guard（F-03「完全沒測試」不成立）。
-- 日常 gate **不會**跑 `scripts/validate/links.py` 的 HTTP 探活；`validate_links.yml` 在本 fork skip。
-- `requirements-dev.txt` 的 `requests` 給上游 unittest 用，不是 check_links 用。
+- `tools/check_upstream_updates.py` 仍以 argv 列表呼叫 `git`，無 `shell=True`。
+- `README.md` 未翻譯。`origin`／`upstream` remote 正確。
+- 日常 gate 仍不跑 `format.py README.md` 與 `links.py` HTTP 探活。
+- `requests` 仍給上游 unittest 用，不是死依賴。
 
 ## 尚未宣稱範圍
 
-- **沒有**對 1000+ 個 API 做活連結或免費額度抽樣。
-- **沒有**宣稱上游 catalog validator 在當前 `master` 是綠的。反證是 R-01／R-02。
-- `dev_check.ps1` **不含** Bandit、CodeQL、完整 `links.py`。Bandit 只在本輪本機抽查。
-- **不宣稱** fork 有自己的 GitHub Release 或獨立版號。
-- **沒有**修 R-06～R-10。這份文件是審查快照，不是修復紀錄。
-
-## 建議下一步（未動手）
-
-1. 若要動 fork 程式：先修 R-06（連結掃描漏檔）與 R-09（未來上游 workflow 沒 guard）。兩項都小、都有測試可鎖。
-2. R-07／R-08 可順手包進同一 PR。
-3. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。
-4. 回貢上游的話，重複連結去重（R-02）比修贊助表格式（R-01）小。
+- **沒有**對 1000+ 個 API 做活連結抽樣。
+- **沒有**宣稱上游 catalog validator 是綠的。
+- `dev_check.ps1` **不含** Bandit、CodeQL。
+- **不宣稱** fork 有自己的 GitHub Release。

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,82 @@
+# Repository review（Windows-first）
+
+- Review date: 2026-08-22
+- Review baseline: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
+- Upstream reviewed through: `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
+- Primary environment: Windows 11、PowerShell、Python 3.14.7（本機）、CI Windows / Ubuntu 3.12
+- Status: 維護骨架可用；API 目錄與 `scripts/validate/` 未改寫；官方仍是上游 `public-apis/public-apis`
+
+## 結論
+
+這個 fork 適合作為 Windows 本機查詢、並追蹤上游目錄更新的維護線。產品是 `README.md` 裡 1000+ 筆免費 public API，行為跟隨上游。本線只加治理骨架：上游檢查、Windows gate、fork CI。
+
+現階段的主要風險不是「fork 把目錄改壞」，而是：
+
+1. 上游自己的 `format.py README.md` 與重複連結檢查，在 fork 當下的 `master` 已經失敗。
+2. 上游每日活連結 workflow 在 2026-08-22 也是 `failure`。
+3. `scripts/validate/format.py` 在 Python 3.14 會對非法跳脫發出 `SyntaxWarning`。
+
+不把 fork 當成第二個官方產品 repo。目錄、貢獻規則與驗證腳本的版權與行為仍屬上游。不翻譯 `README.md`。
+
+## 本輪實證
+
+### 本機
+
+```text
+pwsh -NoProfile -File tools\dev_check.ps1
+→ compileall / ruff E9+F（tests、tools）/ pytest / 上游 unittest / check_links 全綠
+→ 13 passed
+→ 上游 validate package：31 tests OK
+→ check_links：12 份維護文件，0 斷連結
+
+python tools/check_upstream_updates.py
+→ No new upstream commits.
+```
+
+抽查上游目錄檢查（**不列入本 fork 硬閘門**）：
+
+| 指令 | exit | 觀察 |
+|---|---|---|
+| `python scripts/validate/format.py README.md` | 1 | APILayer 贊助表只有 3 欄、表格分隔列被當成 entry、多個分類未按字母排序 |
+| `python scripts/validate/links.py README.md --only_duplicate_links_checker` | 1 | 重複：`isitdownstatus.com`、`tastedive.com/read/api` |
+
+### GitHub Actions
+
+fork 第一次 push 後補上 run URL。預期：
+
+| Workflow | 預期 | 說明 |
+|---|---|---|
+| CI | success | Ubuntu py3.12 + Windows `dev_check.ps1` |
+| Upstream check | success | 無未審查上游 commit |
+| 上游三個 catalog workflow | skipped | `if: github.repository == 'public-apis/public-apis'` |
+
+## 開放 findings
+
+| ID | 嚴重度 | Finding | 證據 | 建議 |
+|---|---|---|---|---|
+| R-01 | P2 | 上游 `format.py` 無法通過當前 `README.md`。贊助區塊與目錄契約不一致。 | 本機實測 exit 1；L043–L055 報 3 欄（需要 5 欄）；多個 ` :---: ` 分隔列被當 entry | 不在本 fork 修目錄。若要回貢，先對準贊助表要不要納入 format 契約。 |
+| R-02 | P2 | 目錄有重複連結，上游 `--only_duplicate_links_checker` 失敗。 | `https://isitdownstatus.com`、`https://tastedive.com/read/api` | 可回貢去重。本線不為了綠燈改 1000+ 筆清單。 |
+| R-03 | P3 | `format.py` 正則用非 raw 字串，Python 3.14 發 `SyntaxWarning`（`\s`、`\*`、`\[`）。 | compileall / 直接執行時印出 SyntaxWarning | 回貢改 raw string。現況仍能跑。 |
+| R-04 | P3 | 上游 workflow 仍用 `actions/checkout@v2`、`setup-python@v2`、Python 3.8。 | `.github/workflows/test_of_*.yml` | 本線不升級那些 pin，避免每次上游同步都衝突。fork CI 用 checkout v7 / Python 3.12。 |
+| R-05 | P3 | `scripts/requirements.txt` 鎖在 2021 的 requests 2.27.1 等。本機改用 `requests>=2.32`。 | `scripts/requirements.txt` vs `requirements-dev.txt` | 不幫上游升 pin。Dependabot 不開 pip。 |
+
+## 已檢查、不列為 finding
+
+- 本 fork `tools/check_upstream_updates.py` 以 argv 列表呼叫 `git`，無 `shell=True`。
+- `README.md` 未翻譯、無 `README.en.md`／`README.zh-Hant.md`。
+- `origin` = `SanHsien/public-apis`，`upstream` = `public-apis/public-apis`，分支 `master`。
+- Baseline `reviewed_through` 等於 clone 時 HEAD `c045a2eb505f0f8b7992bb4af53cc020f25003fd`。
+- 無 `.env`、金鑰。venv 已被 `.gitignore` 排除。
+
+## 尚未宣稱範圍
+
+- **沒有**對 1000+ 個 API 做活連結或免費額度抽樣。
+- **沒有**宣稱上游 catalog validator 在當前 `master` 是綠的。反證是 R-01／R-02。
+- `dev_check.ps1` **不含** Bandit、CodeQL、完整 `links.py`。
+- **不宣稱** fork 有自己的 GitHub Release 或獨立版號。
+
+## 建議下一步（未動手）
+
+1. 第一次 push 後確認 GitHub Actions 的 CI 與 Upstream check 為綠，上游三個 workflow 為 skipped。
+2. 若要回貢：重複連結去重（R-02）比修贊助表格式（R-01）小。
+3. 每週一 03:00 UTC 的 `upstream-check.yml` 失敗時，依 [`docs/UPSTREAM.md`](docs/UPSTREAM.md) 審查後再推進 baseline。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# 安全政策
+
+## 支援範圍
+
+安全修正以本 fork 的最新 `master` 為主；上游版本的問題也會視需要回報原作者。
+
+## 私下回報
+
+請使用 GitHub Security Advisories 的 **Report a vulnerability** 私下回報。若該入口不可用，
+請透過 GitHub 個人檔案聯絡維護者，不要先建立公開 Issue。
+
+回報請包含影響範圍、重現步驟、受影響版本與最小必要證據。請勿附上真實 API key、cookie 或帳號。
+
+## 特別注意
+
+- 本專案是 API **目錄**，不是那些 API 的營運方。清單裡某一服務的漏洞，請向該服務回報。
+- `scripts/validate/links.py` 會對 README 裡的公開 URL 發 HTTP 請求。不要改成帶認證、不要掃私人網段。
+- 第三方 API 的資料處理政策不由本 repo 控制；呼叫前需另行審查其條款與免費額度。

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,23 @@
+# 維護決策
+
+## 2026-08-22：建立 Windows-first 維護型 fork
+
+**決定**：fork `public-apis/public-apis`，保留 MIT 授權與完整歷史，預設分支維持 `master` 以降低與上游同步摩擦。本線聚焦 Windows 開發 gate、fork CI，以及逐筆審查的上游追蹤。目錄本體不翻譯。
+
+**理由**：這份清單是查 API 的單一入口，上游仍在更新（fork 當下 HEAD 為 2026-08-20 的 `#6962`）。缺的是 Windows 11 上可重現的驗證骨架，以及「上游有沒有新 commit」的明確失敗訊號。直接盯上游網頁無法留下審查紀錄。
+
+**限制**：
+
+- 不把 fork 包裝成原創專案，不移除原作者與 MIT 標示。
+- `README.md` 保持上游英文目錄，不建繁中／英文雙檔。
+- `CONTRIBUTING.md` 與 `scripts/validate/` 以上游為準。
+- 上游更新必須逐筆審查。
+- 不啟用對 `scripts/requirements.txt` 的 Dependabot：那些 2021 pin 是上游 Ubuntu 3.8 CI 契約，本線不代為升級。
+
+## 2026-08-22：日常 gate 不拿上游目錄檢查當硬閘門
+
+**決定**：`tools/dev_check.ps1` 與 fork CI 不跑 `scripts/validate/format.py README.md`，也不跑 `links.py` 的重複連結／活連結掃描。改跑上游 `scripts/tests` unittest，以及本 fork 的 pytest／連結檢查。
+
+**理由**：fork 當下對上游 `master` 實測，`format.py README.md` 因 APILayer 贊助表（3 欄而非 5 欄）、表格分隔列被當成 entry、多個分類未按字母排序而失敗；`--only_duplicate_links_checker` 至少打出 `isitdownstatus.com` 與 `tastedive.com/read/api` 兩組重複。上游自己的 `Validate links` workflow 在 2026-08-22 也是 `failure`。本線不代為修 1000+ 筆目錄來換綠燈。
+
+完整活連結掃描留給上游官方 repo 的 `validate_links.yml`。本 fork 把那三個上游 workflow 加上 `if: github.repository == 'public-apis/public-apis'`，避免 fork 上每日紅燈。合併上游 workflow 變更時要重套這條 guard。

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -20,4 +20,11 @@
 
 **理由**：fork 當下對上游 `master` 實測，`format.py README.md` 因 APILayer 贊助表（3 欄而非 5 欄）、表格分隔列被當成 entry、多個分類未按字母排序而失敗；`--only_duplicate_links_checker` 至少打出 `isitdownstatus.com` 與 `tastedive.com/read/api` 兩組重複。上游自己的 `Validate links` workflow 在 2026-08-22 也是 `failure`。本線不代為修 1000+ 筆目錄來換綠燈。
 
-完整活連結掃描留給上游官方 repo 的 `validate_links.yml`。本 fork 把那三個上游 workflow 加上 `if: github.repository == 'public-apis/public-apis'`，避免 fork 上每日紅燈。合併上游 workflow 變更時要重套這條 guard。
+完整活連結掃描留給上游官方 repo 的 `validate_links.yml`。本 fork 把那三個上游 workflow 加上 `if: github.repository == 'public-apis/public-apis'`，避免 fork 上每日紅燈。合併上游 workflow 變更時，`tests/test_docs.py` 會對非 fork 自有的 `*.yml` 檢查這條 guard。
+
+## 2026-08-22：修 fork 審查項，不改上游產品
+
+**決定**：R-06～R-10（連結掃描、upstream checker 例外包裝、路徑邊界、workflow 測試、CI 3.14）在本線修。R-01～R-05（目錄格式、重複連結、`format.py` 跳脫、上游 Action pin、`scripts/requirements.txt`）不修、不回貢。
+
+**理由**：那些不是本 fork 維護骨架的缺陷，改了會跟上游目錄或 3.8 CI 契約打架。
+

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,7 +46,7 @@ pwsh -NoProfile -File tools\dev_check.ps1
 
 不把 `format.py README.md` 或完整／重複連結掃描當本 fork 硬閘門：上游 `master` 當下自己就過不了。細節見 [`DECISIONS.md`](DECISIONS.md)。
 
-PR CI 在 Ubuntu 與 Windows 各跑一套對應步驟。上游原有 workflows 加上 `github.repository == 'public-apis/public-apis'`，避免在本 fork 每天紅燈。
+PR CI 在 Ubuntu 跑 3.12 與 3.14，Windows 跑 3.14。上游原有 workflows 加上 `github.repository == 'public-apis/public-apis'`，避免在本 fork 每天紅燈。
 
 ## 不要做的事
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,57 @@
+# 開發環境
+
+維護者與 AI 接手用的開發文件。查 API 請看 [`README.md`](../README.md)；上游同步在 [`UPSTREAM.md`](UPSTREAM.md)；決策在 [`DECISIONS.md`](DECISIONS.md)。
+
+## 架構
+
+```text
+README.md（人工整理的 public API 目錄）
+        │
+        ├─ scripts/validate/format.py     欄位、排序、描述長度
+        ├─ scripts/validate/links.py      重複連結（日常）／活連結（上游排程）
+        └─ scripts/tests/                 上游 unittest
+```
+
+根目錄其餘檔案（`FORK.md`、`tools/`、`docs/`、`tests/`）是本 fork 的開發與治理骨架。
+
+## 本機開發（Windows）
+
+```powershell
+python -m venv .venv
+.venv\Scripts\python -m pip install --upgrade pip
+.venv\Scripts\python -m pip install -r requirements-dev.txt
+$env:PYTHONUTF8 = "1"
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+只查某一類 API 時，打開 `README.md` 對應章節即可，不必建 venv。
+
+手動重跑單項：
+
+```powershell
+.venv\Scripts\python scripts\validate\format.py README.md
+.venv\Scripts\python scripts\validate\links.py README.md --only_duplicate_links_checker
+.venv\Scripts\python tools\check_upstream_updates.py
+```
+
+## Canonical gate
+
+`tools\dev_check.ps1` 會依序：
+
+1. `python -m compileall`（`scripts`、`tests`、`tools`）
+2. `ruff check`（E9 + F，只掃 `tests`、`tools`；不改上游 `scripts/` 的寫法）
+3. `pytest tests/ -q`
+4. `python -m unittest discover tests`（在 `scripts/` 目錄）
+5. `python tools/check_links.py`
+
+不把 `format.py README.md` 或完整／重複連結掃描當本 fork 硬閘門：上游 `master` 當下自己就過不了。細節見 [`DECISIONS.md`](DECISIONS.md)。
+
+PR CI 在 Ubuntu 與 Windows 各跑一套對應步驟。上游原有 workflows 加上 `github.repository == 'public-apis/public-apis'`，避免在本 fork 每天紅燈。
+
+## 不要做的事
+
+- 不要翻譯 `README.md`。
+- 不要為了 fork 文件去改上游 `CONTRIBUTING.md`。
+- 不要在日常 gate 裡做完整活連結掃描。
+- 不要提交 API key 或把本目錄當成自己的 API 產品。
+- 測試不要去打真實第三方 API；fork 測試只鎖維護骨架。

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -1,0 +1,38 @@
+# 上游維護
+
+## Remote
+
+- Fork：`origin` → `https://github.com/SanHsien/public-apis.git`
+- 原作者：`upstream` → `https://github.com/public-apis/public-apis.git`
+- 追蹤分支：`master`
+
+## 檢查新提交
+
+```powershell
+git fetch upstream master
+python tools\check_upstream_updates.py --strict
+```
+
+工具以 `tools/upstream_baseline.json` 的 `reviewed_through` 為起點，列出所有未審查提交。
+有新提交或檢查失敗時，`--strict` 回傳非零；排程 workflow 也會因此明確失敗。
+
+## 審查清冊
+
+每次只做一次批次審查：
+
+1. 讀 commit 主旨與變更檔案。
+2. 判斷是否與 Windows gate、fork 文件或測試衝突。
+3. 可直接同步的提交用 merge；只需要部分修正時 cherry-pick 或最小重做。
+4. 跑 `pwsh -NoProfile -File tools\dev_check.ps1`。
+5. 在 `docs/DECISIONS.md` 記錄採用／略過理由。
+6. 驗證完成後才把 baseline 推進到已審查的完整 40 字元 SHA。
+
+Baseline 代表「已審查」，不代表「全部已合併」。
+
+`README.md` 新條目直接同步，不必翻譯。若上游改了 `scripts/validate/` 或 GitHub Actions，才需要核對本 fork 的 Windows gate 是否仍能跑。
+
+## 2026-08-22：fork 起點
+
+本 fork 自上游 `master` `c045a2eb505f0f8b7992bb4af53cc020f25003fd`
+（`Merge pull request #6962 from ddevetak/add-football-charts`）建立。此 SHA 設為第一個 `reviewed_through`。
+之後的上游 commit 才需要進入審查清冊。

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# 本 fork 的開發閘門。
+# pytest 9 需要 Python >= 3.10；閘門以 3.12 為準。
+pytest>=8.3.0
+ruff>=0.16
+# links.py 需要 requests。不引用 scripts/requirements.txt 的 2021 pin，
+# 那是上游 Ubuntu 3.8 CI 用的；本線不幫上游升級那些 pin。
+requests>=2.32.0

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -51,21 +51,37 @@ def test_gitignore_covers_generated_reports() -> None:
 
 
 def test_check_links_skips_the_api_catalog() -> None:
-    names = {path.name for path in check_links.iter_documents()}
-    assert "README.md" not in names
-    assert "FORK.md" in names
-    assert "UPSTREAM.md" in names
+    rels = {path.relative_to(ROOT).as_posix() for path in check_links.iter_documents()}
+    assert "README.md" not in rels
+    assert "scripts/README.md" in rels
+    assert "FORK.md" in rels
+    assert "docs/UPSTREAM.md" in rels
 
 
-def test_upstream_catalog_workflows_stay_on_official_repo() -> None:
+def test_check_links_rejects_path_outside_repo(tmp_path: Path) -> None:
+    doc = tmp_path / "note.md"
+    doc.write_text("[here](.)\n", encoding="utf-8")
+    problems = check_links.check_document(doc)
+    assert any("逃出" in item for item in problems)
+
+
+def test_non_fork_workflows_have_repo_guard() -> None:
+    fork_owned = {"ci.yml", "upstream-check.yml"}
     workflows = ROOT / ".github" / "workflows"
-    for name in (
-        "test_of_push_and_pull.yml",
-        "test_of_validate_package.yml",
-        "validate_links.yml",
-    ):
-        text = (workflows / name).read_text(encoding="utf-8")
-        assert "github.repository == 'public-apis/public-apis'" in text
+    scanned = 0
+    for path in sorted(workflows.glob("*.yml")):
+        if path.name in fork_owned:
+            continue
+        scanned += 1
+        text = path.read_text(encoding="utf-8")
+        assert "github.repository == 'public-apis/public-apis'" in text, path.name
+    assert scanned >= 3
+
+
+def test_ci_covers_python_314() -> None:
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "3.14" in ci
+    assert "windows" in ci.lower()
 
 
 def test_fork_ci_does_not_gate_the_catalog_format() -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import check_links  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_maintainer_files_exist() -> None:
+    required = [
+        ROOT / "FORK.md",
+        ROOT / "NOTICE.md",
+        ROOT / "AGENTS.md",
+        ROOT / "CLAUDE.md",
+        ROOT / "SECURITY.md",
+        ROOT / "REVIEW.md",
+        ROOT / "docs" / "UPSTREAM.md",
+        ROOT / "docs" / "DECISIONS.md",
+        ROOT / "docs" / "DEVELOPMENT.md",
+        ROOT / "tools" / "dev_check.ps1",
+        ROOT / "tools" / "check_upstream_updates.py",
+        ROOT / "requirements-dev.txt",
+        ROOT / "README.md",
+        ROOT / "LICENSE",
+        ROOT / "CONTRIBUTING.md",
+    ]
+    missing = [str(path.relative_to(ROOT)) for path in required if not path.is_file()]
+    assert missing == []
+
+
+def test_readme_stays_the_upstream_catalog() -> None:
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    fork = (ROOT / "FORK.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "不要翻譯或改寫 `README.md`" in agents
+    assert "不翻譯、不改寫" in fork
+    assert "A collective list of free APIs" in readme or "public APIs" in readme
+    assert not (ROOT / "README.en.md").exists()
+    assert not (ROOT / "README.zh-Hant.md").exists()
+
+
+def test_gitignore_covers_generated_reports() -> None:
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
+    assert "upstream-review-report.md" in gitignore
+    assert ".venv" in gitignore
+
+
+def test_check_links_skips_the_api_catalog() -> None:
+    names = {path.name for path in check_links.iter_documents()}
+    assert "README.md" not in names
+    assert "FORK.md" in names
+    assert "UPSTREAM.md" in names
+
+
+def test_upstream_catalog_workflows_stay_on_official_repo() -> None:
+    workflows = ROOT / ".github" / "workflows"
+    for name in (
+        "test_of_push_and_pull.yml",
+        "test_of_validate_package.yml",
+        "validate_links.yml",
+    ):
+        text = (workflows / name).read_text(encoding="utf-8")
+        assert "github.repository == 'public-apis/public-apis'" in text
+
+
+def test_fork_ci_does_not_gate_the_catalog_format() -> None:
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    gate = (ROOT / "tools" / "dev_check.ps1").read_text(encoding="utf-8")
+
+    assert "format.py README.md" not in ci
+    assert "format.py" not in gate
+    assert "only_duplicate_links" not in ci
+    assert "only_duplicate_links" not in gate
+
+
+def test_maintainer_markdown_links_resolve() -> None:
+    failures = 0
+    for path in check_links.iter_documents():
+        problems = check_links.check_document(path)
+        failures += len(problems)
+        for problem in problems:
+            print(f"{path}: {problem}")
+    assert failures == 0

--- a/tests/test_upstream_check.py
+++ b/tests/test_upstream_check.py
@@ -65,6 +65,34 @@ def test_load_baseline_rejects_missing_file(tmp_path: Path) -> None:
         checker.load_baseline(tmp_path / "nope.json")
 
 
+def test_run_git_wraps_missing_executable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(checker.subprocess, "run", boom)
+    with pytest.raises(checker.UpstreamCheckError, match="git not found"):
+        checker.run_git(["status"], tmp_path)
+
+
+def test_collect_new_commits_wraps_malformed_log(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run_git(args: list[str], _repo_dir: Path) -> str:
+        if args and args[0] == "log":
+            return "not-a-valid-record\n"
+        return ""
+
+    monkeypatch.setattr(checker, "run_git", fake_run_git)
+    baseline = {
+        "repo": "https://example.invalid/upstream.git",
+        "branch": "master",
+        "reviewed_through": "a" * 40,
+        "reviewed_date": "2026-08-22",
+    }
+    with pytest.raises(checker.UpstreamCheckError, match="unexpected git log line"):
+        checker.collect_new_commits(baseline, tmp_path, "refs/upstream-check/master")
+
+
 def test_baseline_matches_decisions_record() -> None:
     decisions = (
         Path(__file__).parents[1] / "docs" / "DECISIONS.md"

--- a/tests/test_upstream_check.py
+++ b/tests/test_upstream_check.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import check_upstream_updates as checker  # noqa: E402
+
+
+def test_baseline_file_is_valid_and_complete() -> None:
+    baseline = checker.load_baseline()
+
+    assert baseline["repo"].endswith("public-apis.git")
+    assert baseline["branch"] == "master"
+    assert len(baseline["reviewed_through"]) == 40
+    assert baseline["reviewed_date"]
+
+
+def test_workflow_is_scheduled_and_fails_on_unreviewed_commits() -> None:
+    workflow = (
+        Path(__file__).parents[1] / ".github" / "workflows" / "upstream-check.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "schedule:" in workflow
+    assert "cron:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "tools/check_upstream_updates.py" in workflow
+    assert "fetch-depth: 0" in workflow
+    assert "exit 1" in workflow
+
+
+def test_render_markdown_reports_no_new_commits() -> None:
+    baseline = {
+        "repo": "https://example.invalid/upstream.git",
+        "branch": "master",
+        "reviewed_through": "a" * 40,
+        "reviewed_date": "2026-08-22",
+    }
+
+    report = checker.render_markdown(baseline, [])
+
+    assert "No new upstream commits" in report
+
+
+def test_render_markdown_surfaces_check_failure() -> None:
+    baseline = {
+        "repo": "https://example.invalid/upstream.git",
+        "branch": "master",
+        "reviewed_through": "a" * 40,
+        "reviewed_date": "2026-08-22",
+    }
+
+    report = checker.render_markdown(baseline, [], error="git fetch failed")
+
+    assert "Check failed" in report
+    assert "git fetch failed" in report
+
+
+def test_load_baseline_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(checker.UpstreamCheckError):
+        checker.load_baseline(tmp_path / "nope.json")
+
+
+def test_baseline_matches_decisions_record() -> None:
+    decisions = (
+        Path(__file__).parents[1] / "docs" / "DECISIONS.md"
+    ).read_text(encoding="utf-8")
+    baseline = json.loads(
+        (Path(__file__).parents[1] / "tools" / "upstream_baseline.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert baseline["reviewed_date"] in decisions
+    assert baseline["reviewed_through"][:7] in (
+        Path(__file__).parents[1] / "docs" / "UPSTREAM.md"
+    ).read_text(encoding="utf-8")

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""檢查維護文件之間的相對連結指得到東西。
+
+本 fork 的公開入口互相連來連去：FORK、NOTICE、AGENTS 與 docs。
+文件被重新定位或改名時，這些連結會靜靜斷掉。只驗相對連結；外部網址交給人看。
+不掃上游 `README.md`：那是 1000+ API 目錄，連結健康由上游的 format / links 腳本負責。
+
+    python tools/check_links.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+ROOT = Path(__file__).resolve().parent.parent
+LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#")
+
+
+SKIP_NAMES = {
+    "README.md",
+    "upstream-review-report.md",
+}
+
+
+def iter_documents() -> list[Path]:
+    documents = []
+    documents.extend(ROOT.glob("*.md"))
+    documents.extend((ROOT / "docs").glob("*.md"))
+    github = ROOT / ".github"
+    if github.is_dir():
+        documents.extend(github.rglob("*.md"))
+    scripts_readme = ROOT / "scripts" / "README.md"
+    if scripts_readme.is_file():
+        documents.append(scripts_readme)
+    return sorted(
+        path
+        for path in documents
+        if path.is_file() and path.name not in SKIP_NAMES
+    )
+
+
+def check_document(path: Path) -> list[str]:
+    problems: list[str] = []
+    for match in LINK_PATTERN.finditer(path.read_text(encoding="utf-8")):
+        target = match.group(1).strip().strip("<>")
+        if not target or target.startswith(SKIP_PREFIXES):
+            continue
+        file_part = unquote(target.split("#", 1)[0])
+        if not file_part:
+            continue
+        if file_part.startswith("/"):
+            resolved = (ROOT / file_part.lstrip("/")).resolve()
+        else:
+            resolved = (path.parent / file_part).resolve()
+        if not resolved.exists():
+            try:
+                shown = resolved.relative_to(ROOT)
+            except ValueError:
+                shown = resolved
+            problems.append(f"{target} → 找不到 {shown}")
+    return problems
+
+
+def main() -> int:
+    documents = iter_documents()
+    if not documents:
+        print("找不到任何維護用 Markdown 檔")
+        return 1
+
+    failures = 0
+    for path in documents:
+        problems = check_document(path)
+        rel = path.relative_to(ROOT)
+        if problems:
+            failures += 1
+            for problem in problems:
+                print(f"FAIL {rel}: {problem}")
+        else:
+            print(f"OK   {rel}")
+
+    print(f"\n共 {len(documents)} 份文件，{failures} 份有斷掉的相對連結。")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -3,7 +3,7 @@
 
 本 fork 的公開入口互相連來連去：FORK、NOTICE、AGENTS 與 docs。
 文件被重新定位或改名時，這些連結會靜靜斷掉。只驗相對連結；外部網址交給人看。
-不掃上游 `README.md`：那是 1000+ API 目錄，連結健康由上游的 format / links 腳本負責。
+不掃根目錄 `README.md`：那是 1000+ API 目錄。`scripts/README.md` 仍會掃。
 
     python tools/check_links.py
 """
@@ -20,7 +20,7 @@ LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#")
 
 
-SKIP_NAMES = {
+SKIP_RELATIVE = {
     "README.md",
     "upstream-review-report.md",
 }
@@ -39,7 +39,7 @@ def iter_documents() -> list[Path]:
     return sorted(
         path
         for path in documents
-        if path.is_file() and path.name not in SKIP_NAMES
+        if path.is_file() and path.relative_to(ROOT).as_posix() not in SKIP_RELATIVE
     )
 
 
@@ -56,6 +56,9 @@ def check_document(path: Path) -> list[str]:
             resolved = (ROOT / file_part.lstrip("/")).resolve()
         else:
             resolved = (path.parent / file_part).resolve()
+        if not resolved.is_relative_to(ROOT):
+            problems.append(f"{target} → 連結逃出 repo 根目錄")
+            continue
         if not resolved.exists():
             try:
                 shown = resolved.relative_to(ROOT)

--- a/tools/check_upstream_updates.py
+++ b/tools/check_upstream_updates.py
@@ -1,0 +1,189 @@
+"""Report upstream commits that have not yet been reviewed by this fork."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE_PATH = REPO_ROOT / "tools" / "upstream_baseline.json"
+UPSTREAM_REF_PREFIX = "refs/upstream-check"
+
+
+class UpstreamCheckError(RuntimeError):
+    """Raised when the baseline or upstream Git history cannot be inspected."""
+
+
+def load_baseline(path: Path = BASELINE_PATH) -> dict:
+    if not path.is_file():
+        raise UpstreamCheckError(f"missing baseline file: {path}")
+    try:
+        baseline = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpstreamCheckError(f"invalid baseline file: {path}: {exc}") from exc
+    required = {"repo", "branch", "reviewed_through", "reviewed_date"}
+    missing = sorted(required - baseline.keys())
+    if missing:
+        raise UpstreamCheckError(f"baseline missing fields: {', '.join(missing)}")
+    if len(baseline["reviewed_through"]) != 40:
+        raise UpstreamCheckError("reviewed_through must be a full 40-character SHA")
+    return baseline
+
+
+def run_git(args: list[str], repo_dir: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        raise UpstreamCheckError(
+            f"git {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def fetch_upstream(baseline: dict, repo_dir: Path) -> str:
+    branch = baseline["branch"]
+    ref = f"{UPSTREAM_REF_PREFIX}/{branch}"
+    run_git(
+        [
+            "fetch",
+            "--quiet",
+            baseline["repo"],
+            f"+refs/heads/{branch}:{ref}",
+        ],
+        repo_dir,
+    )
+    return ref
+
+
+def collect_new_commits(baseline: dict, repo_dir: Path, ref: str) -> list[dict]:
+    reviewed = baseline["reviewed_through"]
+    raw = run_git(
+        [
+            "log",
+            "--reverse",
+            "--date=short",
+            "--format=%H%x1f%ad%x1f%s",
+            f"{reviewed}..{ref}",
+        ],
+        repo_dir,
+    )
+    commits = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        sha, date, subject = line.split("\x1f", 2)
+        files = [
+            item
+            for item in run_git(["show", "--name-only", "--format=", sha], repo_dir).splitlines()
+            if item.strip()
+        ]
+        commits.append(
+            {
+                "sha": sha,
+                "short": sha[:7],
+                "date": date,
+                "subject": subject,
+                "files": files,
+            }
+        )
+    return commits
+
+
+def render_markdown(
+    baseline: dict,
+    commits: list[dict],
+    error: str | None = None,
+) -> str:
+    lines = [
+        "# Upstream review report",
+        "",
+        f"- Upstream: `{baseline['repo']}` (`{baseline['branch']}`)",
+        f"- Reviewed through: `{baseline['reviewed_through'][:7]}`",
+        f"- Last review date: {baseline['reviewed_date']}",
+        "",
+    ]
+    if error:
+        lines.extend(["## Check failed", "", f"```text\n{error}\n```", ""])
+        return "\n".join(lines)
+    if not commits:
+        lines.extend(["## Result", "", "No new upstream commits. Nothing to review.", ""])
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "## Result",
+            "",
+            f"{len(commits)} upstream commit(s) require review.",
+            "",
+            "| Commit | Date | Subject | Files |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for commit in commits:
+        subject = commit["subject"].replace("|", "\\|")
+        files = "<br>".join(item.replace("|", "\\|") for item in commit["files"][:8])
+        if len(commit["files"]) > 8:
+            files += f"<br>… +{len(commit['files']) - 8} more"
+        lines.append(
+            f"| `{commit['short']}` | {commit['date']} | {subject} | {files or '(none)'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Review each commit, record adopt/skip decisions in `docs/DECISIONS.md`, ",
+            "then advance `tools/upstream_baseline.json` only after verification.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="upstream-review-report.md")
+    parser.add_argument("--repo-dir", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when new commits require review.",
+    )
+    args = parser.parse_args()
+
+    baseline: dict
+    commits: list[dict] = []
+    error: str | None = None
+    try:
+        baseline = load_baseline()
+        ref = fetch_upstream(baseline, args.repo_dir)
+        commits = collect_new_commits(baseline, args.repo_dir, ref)
+    except UpstreamCheckError as exc:
+        error = str(exc)
+        baseline = {
+            "repo": "unknown",
+            "branch": "unknown",
+            "reviewed_through": "0" * 40,
+            "reviewed_date": "unknown",
+        }
+
+    report = render_markdown(baseline, commits, error)
+    output = Path(args.output)
+    output.write_text(report, encoding="utf-8")
+    print(report)
+
+    if error:
+        return 2
+    if args.strict and commits:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_upstream_updates.py
+++ b/tools/check_upstream_updates.py
@@ -33,14 +33,17 @@ def load_baseline(path: Path = BASELINE_PATH) -> dict:
 
 
 def run_git(args: list[str], repo_dir: Path) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo_dir,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError as exc:
+        raise UpstreamCheckError(f"git not found: {exc}") from exc
     if result.returncode != 0:
         raise UpstreamCheckError(
             f"git {' '.join(args)} failed: {result.stderr.strip()}"
@@ -79,7 +82,10 @@ def collect_new_commits(baseline: dict, repo_dir: Path, ref: str) -> list[dict]:
     for line in raw.splitlines():
         if not line.strip():
             continue
-        sha, date, subject = line.split("\x1f", 2)
+        try:
+            sha, date, subject = line.split("\x1f", 2)
+        except ValueError as exc:
+            raise UpstreamCheckError(f"unexpected git log line: {line!r}") from exc
         files = [
             item
             for item in run_git(["show", "--name-only", "--format=", sha], repo_dir).splitlines()

--- a/tools/dev_check.ps1
+++ b/tools/dev_check.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location -LiteralPath $repoRoot
+
+$venvPython = Join-Path $repoRoot ".venv\Scripts\python.exe"
+if (Test-Path -LiteralPath $venvPython) {
+    $pythonExe = $venvPython
+} else {
+    $pythonExe = (Get-Command python -ErrorAction Stop).Source
+}
+
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
+
+function Invoke-PythonStep {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Label,
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    Write-Host "==> $Label"
+    & $script:pythonExe @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+Invoke-PythonStep -Label "Compile maintained Python" -Arguments @(
+    "-m", "compileall", "-q", "scripts", "tests", "tools"
+)
+Invoke-PythonStep -Label "Ruff (E9 + F)" -Arguments @(
+    "-m", "ruff", "check", "--select", "E9,F", "--target-version", "py39",
+    "tests", "tools"
+)
+Invoke-PythonStep -Label "Pytest" -Arguments @("-m", "pytest", "tests", "-q")
+
+Write-Host "==> Upstream validate package tests"
+Push-Location -LiteralPath (Join-Path $repoRoot "scripts")
+try {
+    & $pythonExe -m unittest discover tests --quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw "Upstream validate package tests failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}
+
+Invoke-PythonStep -Label "Check Markdown links" -Arguments @(
+    "tools\check_links.py"
+)
+
+Write-Host "WINDOWS DEV CHECK GREEN"

--- a/tools/upstream_baseline.json
+++ b/tools/upstream_baseline.json
@@ -1,0 +1,7 @@
+{
+  "repo": "https://github.com/public-apis/public-apis.git",
+  "branch": "master",
+  "reviewed_through": "c045a2eb505f0f8b7992bb4af53cc020f25003fd",
+  "reviewed_date": "2026-08-22",
+  "notes": "SanHsien fork baseline at clone time. HEAD is upstream master commit Merge pull request #6962 from ddevetak/add-football-charts."
+}


### PR DESCRIPTION
## Summary
- 修 fork 骨架：連結掃描漏檔、upstream checker 例外包裝、路徑逃出、workflow guard 測試、CI 加上 Python 3.14。
- 不改 `README.md` 目錄、不改 `scripts/validate/`、不升級上游 Action pin、不回貢。
- 本機 `pwsh -NoProfile -File tools\dev_check.ps1`：pytest 17 passed、check_links 13 份文件全綠。

## Test plan
- [ ] Ubuntu CI 3.12 / 3.14 綠
- [ ] Windows CI 3.14 `dev_check.ps1` 綠
- [ ] 上游三個 catalog workflow 仍 skipped

Made with [Cursor](https://cursor.com)