### PR TITLE
Add Urgences Québec (Health)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ API | Description | Auth | HTTPS | CORS |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |
 | [Orion Health](https://developer.orionhealth.io/) | Medical platform which allows the development of applications for different healthcare scenarios | `OAuth` | Yes | Unknown |
 | [Quarantine](https://quarantine.country/coronavirus/api/) | Coronavirus API with free COVID-19 live updates | No | Yes | Yes |
+| [Urgences Québec](https://sante.handled.tools/en/donnees) | Hourly occupancy and wait times for the 120 emergency rooms in Quebec, Canada | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds one row to Health.

Urgences Québec is an independent open API over Quebec's emergency-room situation. Québec's health ministry publishes a single file that it overwrites every hour, so nothing historical survives on the official side; this API keeps the hourly readings and serves them as JSON.

- `/api/now` — current occupancy, stretcher counts, people waiting, patients past 24h/48h and average stay, for all 120 emergency rooms
- `/api/facilities` — addresses, coordinates, phone, region for the same 120
- `/api/cliniques`, `/api/chirurgies` — walk-in clinic hours and surgical wait times

No key, no rate limit, `Access-Control-Allow-Origin: *`, HTTPS only. Data page with the sources and licence: https://sante.handled.tools/en/donnees

Not affiliated with the ministry — the underlying data is its open publication.