### PR TITLE
Add Worklittle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,7 +1339,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |
 | [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |
 | [WhatJobs](https://www.whatjobs.com/affiliates) | Job search engine | `apiKey` | Yes | Unknown |
-| [Worklittle](https://docs.worklittle.com/jobs/resources/rate-limits) | Job index of 4 million roles with visa, distance, and salary filters | `apiKey` | Yes | Unknown |
+| [Worklittle](https://docs.worklittle.com) | Job search, over 4 million jobs | `apiKey` | Yes | Yes |
 | [ZipRecruiter](https://www.ziprecruiter.com/publishers) | Job search app and website | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**

--- a/README.md
+++ b/README.md
@@ -1339,6 +1339,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Upwork](https://developers.upwork.com/) | Freelance job board and management system | `OAuth` | Yes | Unknown |
 | [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |
 | [WhatJobs](https://www.whatjobs.com/affiliates) | Job search engine | `apiKey` | Yes | Unknown |
+| [Worklittle](https://docs.worklittle.com/jobs/resources/rate-limits) | Job index of 4 million roles with visa, distance, and salary filters | `apiKey` | Yes | Unknown |
 | [ZipRecruiter](https://www.ziprecruiter.com/publishers) | Job search app and website | `apiKey` | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Add Worklittle under Jobs.

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [Worklittle](https://docs.worklittle.com) | Job search, over 4 million jobs | `apiKey` | Yes | Yes |

- REST: https://api.worklittle.com
- OpenAPI: https://docs.worklittle.com/openapi/openapi.yaml
- CORS: `Access-Control-Allow-Origin: *` on the jobs API