### PR TITLE
Add 2BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Business
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [2BASE](https://2base.ru/api/docs) | Search Russian companies using EGRUL and public business data | No | Yes | No |
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds 2BASE to the Business category: a no-auth, HTTPS, read-only API for searching Russian companies using EGRUL and public business data. Public phone numbers and emails are masked. The documentation and live endpoints were verified before submission.

- [x] Formatted according to the contributing guide
- [x] Ordered alphabetically
- [x] Useful description under 100 characters without trailing punctuation
- [x] Searched existing issues and pull requests
- [x] One addition and one commit