### PR TITLE
Add Presend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database for 263 devices | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [Presend](https://presend.pages.dev/api) | Free utility API: hashing, email/password checks, PDF/image tools, IP geolocation, no signup | No | Yes | Yes |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyForge](https://proxyforge.dev) | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h | No | Yes | Yes |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds Presend, a free utility API with no signup and no API key required.

- Hashing (SHA-256/1/512)
- Combined email verification (syntax + MX + disposable-domain + role-account detection in one call)
- Combined password check (strength/entropy + optional breach check)
- Phone number validation/formatting with automatic IP-based country fallback
- PDF merge+compress and image EXIF/GPS cleaning, each chaining multiple operations in a single call
- IP geolocation with Tor exit-node detection
- Standard dev utilities: UUID, Base64, JWT decode, timestamp, color conversion, User-Agent parsing, CSV/JSON conversion

Full docs and an OpenAPI spec: https://presend.pages.dev/api
Source: https://github.com/presendapp/presend