### PR TITLE
Add VotePredictor API (Government)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,6 +1269,7 @@ API | Description | Auth | HTTPS | CORS |
 | [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs) | US federal contracts, grants, and agency spending data updated daily | No | Yes | Yes |
 | [USAspending.gov](https://api.usaspending.gov/) | US federal spending data | No | Yes | Unknown |
 | [Vett](https://wimberly.solutions/api/free-sanctions-check/) | Screen names & companies against OFAC, PEP, watchlists & recalls | No | Yes | Yes |
+| [VotePredictor](https://votepredictor.com/developers) | US election forecasts, congressional voting records and forecaster accuracy ratings | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds VotePredictor to the Government section.

| API | Description | Auth | HTTPS | CORS |
|:---|:---|:---|:---|:---|
| [VotePredictor](https://votepredictor.com/developers) | US election forecasts, congressional voting records and forecaster accuracy ratings | No | Yes | Yes |

Free JSON API for US election forecasts — 2026 Senate, House and Governor win
probabilities, voting records and reported net worth for every member of Congress, and
accuracy ratings for major forecasters. No key, no signup, no paid tier.

Each column verified against the live API rather than assumed:

- **Auth `No`** — `curl https://votepredictor.com/api/v1/race/2026_SEN_OH` returns 200 with
  no credentials.
- **HTTPS `Yes`** — HSTS enabled.
- **CORS `Yes`** — every response sets `access-control-allow-origin: *`.

Meets the contribution guideline that the API has full free access and does not depend on
purchasing a device or service.

Placed alphabetically after `Vett`, at the end of the Government section. `scripts/validate/format.py`
reports no errors on the added line (the two it prints for a table separator row are
pre-existing on `master`).

Docs: https://votepredictor.com/developers