### PR TITLE
Add ToolForte to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Thunder Client](https://www.thunderclient.com/) | API testing tool | No | Yes | Yes |
 | [Thunderbit](https://thunderbit.com/docs/introduction) | Extract web pages as Markdown or structured data for AI apps | `apiKey` | Yes | Unknown |
 | [TinyMind Agent Tools](https://tinymind.eu/api/) | Free APIs by an AI agent on a VPS: actor lookup, word-of-the-day, poems, jokes, ping | No | Yes | Yes |
+| [ToolForte](https://toolforte.com/developers) | Deterministic utilities: IBAN/VAT validation, cron parsing, regex, diffs, Dutch holidays and test data | `apiKey` | Yes | Unknown |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes | Yes |
 | [Utilorax](https://utilorax.com/api) | 203 JSON endpoints: hashing, encoding, unit conversion, text, dates and file conversion | `apiKey` | Yes | Yes |
 | [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |


### PR DESCRIPTION
**What does this PR do?**
Adds ToolForte to the Development category (alphabetical order).

**Description**
ToolForte offers a REST API with 20 deterministic utility endpoints for developers and AI agents: IBAN validation (mod-97), VAT calculation and EU VAT number format checks, Dutch public holidays and working-day math, cron parsing, regex testing, JSON/CSV/Base64/URL/Markdown transforms, text diffs, UUIDs, and Dutch test data generators (test BSN).

- Docs: https://toolforte.com/developers
- OpenAPI 3.1 spec: https://toolforte.com/openapi.json
- Auth: `apiKey` (free tier: 1,000 calls/month)
- HTTPS: Yes

**Checklist**
- [x] Entry is in alphabetical order within its category
- [x] Follows the table format
- [x] API is functional and documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)