### PR TITLE
Add Banking Access Index to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,7 +859,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
-| [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) | Which US business banking providers accept founders by country of residence, with sourced evidence | No | Yes | Yes | |
+| [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) | Which US business banking providers accept founders by country of residence, with sources | No | Yes | Yes |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |

--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
 | [Banco do Brasil](https://developers.bb.com.br/home) | All Banco do Brasil financial transaction APIs | `OAuth` | Yes | Yes | |
 | [Bank Data](https://apilayer.com/marketplace/bank_data-api) | Instant IBAN and SWIFT number validation across the globe | `apiKey` | Yes | Unknown | |
+| [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) | Which US business banking providers accept founders by country of residence, with sourced evidence | No | Yes | Yes | |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown | |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown | |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds the Banking Access Index to the Finance section.

**What it is:** a free, no-auth JSON endpoint recording which US business banking providers accept founders by country of residence, with a sourced evidence quote behind each claim. Published under CC-BY and archived with a DataCite DOI (10.5281/zenodo.21336392).

**Endpoint:** https://www.globalsolo.global/data/banking-access-index.json

Field values were measured, not assumed:

```
$ curl -sI -H 'Origin: https://example.com' https://www.globalsolo.global/data/banking-access-index.json
HTTP/2 200
access-control-allow-origin: *
content-type: application/json; charset=utf-8
```

- Auth: No
- HTTPS: Yes
- CORS: Yes

**Checks run:**
- `scripts/validate/format.py` — the new row produces zero errors. Message-level diff against the base README is identical, so nothing new was introduced (the repo has pre-existing ordering warnings unrelated to this change).
- Alphabetical placement: after `Bank Data`, before `Billplz`.
- No existing entry covers account-opening eligibility by country of residence — the nearest neighbours (Plaid, Nordigen, Mono) all cover transaction data on accounts that already exist.

Free and non-commercial: the dataset is CC-BY, downloadable in full, and requires no signup.