### PR TITLE
Add Profitvana API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
+| [Profitvana](https://www.profitvana.com/developers) | Seller fees for 31 marketplaces and payment processors, verified monthly | No | Yes | Yes |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Sparepilot](https://sparepilot.com/developers) | Spare parts catalog, OEM cross-references & price comparison for garden power equipment | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

---

Adds Profitvana to the **Shopping** section.

Free, key-less JSON API for marketplace and payment processor seller fees across 31 platforms (eBay, Etsy, Amazon, PayPal, Stripe, Shopify, TikTok Shop and others). Every rate is re-verified monthly against the platform's own official fee page, and each response carries the source URL plus the date it was last checked.

- Docs: https://www.profitvana.com/developers
- No auth, HTTPS, CORS enabled

Example request:

```
https://www.profitvana.com/api/v1/calculate?platform=ebay-fee-calculator&salePrice=100&itemCost=40
```

Other endpoints: `/api/v1/platforms`, `/api/v1/platforms/{slug}`, `/api/v1/compare`, `/api/v1/fee-index` (a 20-country fee dataset), `/api/v1/rates`.
