### PR TITLE
Add Fakenamely API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1885,6 +1885,7 @@ API | Description | Auth | HTTPS | CORS |
 | [DummyJSON](https://dummyjson.com/) | Fake REST API with products, users, posts, comments, todos and more | No | Yes | Yes |
 | [English Random Words](https://random-words-api.vercel.app/word) | Generate English Random Words with Pronunciation | No | Yes | No |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
+| [Fakenamely](https://fakenamely.com/api) | Keyless, seedable fictional identities, names and addresses with real postal codes for 38 countries | No | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
 | [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |
 | [GeneradorDNI](https://api.generadordni.es) | Data generator API. Profiles, vehicles, banks and cards, etc | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Fakenamely to **Test Data**.

| Field | Value |
| --- | --- |
| Docs | https://fakenamely.com/api (OpenAPI: https://fakenamely.com/api/openapi.json) |
| Auth | No — there is no key to request |
| HTTPS | Yes |
| CORS | Yes (`access-control-allow-origin: *`, verified) |
| Free | Entirely. No paid tier, no account, no quota to apply for |

Fictional identities, names, single fields and postal addresses for tests, fixtures and demos. What distinguishes it from the other entries in this section: a `seed` parameter makes any response reproducible (the same seed returns byte-identical records), and address records pair a real city with a postal code genuinely issued for it in 38 countries (US codes from the GeoNames dataset, CC BY 4.0) while the street is invented, so a record validates without pointing at anyone. Phone numbers come from the 555-01XX range reserved for fiction and emails from RFC 2606 domains with a null MX.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
