### PR TITLE
Add Urgences Québec to Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ API | Description | Auth | HTTPS | CORS |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |
 | [Orion Health](https://developer.orionhealth.io/) | Medical platform which allows the development of applications for different healthcare scenarios | `OAuth` | Yes | Unknown |
 | [Quarantine](https://quarantine.country/coronavirus/api/) | Coronavirus API with free COVID-19 live updates | No | Yes | Yes |
+| [Urgences Québec](https://sante.handled.tools/api) | Hourly emergency room occupancy, stretcher counts and wait times for every hospital in Quebec, Canada | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds Urgences Québec to the Health section.

It publishes emergency room occupancy for all 120 hospital emergency departments in Quebec, Canada, refreshed every 15 minutes from the provincial health ministry's open data, plus an hourly history going back further than the ministry's own feed, which only ever exposes the current hour. Walk-in clinic hours and provincial surgery wait lists are on the same base URL.

No key, no account, no rate limit, HTTPS only, `Access-Control-Allow-Origin: *`.

- Docs: https://sante.handled.tools/api
- `curl https://sante.handled.tools/api/now`
- `curl 'https://sante.handled.tools/api/facility/51218352/history?days=14'`

Disclosure: I run this API. It is free and stays free; there is a paid iOS app on the same data, and nothing in the API is behind it. The existing ERstat entry covers Canadian ER closures and disruptions, which is a different dataset from occupancy.
