### PR TITLE
Add IBAN Checker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
+| [IBAN Checker](https://ibanchecker.cash/api-docs) | Free IBAN validation and BIC/SWIFT lookup across 92 countries, GDPR compliant, no data stored | `apiKey` | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 89 countries with 121k+ BIC entries | `apiKey` | Yes | No |
 | [IEX Cloud](https://iexcloud.io/docs/api/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes | |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds ibanchecker.cash's IBAN validation and BIC/SWIFT lookup API to the Finance section, alphabetically between Hotstoks and IBANforge.

Free tier available via email signup. REST API, JSON responses, CORS enabled, HTTPS only. Validates IBAN structure (ISO 13616 / MOD-97) plus per-country national check digits, and looks up bank/BIC details across 92 countries.

Docs: https://ibanchecker.cash/api-docs