### PR TITLE
Add SocialCrawl API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Revolt](https://developers.revolt.chat/api/) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
 | [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth` | Yes | Unknown |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Yes | Unknown |
+| [SocialCrawl](https://www.socialcrawl.dev/docs) | Social and commerce data from 50+ platforms in one JSON schema | `apiKey` | Yes | Yes |
 | [SocialSwarm](https://social-swarm-main-aa77a19.zuplo.site) | Turn articles into ready-to-post X thread drafts with different hooks | `apiKey` | Yes | No |
 | [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
 | [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds SocialCrawl to the Social section, alphabetically between Slack and SocialSwarm.

- Docs: https://www.socialcrawl.dev/docs
- Auth: apiKey (x-api-key)
- HTTPS: Yes
- CORS: Yes (access-control-allow-origin: *)
- Free tier: 100 credits on signup, no card required
- I work on SocialCrawl / Ridio

- [x] Formatted per CONTRIBUTING.md
- [x] Ordered alphabetically
- [x] Useful description, under 100 characters, no ending punctuation
- [x] Columns padded with one space on either side
- [x] Searched for duplicates
- [x] Single commit