### PR TITLE
Add ADSBiq API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1960,6 +1960,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [ADS-B Exchange](https://www.adsbexchange.com/data/) | Access real-time and historical data of any and all airborne aircraft | No | Yes | Unknown |
+| [ADSBiq](https://adsbiq.com/api/docs) | Community-powered real-time aircraft data and free daily Parquet exports | No | Yes | No |
 | [airportsapi](https://airport-web.appspot.com/api/docs/) | Get name and website-URL for airports by ICAO code | No | Yes | Unknown |
 | [AIS Hub](http://www.aishub.net/api) | Real-time data of any marine and inland vessel equipped with AIS tracking system | `apiKey` | No | Unknown |
 | [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds ADSBiq, a community-powered source of real-time aircraft data with free daily Parquet exports. The documented endpoint is publicly accessible without authentication, uses HTTPS, and does not currently expose cross-origin access.