### PR TITLE
Add StackScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1730,6 +1730,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
 | [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
 | [SSL Domain Health Check](https://rapidapi.com/goktugbk/api/ssl-domain-health-check) | SSL certificate validity, domain WHOIS status, and DNS record checks for any domain | `apiKey` | Yes | Unknown |
+| [StackScan](https://api.stackscan.com/docs) | Technology stack of any domain, plus reverse lookup of sites using a given technology | `apiKey` | Yes | Yes |
 | [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
 | [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
 | [URLhaus](https://urlhaus.abuse.ch/api/) | Database of malicious URLs used for malware distribution | `No` | Yes | Unknown |


### PR DESCRIPTION
Adds StackScan to **Security**, alphabetically between SSL Domain Health Check and Threat Jammer.

**Disclosure: I work for StackScan.**

The API answers two directions over an index of 360M+ sites and 55,000+ technologies:

- `domains/lookup` returns the technology stack for a domain, with each technology's category and how many sites run it.
- `technologies/lookup` goes the other way, returning site counts and country distribution for a given technology, optionally with the matching site list.

There are also batch variants of both, and an endpoint for building and downloading full technology lists.

Verified against tesla.com: 33 technologies returned, each with parent and child category.

Free tier on email verification: 100 lifetime API credits. Paid plans add bulk volume.

- Auth: bearer token plus a workspace header, so `apiKey`
- HTTPS: yes
- CORS: yes, verified `access-control-allow-origin: *`

Description is 85 characters, under the 100 limit. `scripts/validate/format.py` reports no new errors.