### PR TITLE
Add TranscriptOut API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2126,6 +2126,7 @@ API | Description | Auth | HTTPS | CORS |
 | [TMDb](https://www.themoviedb.org/documentation/api) | Community-based movie data | `apiKey` | Yes | Unknown |
 | [TrailerAddict](https://www.traileraddict.com/trailerapi) | Easily embed trailers from TrailerAddict | `apiKey` | No | Unknown |    
 | [Trakt](https://trakt.docs.apiary.io/) | Movie and TV Data | `apiKey` | Yes | Yes |
+| [TranscriptOut](https://transcriptout.com/docs) | YouTube video transcripts, search, channel and playlist data | `apiKey` | Yes | No |
 | [TVDB](https://thetvdb.com/api-information) | Television data | `apiKey` | Yes | Unknown |
 | [TVMaze](http://www.tvmaze.com/api) | TV Show Data | No | No | Unknown |
 | [uNoGS](https://rapidapi.com/unogs/api/unogsng) | Unofficial Netflix Online Global Search, Search all netflix regions in one place | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Add TranscriptOut to the Video section.

TranscriptOut is a YouTube data API with a free tier (100 credits on signup, no card). It serves video transcripts in five formats, native video and channel search, channel and playlist listings, and async batch transcript jobs.

- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/public-apis/public-apis/blob/master/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category, added to Video)
- [x] All changes have been squashed into a single commit