### PR TITLE
Add BTCGlobe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Blockchain](https://www.blockchain.com/api) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Yes | Unknown |
 | [blockfrost Cardano](https://blockfrost.io/) | Interaction with the Cardano mainnet and several testnets | `apiKey` | Yes | Unknown |
 | [Brave NewCoin](https://bravenewcoin.com/developers) | Real-time and historic crypto data from more than 200+ exchanges | `apiKey` | Yes | Unknown |
+| [BTCGlobe](https://btcglobe.live/join#makers) | Bitcoin height, fees, mempool and peer data served live from two self-hosted nodes | No | Yes | Yes |
 | [btcnode.uk](https://btcnode.uk) | Bitcoin blockchain data, fees, mempool, SEC insider trades, Reddit sentiment. x402 micropayments for paid endpoints. | No | Yes | Unknown |
 | [BtcTurk](https://docs.btcturk.com/) | Real-time cryptocurrency data, graphs and API that allows buy&sell | `apiKey` | Yes | Yes |
 | [Bybit](https://bybit-exchange.github.io/docs/linear/#t-introduction) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category here)
- [x] All changes have been squashed into a single commit

Adds BTCGlobe to Cryptocurrency.

I run two Bitcoin full nodes at home, one in Canada and one in Romania, and the site serves what they hear. Four GET endpoints, no key and no signup:

- `/api/meta` height, fees, price, mempool, peers
- `/api/nodes` the two nodes and the small miner
- `/api/history` fee and mempool samples every 5 minutes
- `/api/journal` records and first times the nodes noticed

Docs: https://btcglobe.live/join#makers

Try it: curl -s https://btcglobe.live/api/meta

Auth No, HTTPS Yes, CORS Yes (Access-Control-Allow-Origin: * on all four). Answers are cached 10 to 60 seconds at the edge, so polling faster than once a minute buys nothing.