### PR TITLE
Add eidosSpeech - free text-to-speech API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1921,6 +1921,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Audexum](https://audexum.com/docs) | Text-to-speech REST API with 43 voices and 33 languages | `apiKey` | Yes | Yes |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
+| [eidosSpeech](https://eidosspeech.xyz) | Free text-to-speech API with 1,200+ neural voices in 75+ languages | `apiKey` | Yes | Yes |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |
 | [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
 | [GeoScore](https://geoscoreapi.com) | Score content for AI search citation readiness with a 0-100 GEO score and 8 structural metrics | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## eidosSpeech — Free Text-to-Speech API

| | |
|---|---|
| **API** | [eidosSpeech](https://eidosspeech.xyz) |
| **Category** | Text Analysis |
| **Description** | Free text-to-speech API with 1,200+ neural voices in 75+ languages |
| **Auth** | `apiKey` (X-API-Key header) |
| **HTTPS** | Yes |
| **CORS** | Yes |
| **Documentation** | https://eidosspeech.xyz/api-docs |

Free tier: 30 requests/day, no credit card required. Returns MP3 directly.

### Example
```bash
curl -X POST https://eidosspeech.xyz/api/v1/tts \
  -H "X-API-Key: YOUR_KEY" \
  -H "Content-Type: application/json" \
  -d '{"text":"Hello world","voice":"en-US-JennyNeural"}' \
  --output audio.mp3
```

### Checklist
- [x] Free tier available (no credit card)
- [x] Publicly documented
- [x] HTTPS enabled
- [x] CORS enabled
- [x] Inserted in alphabetical order (Text Analysis, between Detect Language and ELI)
- [x] Follows the table format
