### PR TITLE
Add Shotium API

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |
+| [Shotium](https://shotium.com/docs) | Render any URL to a screenshot or a templated Open Graph image | `apiKey` | Yes | No |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
 | [SiteIntel](https://siteintel.duckdns.org) | Extract metadata, tech stack, emails, and screenshots from any URL | `apiKey` | Yes | Unknown |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |


### PR DESCRIPTION
Adds Shotium to the Development section, alphabetically between Sheetsu and SHOUTCLOUD.

Shotium renders any public URL to a screenshot, or a 1200x630 Open Graph image from a built-in template.

Column values, for the record:

- **Auth** `apiKey` — a Bearer API key.
- **HTTPS** Yes — HTTP is not served.
- **CORS** No — verified against production rather than assumed. The key belongs on the server side, so no `Access-Control-Allow-Origin` headers are sent.

Documentation: https://shotium.com/docs
OpenAPI 3.1 definition: https://shotium.com/openapi.json

Ran `scripts/validate/format.py` and `scripts/validate/links.py --only_duplicate_links_checker` locally: the new entry raises no errors, and the error count is unchanged from master (the remaining ones are pre-existing).