### PR TITLE
feat: add PubChem API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenAlex](https://docs.openalex.org/) | Open catalog of scholarly works, authors, institutions, sources, and concepts | No | Yes | Yes |
 | [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
+| [PubChem](https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest) | Chemical structure, property and bioactivity data | No | Yes | Yes |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |


### PR DESCRIPTION
Add PubChem — chemical structure, property and bioactivity data. No auth, HTTPS Yes, CORS Yes. Alphabetically in Science & Math section.