### PR TITLE
Add Tamperlens API

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Yes | Unknown |
 | [Smart Image Enhancement](https://apilayer.com/marketplace/image_enhancement-api) | Performs image upscaling by adding detail to images through multiple super-resolution algorithms | `apiKey` | Yes | Unknown |
 | [staffSign](https://staffsign.de/docs) | Digital employment contract API with QES/eIDAS support for HR and staffing | `apiKey` | Yes | Yes |
+| [Tamperlens](https://tamperlens.com/api-reference) | Structural tampering and failed-redaction signals for PDF, Office and image files; free tier | `apiKey` | Yes | Yes |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
 | [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Adds Tamperlens to Documents & Productivity: it takes a PDF, Office file or image and returns structural tampering and failed-redaction signals as JSON, with a free tier of 50 documents/month and no card required.

- Auth `apiKey`, HTTPS yes, CORS verified against the live endpoint (`Access-Control-Allow-Origin` echoed on a cross-origin preflight).
- Placed alphabetically in the section; `scripts/validate/format.py` reports the same 557 pre-existing findings before and after the change, none of them on the new row.
