### PR TITLE
Add MapJSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
 | [Longdo Map](https://map.longdo.com/docs/) | Interactive map with detailed places and information portal in Thailand | `apiKey` | Yes | Yes |
 | [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
+| [MapJSON](https://mapjson.com/docs/) | Country, region & physical map geometry as TopoJSON/GeoJSON, no key required | No | Yes | Yes |
 | [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No | Yes
 | [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |
 | [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/) | Provides worldwide forward / reverse geocoding | No | Yes | Yes |


### PR DESCRIPTION
Adds MapJSON to the **Geocoding** section (between Mapbox and MapQuest).

MapJSON is a free, hosted API returning country, administrative region/district, postal, and physical (rivers, lakes, coastlines) geometry as TopoJSON or GeoJSON. No key, no account, no rate limits. Docs: https://mapjson.com/docs/ — example call: `https://api.mapjson.com/v1/geo?filter=Poland`

I maintain the API; it is fully free with no paid tier.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
