### PR TITLE
Add StackerScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
+| [StackerScan](https://www.stackerscan.com/docs) | Live and historical precious-metals spot prices, observed dealer premiums over spot, and the Goldback exchange rate | No | Yes | Yes | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [StockFit](https://api.stockfit.io/docs) | SEC filings, financial statements, earnings, ETF holdings and ownership data | `apiKey` | Yes | Yes | |
 | [Styvio](https://www.Styvio.com) | Realtime and historical stock data and current stock sentiment | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds StackerScan to the Finance section, alphabetical placement.

| [StackerScan](https://www.stackerscan.com/docs) | Live and historical precious-metals spot prices, observed dealer premiums over spot, and the Goldback exchange rate | No | Yes | Yes | |

- Fully open read-only API — no authentication of any kind; stated in the linked docs and in the OpenAPI 3.1 document at https://www.stackerscan.com/openapi.json
- HTTPS: Yes. CORS: Yes — every public endpoint answers `Access-Control-Allow-Origin: *` (documented)
- Free, self-serve, publicly reachable now; one link, one commit