### PR TITLE
Add Design DNA API (Art & Design)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | No | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
+| [Design DNA](https://rapidapi.com/rajimisonpaul/api/design-dna) | Extract any website's design system (fonts, type scale, colors, spacing, CSS tokens) as JSON | `apiKey` | Yes | Unknown |
 | [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth` | Yes | Unknown |
 | [DummyImage](https://dummyimage.com/) | Generate placeholder images with custom size, colors and text | No | Yes | Unknown |
 | [EmojiHub](https://github.com/cheatsnake/emojihub) | Get emojis by categories and groups | No | Yes | Yes |


### PR DESCRIPTION
Adds **Design DNA** — an API that extracts any website's measured design system (type scale, fonts, colors, spacing, layout, CSS variables) as JSON in one call. Free tier available on RapidAPI.

- Listing / docs: https://rapidapi.com/rajimisonpaul/api/design-dna
- Auth: apiKey (RapidAPI) · HTTPS: Yes · Free tier: Yes
- Added under **Art & Design**, alphabetical order preserved (between Cooper Hewitt and Dribbble).

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>