### PR TITLE
Add VineVerse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ API | Description | Auth | HTTPS | CORS |
 | [The Bible](https://docs.api.bible) | Everything you need from the Bible in one discoverable place | `apiKey` | Yes | Unknown |
 | [Thirukkural](https://api-thirukkural.web.app/) | 1330 Thirukkural poems and explanation in Tamil and English | No | Yes | Yes |
 | [Urantia Papers](https://urantia.dev) | Full-text + semantic search across the Urantia Papers, with audio narration, entities, translations | No | Yes | Yes |
+| [VineVerse](https://vineverse.bible/api) | Bible knowledge graph: 31,102 verses, 341,289 cross references, people, places and themes | No | Yes | Yes |
 | [Wizard World](https://wizard-world-api.herokuapp.com/swagger/index.html) | Get information from the Harry Potter universe | No | Yes | Yes |
 | [Wolne Lektury](https://wolnelektury.pl/api/) | API for obtaining information about e-books available on the WolneLektury.pl website | No | Yes | Unknown |
 


### PR DESCRIPTION
Adds VineVerse to **Books**.

[VineVerse](https://vineverse.bible/api) serves the Bible as a knowledge graph rather than as verse text alone: all 31,102 verses of the Berean Standard Bible (public domain) plus 341,289 vote-weighted cross references, ~3,000 people, ~1,300 geocoded places, topical themes, the 613 commandments and Strong's Hebrew — 15 GET endpoints, described by an OpenAPI 3.1 document at https://vineverse.bible/openapi.json.

- **Auth:** No — there is no key to issue, no account and no rate-limit tier.
- **HTTPS:** Yes.
- **CORS:** Yes — `Access-Control-Allow-Origin: *`, so it works from the browser.

Free and openly licensed throughout (text public domain, data CC BY 4.0). Not a paid product and not a free tier of one.

Added in alphabetical order between Urantia Papers and Wizard World. One link, description is 89 characters.