### PR TITLE
Add Yes or No Oracle to Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
 | [TasteDive](https://tastedive.com/read/api) | Content-based recommendations for movies, music, TV shows, books, games, and podcasts | `apiKey` | Yes | No |
 | [Techy](https://techy-api.vercel.app/) | JSON and Plaintext API for tech-savvy sounding phrases | No | Yes | Unknown |
+| [Yes or No Oracle](https://yesnooracle.app/api) | Random yes/no/maybe answers in 7 themed oracle voices (Magic 8 Ball, Tarot, and more) | No | Yes | Yes |
 | [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2) | REST API for Yo Momma Jokes | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds the **Yes or No Oracle** API to the Entertainment section.

A free, key-less JSON API that returns a random yes / no / maybe answer, with 7 themed oracle voices (Magic 8 Ball, Tarot, Crystal Ball, I Ching, Pendulum, Runes, and a general oracle). Each answer includes a themed headline word and a reflective phrase.

- **Endpoint:** `GET https://yesnooracle.app/api/oracle`
- **Docs & live playground:** https://yesnooracle.app/api
- **Auth:** No · **HTTPS:** Yes · **CORS:** Yes
- Placed alphabetically in Entertainment (between `Techy` and `Yo Momma Jokes`).

Example:
```bash
curl "https://yesnooracle.app/api/oracle?tool=tarot"
# {"answer":"yes","word":"The Emperor","phrase":"...","tool":"tarot",...}
```

### My submission

- [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md) before opening a Pull Request.
- [x] This API is not on the list.
- [x] Only one API added per pull request.
- [x] The subcategory is in the correct alphabetical order.
- [x] The entry is in the correct alphabetical order.
- [x] The description does not exceed 100 characters.
- [x] The description does not end with a period.
- [x] The description does not start with `A` / `An` / `The`.
- [x] Auth uses one of the approved values (`No`).
- [x] HTTPS and CORS use approved values.
- [x] The API name does not end with `API` and does not mention the TLD.