### PR TITLE
Update x402 Crypto API entry with public HTTPS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+| [x402 Crypto API](http://43.157.206.248:4020) | AI agent crypto data API — pay per request in USDC on Base. 30+ endpoints. No API keys needed. | No | Yes | Yes |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
-| [x402 Crypto API](http://43.157.206.248:4020) | AI agent crypto data API — pay per request in USDC on Base. 30+ endpoints. No API keys needed. | No | Yes | Yes |
+| [x402 Crypto API](https://civilization-jacket-released-desperate.trycloudflare.com) | AI agent crypto data API — pay per request in USDC on Base via x402 protocol. 35+ endpoints, 6 free. No API keys needed. | No | Yes | Yes |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Updates the existing x402 Crypto API entry:

- URL changed from raw IP (`http://43.157.206.248:4020`) to public HTTPS URL
- Description updated: 35+ endpoints, 6 free tier endpoints
- Payment via x402 protocol (USDC on Base) — no API keys needed

Live: https://civilization-jacket-released-desperate.trycloudflare.com
Docs: https://civilization-jacket-released-desperate.trycloudflare.com/docs