### PR TITLE
Add RevAddress API

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown | |
 | [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown | |
 | [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown | |
+| [RevAddress](https://revaddress.com/docs/) | US address standardization, congressional and state legislative districts, Census data; free tier | `apiKey` | Yes | No | |
 | [SchemaShield](https://rapidapi.com/kaiasistentedavid/api/schema-change-risk) | Read-only preflight for breaking schema changes and downstream query impact | `apiKey` | Yes | Unknown | |
 | [Temsor](https://api.temsor.com/docs) | Validates Turkish national ID, tax number, IBAN, phone, plate and parses addresses | `apiKey` | Yes | Yes | |
 | [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adds RevAddress to Data Validation.

- Docs: https://revaddress.com/docs/ — OpenAPI at https://api.revaddress.com/openapi.yaml
- Free tier: 1,000 credits a month, no card, does not expire (https://revaddress.com/pricing/)
- What it does: US address standardization (Census-based), congressional and state legislative district lookup including the 2026 redistricted lines, tract-level Census data, all with per-block provenance
- Auth: `apiKey` (X-API-Key header) · HTTPS: yes · CORS: allowlisted origins only, so "No"

Alphabetical within the section (after PurgoMalum), description under 100 characters, one link.