### PR TITLE
feat: add WeatherXM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2175,6 +2175,7 @@ API | Description | Auth | HTTPS | CORS |
 | [weather-api](https://github.com/robertoduessmann/weather-api) | A RESTful free API to check the weather | No | Yes | No |
 | [WeatherAPI](https://www.weatherapi.com/) | Weather API with other stuff like Astronomy and Geolocation API | `apiKey` | Yes | Yes |
 | [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
+| [WeatherXM](https://weatherxm.com/) | Decentralized weather network with hyperlocal forecasts and rewards | No | Yes | Yes |
 | [World Time & Weather](https://worldtimeweather.com/api.html) | Current weather, local time, UTC offset and DST rules for 400 cities as static JSON | No | Yes | Yes |
 | [wttr.in](https://wttr.in/:help) | Weather in your terminal, supports JSON output | No | Yes | Yes |
 | [Yandex.Weather](https://yandex.com/dev/weather/) | Assesses weather condition in specific locations | `apiKey` | Yes | No |


### PR DESCRIPTION
Add WeatherXM — decentralized weather network with hyperlocal forecasts. No auth, HTTPS Yes, CORS Yes. Alphabetically inserted in Weather section.