### PR TITLE
Add FilingPulse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Edgrapi](https://edgrapi.com) | Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q sections as normalized JSON | `apiKey` | Yes | Unknown | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
+| [FilingPulse](https://filingpulse.io/docs.html) | SEC EDGAR filings normalized to JSON: Form 4 insider trades, 8-K events, S-1 registrations | `apiKey` | Yes | No |
 | [Filingrail](https://rapidapi.com/hudson-enterprises-llc-hudson-enterprises-llc-default/api/filingrail) | SEC EDGAR filings, XBRL financials, Form 4 insider trades, 8-K events and 13F holdings | `apiKey` | Yes | Unknown |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds FilingPulse to the Finance section (alphabetical, before Filingrail).

- API: https://filingpulse.io/docs.html
- SEC EDGAR filings normalized to one JSON schema: Form 4 insider trades, 8-K events by item code, S-1/IPO registrations threaded by file number
- Auth: `apiKey` (free tier available, no card)
- HTTPS: Yes
- CORS: No (server-side API; only localhost origins are allowed for browser use)

One API, one commit, per CONTRIBUTING.md. Disclosure: I run this API.