### PR TITLE
Add PairBook to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NORTH7 Agent](https://north7.ai/v1/docs) | Trading signals, market analysis and geopolitical intelligence | `apiKey` | Yes | Yes |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
+| [PairBook](https://www.pairbook.io/api/) | Correlation, beta, volatility and holdings overlap for US stocks and ETFs | No | Yes | Yes | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |

--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NORTH7 Agent](https://north7.ai/v1/docs) | Trading signals, market analysis and geopolitical intelligence | `apiKey` | Yes | Yes |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
-| [PairBook](https://www.pairbook.io/api/) | Correlation, beta, volatility and holdings overlap for US stocks and ETFs | No | Yes | Yes | |
+| [PairBook](https://www.pairbook.io/api/) | Correlation, beta, volatility and holdings overlap for US stocks and ETFs | No | Yes | Yes |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown | |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes | |


### PR DESCRIPTION
Adds PairBook, a free API serving correlation, covariance, beta, volatility and ETF holdings-overlap data for 4,700+ US stocks and ETFs, refreshed every trading day.

- Fully free (no paid tier required), no signup
- Auth: No
- HTTPS: Yes
- CORS: Yes
- Docs: https://www.pairbook.io/api/ (OpenAPI 3.1: https://www.pairbook.io/api/openapi.json)

Thanks for maintaining the list!