### PR TITLE
Add SEC Form 4 Insider Trades API to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown | |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown | |
 | [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | API to access annual reports of public US companies | No | Yes | Yes | |
+| [SEC Form 4 Insider Trades](https://documenter.getpostman.com/view/57719789/2sBYAsyCVM) | Normalized SEC Form 4 insider transactions as clean JSON | `apiKey` | Yes | Unknown | |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown | |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes | |
 | [StockFit](https://api.stockfit.io/docs) | SEC filings, financial statements, earnings, ETF holdings and ownership data | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Adds one entry to the Finance category: a normalized SEC Form 4 insider-trading transactions API (clean JSON, apiKey auth, HTTPS). Follows the existing table format and alphabetical ordering.