### PR TITLE
Add Marbella Sunbed Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ API | Description | Auth | HTTPS | CORS |
 | [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
 | [LottoLens PH](https://remo65588-boop.github.io/lottolens-ph-public-data/api/) | Fixed Philippine PCSO historical results and normal draw schedules | No | Yes | Yes |
 | [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |
+| [Marbella Sunbed Index](https://marbellawire.com/prices/sunbeds/) | High-season sunbed and minimum-spend prices for Marbella beach venues, JSON and CSV, CC BY 4.0 | No | Yes | Yes |
 | [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
 | [MostExpensiveWatches](https://mostexpensivewatches.net/api) | Documented luxury watch auction records, live listings, valuations and price indices | No | Yes | Yes |
 | [ModelPartFinder Error Codes](https://modelpartfinder.com/docs/api) | Lookup appliance and equipment error codes by brand and code, with recommended replacement parts | No | Yes | Yes |


### PR DESCRIPTION
**What**: Adds the Marbella Sunbed Index to Open Data.

Free, open dataset of high-season sunbed and minimum-spend prices at Marbella (Spain) beach clubs and chiringuitos, published by Marbella Wire. No auth, no rate limits, no paid tier.

- JSON: https://marbellawire.com/data/sunbed-index.json
- CSV: https://marbellawire.com/data/sunbed-index.csv
- Docs/methodology: https://marbellawire.com/prices/sunbeds/

HTTPS ✓ · CORS `*` ✓ · Licence CC BY 4.0. Mirrored with provenance and data dictionary at https://github.com/shiftdylson1/marbella-price-data.

Checked the contributing guidelines: one link, alphabetical order kept, description ≤100 chars, name doesn't end in "API".
