### PR TITLE
Add FindSaunaPlunge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | COVID-19 live statistics into sites per hour | No | Yes | Unknown |
 | [Edamam](https://developer.edamam.com/) | Food and nutrition data API with recipe search | `apiKey` | Yes | Unknown |
 | [ERstat](https://erstat.ca/developers) | Live Canadian emergency room closures and service disruptions, by province | `apiKey` | Yes | Yes |
+| [FindSaunaPlunge](https://findsaunaplunge.com/api/) | US cold plunge and sauna venues with dated, source-quoted temperatures and prices | No | Yes | Yes |
 | [FoodData Central](https://fdc.nal.usda.gov/) | National Nutrient Database for Standard Reference | `apiKey` | Yes | Unknown |
 | [Healthcare.gov](https://www.healthcare.gov/developers/) | Educational content about the US Health Insurance Marketplace | No | Yes | Unknown |
 | [Humanitarian Data Exchange](https://data.humdata.org/) | Humanitarian Data Exchange (HDX) is open platform for sharing data across crises and organisations | No | Yes | Unknown |


### PR DESCRIPTION
**Category:** Health

- Docs: https://findsaunaplunge.com/api/
- Endpoint: https://findsaunaplunge.com/api/v1/venues.json (plus `nearby.json`, `search-index.json`, `redirects.json`)
- Auth: none · HTTPS: yes · CORS: yes (`access-control-allow-origin: *`)
- Licence: CC BY 4.0. 548 cold plunge / sauna / contrast-therapy venues across 23 US metros; every temperature and price carries its source page, capture date and quote. Absent fields mean "not published".

Checklist: single link, no duplicate found, name without TLD or "API", alphabetical within Health, squashed, targets `master`.