### PR TITLE
Add Huyền Minh API

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth` | Yes | Unknown |
 | [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
 | [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
+| [Huyền Minh](https://huyenminh.com.vn/api) | Vietnamese lunar calendar, solar-lunar conversion and traditional festival dates | No | Yes | Yes |
 | [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
 | [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
 | [Namedays Calendar](https://nameday.abalin.net) | Provides namedays for multiple countries | No | Yes | Yes |


### PR DESCRIPTION
Adds **Huyền Minh** to the **Calendar** category.

| Field | Value |
|---|---|
| Docs | https://huyenminh.com.vn/api |
| OpenAPI 3.1 | https://huyenminh.com.vn/openapi.json |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes (`Access-Control-Allow-Origin: *`, preflight handled) |

### What it does

Vietnamese lunar calendar: Gregorian ⇄ lunar conversion (including leap
months), and the Gregorian dates of the 13 traditional Vietnamese festivals
(Tết Nguyên Đán, Vu Lan, Trung Thu, and others). It also computes full
traditional astrology charts — *tử vi* (Zi Wei Dou Shu) and *bát tự*
(BaZi / Four Pillars) — returning raw structured data only, never
interpretation.

### Checklist

- [x] Free, no signup, no API key, no rate limit, no commercial restriction
- [x] HTTPS
- [x] CORS enabled
- [x] Documented — human-readable page with an English section, plus
      OpenAPI 3.1 and an `llms.txt`
- [x] Description under 100 characters
- [x] Alphabetical order within the Calendar section
- [x] One link, single squashed commit, targeting `master`

### Try it

```
curl 'https://huyenminh.com.vn/api/amlich?d=15&m=7&y=2026'
curl 'https://huyenminh.com.vn/api/le?nam=2026'
```

Note: the `Validate Markdown format` job already fails on `master` (several
categories are not in alphabetical order). I verified locally that this
change adds **no new** validator complaints — the output is identical before
and after, apart from line numbers shifting by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
