### PR TITLE
Add Proofmail to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
 | [Mailtrap](https://mailtrap.io) | Email API and SMTP for sending transactional and bulk emails, with email testing sandbox for safe development | apiKey | Yes | Unknown |
 | [PostStack](https://poststack.dev/docs) | EU-hosted email API for transactional and marketing email, with contacts, broadcasts, and analytics | `apiKey` | Yes | No |
+| [Proofmail](https://rapidapi.com/olegggnormal/api/proofmail-email-verification-api) | Email verification with a live SMTP mailbox check: invalid, catch-all, disposable and role addresses | `apiKey` | Yes | Yes |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [uchecker](https://api.uchecker.net/docs) | Bulk email verification with full SMTP server responses | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add Proofmail to Email

**API:** https://rapidapi.com/olegggnormal/api/proofmail-email-verification-api

**What it does:** email verification with a live SMTP mailbox check — flags invalid and non-existent addresses, catch-all domains, disposable and role accounts. Returns `risky`/`unknown` with a machine-readable reason when the mailbox cannot be confirmed instead of guessing.

**Free tier:** yes (BASIC plan, 500 requests/month, no card). Public OpenAPI spec: https://api.proofmailapi.com/v1/openapi.yaml

- [x] Auth: `apiKey`
- [x] HTTPS: Yes
- [x] CORS: Yes (`Access-Control-Allow-Origin: *`)
- [x] Alphabetical position: between PostStack and Sendgrid
- [x] `scripts/validate/links.py` passes for the new link; `format.py` reports no issue on the added line (the other warnings it prints are pre-existing)
