### PR TITLE
Add 54ch10 Brief API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1689,6 +1689,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Security
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
+| [54ch10 Brief](https://54ch10.uk/AGENT.md) | Pre-interact risk briefs for addresses, tokens, and URLs (analytics-only) | No | Yes | Yes |
 | [Application Environment Verification](https://github.com/fingerprintjs/aev) | Android library and API to verify the safety of user devices, detect rooted devices and other risks | `apiKey` | Yes | Yes |
 | [BinaryEdge](https://docs.binaryedge.io/api-v2.html) | Provide access to BinaryEdge 40fy scanning platform | `apiKey` | Yes | Yes |
 | [BitWarden](https://bitwarden.com/help/api/) | Best open-source password manager | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## Summary
Adds **54ch10 Brief** under Security: free-tier `GET /v1/brief` for pre-interact JSON briefs on addresses, tokens, and URLs (analytics-only, not advice). Docs: https://54ch10.uk/AGENT.md · OpenAPI: https://54ch10.uk/openapi.json

## Auth
Free tier requires no auth (20/day/IP). Optional paid Bearer key for higher limits.

## Test plan
- [x] `curl -sS 'https://54ch10.uk/v1/brief?type=url&q=https://example.com'`
- [x] `curl -sS 'https://54ch10.uk/health'`
- [x] HTTPS + CORS `*`