### PR TITLE
docs: fix typo 'in now Live' -> 'is now Live'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# APILayer Unified Suite in now Live! 🎉 🥳
+# APILayer Unified Suite is now Live! 🎉 🥳
 
 [APILayer unified suite](https://apilayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo) allows you to integrate production-grade REST APIs using **One Account, One Dashboard, and One API key.** Whether you need to geocode an address, validate an email, fetch a flight, pull stock market data, or scrape a search result.
 


### PR DESCRIPTION
Fixes typo in README heading: 'in now Live' -> 'is now Live'.