### PR TITLE
Add Helious API

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
 | [Goldprice.dev](https://goldprice.dev/docs) | Cross-validated gold, silver & copper spot, futures & 30-year history in 13 currencies | No | Yes | Unknown | |
 | [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |
+| [Helious](https://helious.io/developers/) | US Treasury auction results with the tail and bidder split, plus scored economic releases | No | Yes | Yes | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 89 countries with 121k+ BIC entries | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds Helious to **Finance**.

US Treasury auction results published seconds after each auction, including the tail and the full bidder split, plus economic releases scored against forecast on the print.

Checklist against the contributing guidelines:

- **Auth: `No`** — there is a genuinely keyless tier, not a trial. `curl https://api.helious.io/v1/rates` returns `200` with no credential and no signup. OAuth 2.1 and bearer keys exist but are optional upgrades for live data and deeper history.
- **HTTPS: Yes**
- **CORS: Yes** — verified, `access-control-allow-origin: *` on the public `/v1` surface.
- **Description: 89 characters**, within the 100 limit.
- **Alphabetical order** — inserted between `Halal Terminal` and `Helium`.
- **One link**, single squashed commit, targeted at `master`.
- Name carries no TLD and does not end in "API".
- Documentation: https://helious.io/developers/ — with an OpenAPI 3 definition at https://helious.io/.well-known/openapi-public.json

Not a marketing submission: the free tier is usable on its own for building against, without payment or a device purchase.
