### PR TITLE
Update Orizn Visa entry: stale counts, link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1987,7 +1987,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
-| [Orizn Visa](https://visa.orizn.app) | Visa requirements for 199 countries, 39K+ passport-destination pairs in 15 languages | `apiKey` | Yes | Yes |
+| [Orizn Visa](https://visa.orizn.app/docs) | Visa and entry requirements for any passport/destination pair, in 15 languages | `apiKey` | Yes | Yes |
 | [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [OpenVan](https://openvan.camp/docs) | Fuel prices for 121 countries, food cost index & vanlife weather scores for RV travel | No | Yes | Yes |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Correction to an existing entry under **Transportation**.

The description read *"199 countries, 39K+ passport-destination pairs"*. That count was frozen from an early release and no longer matches the dataset — the project has since removed hardcoded counts from its published metadata rather than reprint a number that goes stale again. Live coverage is public and unauthenticated at `https://visa.orizn.app/api/v1/visa/stats`.

The link now points at the documentation instead of the marketing page.

`Auth`, `HTTPS` and `CORS` values are unchanged and still accurate: an API key is required (free tier, no card), HTTPS only, and `Access-Control-Allow-Origin: *` on every public endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)