### PR TITLE
docs: fix duplicate Markestack typo -> Mediastack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fork our official [APILayer Postman Collection](https://www.postman.com/apilayer
 ### APIs Covered Under APILayer Suite!
 
 - [IPstack](https://apilayer.com/products/ipstack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)
-- [Markestack](https://apilayer.com/products/mediastack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)
+- [Mediastack](https://apilayer.com/products/mediastack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)
 - [Aviationstack](https://apilayer.com/products/aviationstack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)
 - [Positionstack](https://apilayer.com/products/positionstack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)
 - [Mediastack](https://apilayer.com/products/mediastack?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo)


### PR DESCRIPTION
docs: fix typo where first Markestack should be Mediastack (link already points to mediastack product, second entry is correct; first was duplicate typo).