### PR TITLE
Correct the Audexum entry and move it to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI Economics Tools](https://piszczek.pl/tools/api) | Token cost, LLM energy, agent-hour and Proof-Adjusted Autonomy calculators by Michał Piszczek | No | Yes | Yes |
 | [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
+| [Audexum](https://audexum.com/docs) | Speech-to-text in 25 languages and text-to-speech with 43 voices in 32 languages | `apiKey` | Yes | Yes |
 | [BRAINIALL](https://github.com/fasuizu-br/brainiall-transcription-skill) | PT-BR and Spanish audio transcription with diarization and SRT/VTT | `apiKey` | Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth` | Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
@@ -1927,7 +1928,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Code Detection](https://codedetectionapi.runtime.dev) | Detect, label, format and enrich the code in your app or in your data pipeline | `OAuth` | Yes | Unknown |
 | [apilayer languagelayer](https://languagelayer.com/) | Language Detection JSON API supporting 173 languages | `OAuth` | Yes | Unknown |
 | [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | A collection of information retrieval and natural language APIs | `apiKey` | Yes | Unknown |
-| [Audexum](https://audexum.com/docs) | Text-to-speech REST API with 43 voices and 33 languages | `apiKey` | Yes | Yes |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Correcting our own entry (added in #6166).

**Section.** It is currently under `Text Analysis`, between `apilayer languagelayer` and `Cloudmersive Natural Language Processing` — language-detection and NLP text tools. Audexum is a speech API, so `Machine Learning` is the closer fit under the "section most in line with the services offered" rule; that section already lists BRAINIALL (audio transcription) and Hugging Face's audio inference. It was also out of alphabetical order where it sat (`Audexum` after `Aylien`); the new position, between `AI For Thai` and `BRAINIALL`, is correct.

**Description.** The old text described only text-to-speech and did not mention speech-to-text at all, which is half of what the API does. It also said 33 languages where the docs say 32.

```
- | [Audexum](https://audexum.com/docs) | Text-to-speech REST API with 43 voices and 33 languages | `apiKey` | Yes | Yes |
+ | [Audexum](https://audexum.com/docs) | Speech-to-text in 25 languages and text-to-speech with 43 voices in 32 languages | `apiKey` | Yes | Yes |
```

Description is 80 characters. Auth, HTTPS and CORS are unchanged and still accurate (`access-control-allow-origin: *`). Free tier is unchanged and requires no purchase. One line changed, no new `scripts/validate/format.py` findings.