### PR TITLE
Add BookNear API

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Bhagavad Gita](https://bhagavadgita.io/api) | Bhagavad Gita text | `OAuth` | Yes | Yes |
 | [Bhagavad Gita telugu](https://gita-api.vercel.app) | Bhagavad Gita API in telugu and odia languages | No | Yes | Yes |
 | [Bible-api](https://bible-api.com/) | Free Bible API with multiple languages | No | Yes | Yes |
+| [BookNear](https://booknear.me/llms.txt) | Bookshops, libraries and public bookcases near a location, from OpenStreetMap | No | Yes | Yes |
 | [British National Bibliography](http://bnb.data.bl.uk/) | Books | No | No | Unknown |
 | [Crossref Metadata Search](https://github.com/CrossRef/rest-api-doc) | Books & Articles Metadata | No | Yes | Unknown |
 | [Ganjoor](https://api.ganjoor.net) | Classic Persian poetry works including access to related manuscripts, recitations and music tracks | `OAuth` | Yes | Yes |


### PR DESCRIPTION
Adds the BookNear API to **Books**.

`GET https://booknear.me/api/near?lat=48.8566&lon=2.3522&r=8000` returns the bookshops, public
libraries and little free libraries (public bookcases) near a point, anywhere on earth, as JSON.

- **Auth:** `No` — no key, no signup, no registration of any kind.
- **HTTPS:** `Yes` — HTTP is 301'd to HTTPS.
- **CORS:** `Yes` — `Access-Control-Allow-Origin: *`.
- Fully free, no paid tier, no device purchase, nothing to buy. Not a marketing entry — there is
  no product and no company behind it.
- Docs are at the linked URL (`llms.txt`, written to be readable by people and agents alike).

Try it:

```
curl "https://booknear.me/api/near?lat=48.8566&lon=2.3522&r=8000"
```

Underlying place data is © OpenStreetMap contributors (ODbL) and every response carries the
attribution string.

Checklist:
- Searched existing entries and open PRs — no duplicate, and this is not a new version of a
  listed API.
- One link in this PR.
- Alphabetical order preserved (between `Bible-api` and `British National Bibliography`).
- Description is 77 characters.
- TLD omitted from the API name per the guidelines.
- Columns padded with one space either side.

I considered `Geocoding` since the API returns places, but the service is specifically about
finding books, so `Books` seemed the better fit. Happy to move it if you'd prefer.