### PR TITLE
Add GZW Data Gray Zone Warfare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,6 +996,7 @@ API | Description | Auth | HTTPS | CORS |
 | [GraphQL Pokemon](https://github.com/favware/graphql-pokemon) | GraphQL powered Pokemon API. Supports generations 1 through 8 | No | Yes | Yes |
 | [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | Guild Wars 2 Game Information | `apiKey` | Yes | Unknown |
 | [GW2Spidy](https://github.com/rubensayshi/gw2spidy/wiki) | GW2Spidy API, Items data on the Guild Wars 2 Trade Market | No | Yes | Unknown |
+| [GZW Data](https://gzw-data.vercel.app/docs/) | Gray Zone Warfare weapons, missions, loot, armor and game data | No | Yes | Yes |
 | [Halo](https://developer.haloapi.com/) | Halo 5 and Halo Wars 2 Information | `apiKey` | Yes | Unknown |
 | [Hearthstone](http://hearthstoneapi.com/) | Hearthstone Cards Information | `X-Mashape-Key` | Yes | Unknown |
 | [Humble Bundle](https://rapidapi.com/Ziggoto/api/humble-bundle) | Humble Bundle's current bundles | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary

- Add GZW Data to the Games & Comics API list.
- The API provides public Gray Zone Warfare weapons, missions, loot, armor and other game data.
- No API key is required; HTTPS and CORS are supported.

API reference: https://gzw-data.vercel.app/docs/
OpenAPI spec: https://gzw-data.vercel.app/api/spec