### PR TITLE
Add Equipment Capital Index to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes | |
 | [EconPulse](https://econpulse.io) | Live economic data — CPI, PPI, energy, treasury rates, BTC premium | `apiKey` | Yes | Yes |
 | [Edgrapi](https://edgrapi.com) | Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q sections as normalized JSON | `apiKey` | Yes | Unknown | |
+| [Equipment Capital Index](https://www.equipmentcapitalindex.com/openapi.json) | Commercial equipment financing rate benchmarks by category | No | Yes | Yes | |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown | |
 | [Filingrail](https://rapidapi.com/hudson-enterprises-llc-hudson-enterprises-llc-default/api/filingrail) | SEC EDGAR filings, XBRL financials, Form 4 insider trades, 8-K events and 13F holdings | `apiKey` | Yes | Unknown |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds Equipment Capital Index's free, public rate-benchmark API to the Finance section.

- No auth required, HTTPS, CORS enabled (`Access-Control-Allow-Origin: *`)
- OpenAPI 3.0 spec: https://www.equipmentcapitalindex.com/openapi.json
- Live endpoint: https://www.equipmentcapitalindex.com/api/rate-report.json

Single addition, alphabetically placed between Edgrapi and Fed Treasury.