### PR TITLE
Add Automation Integration Preflight API

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
+| [Automation Integration Preflight](https://rapidapi.com/tinyopsstudio/api/automation-integration-preflight) | Inspect public pages for bounded automation-integration readiness evidence | `apiKey` | Yes | No |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |
 | [Base](https://www.base-api.io/) | Building quick backends | `apiKey` | Yes | Yes |
 | [Beeceptor](https://beeceptor.com/) | Build a mock Rest API endpoint in seconds | No | Yes | Yes |


### PR DESCRIPTION
Adds Automation Integration Preflight to the Development category. The linked service has a free tier, public documentation, HTTPS, apiKey authentication, and no CORS. I checked the README and prior issues and pull requests for a duplicate before submitting.