### PR TITLE
Update 5DollarFootballAPI name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1830,7 +1830,7 @@ API | Description | Auth | HTTPS | CORS |
 ### Sports & Fitness
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
-| [5DollarFootball](https://5dollarfootballapi.com/) | Football fixtures, results, standings and historical odds with corner and card lines | `apiKey` | Yes | Yes |
+| [5DollarFootballAPI](https://5dollarfootballapi.com/) | Football fixtures, live scores, tick-by-tick bet365 odds (+18 more books) and corner & card lines | `apiKey` | Yes | Yes |
 | [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey` | Yes | Yes |
 | [ApiMedic](https://apimedic.com/) | ApiMedic offers a medical symptom checker API primarily for patients | `apiKey` | Yes | Unknown |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |


### PR DESCRIPTION
Follow-up to #7066 (merged earlier today) — I'm the API's maintainer.

- Name: 5DollarFootball → **5DollarFootballAPI**, matching the actual product name at https://5dollarfootballapi.com
- Description: more precise about what the API carries — live scores, tick-by-tick bet365 odds (plus 18 more bookmakers) and corner & card lines (97 chars)

Single line change, same position and columns.