### PR TITLE
Add ExactCup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
 | [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |
 | [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | Recipe Search | `apiKey` | Yes | Unknown |
+| [ExactCup](https://exactcup.github.io/api/) | Cooking ingredient densities: grams per US cup, tablespoon, teaspoon and mL | No | Yes | Yes |
 | [Food Info](https://food-info.org/developer) | Nutrition data for millions of foods from six national food composition datasets | `apiKey` | Yes | No |
 | [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
 | [Fruityvice](https://www.fruityvice.com) | Data about all kinds of fruit | No | Yes | Unknown |


### PR DESCRIPTION
Adds **ExactCup** to `Food & Drink`.

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [ExactCup](https://exactcup.github.io/api/) | Cooking ingredient densities: grams per US cup, tablespoon, teaspoon and mL | No | Yes | Yes |

**What it is:** a read-only JSON API giving the weight of one US cup (and tablespoon, teaspoon, mL and oz) for 80 cooking and baking ingredients — the data you need to convert a recipe's volume measurements into grams, since a cup of flour (120 g) and a cup of honey (340 g) are wildly different weights. Nothing in the list currently covers volume→weight ingredient density.

- **Free, no key, no sign-up, no rate limit** — static JSON on a CDN, `Access-Control-Allow-Origin: *`, HTTPS only.
- **Docs:** https://exactcup.github.io/api/ (endpoints, field reference, curl/JS/Python examples, terms).
- **Try it:** `curl https://exactcup.github.io/api/v1/ingredients/honey.json`
- Endpoints: `/api/v1/index.json`, `/api/v1/ingredients.json`, `/api/v1/ingredients/{slug}.json`, `/api/v1/categories.json`, `/api/v1/units.json`.
- **Licence:** data is CC BY 4.0. Source data is also published openly at https://github.com/exactcup/ingredient-density-dataset.

**Checks:** entry is alphabetical within Food & Drink; description is 75 characters; no duplicate entry or prior PR for this API; `scripts/validate/format.py` reports the same 557 pre-existing findings before and after this change (no new ones); single squashed commit.

**Disclosure:** I built and maintain this API — it is free with no paid tier, no account and no upsell, so it is not a marketing submission for a paid product.