### PR TITLE
Add PublicDataHub to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
 | [Pan Africa Data](https://panafricadata.com) | Macroeconomic and subnational income distribution data for all 54 African countries | `apiKey` | Yes | Unknown |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
+| [PublicDataHub](https://publicdatahub.org/api) | US public schools, hospitals and federal agency budgets as JSON/CSV, with provenance | No | Yes | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Registrum](https://api.registrum.co.uk/docs) | UK company data: profiles, directors, PSC, iXBRL-parsed financials, ECCTA status | `apiKey` | Yes | No |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds PublicDataHub to the **Open Data** section.

It publishes United States federal reference data — public schools and school districts (NCES Common Core of Data), Medicare-certified hospitals (CMS Provider Data), and federal agency budgets (USAspending) — as per-record JSON and CSV. Every response carries the agency, dataset, licence and release date that produced it.

`GET https://publicdatahub.org/api/export/hospital/mayo-clinic-hospital-rochester.json`

- **Auth `No`** — no key, no registration, no rate limit on per-record endpoints.
- **HTTPS `Yes`** — HTTPS only, HSTS preloaded.
- **CORS `Yes`** — every export sends `Access-Control-Allow-Origin: *`.

An OpenAPI 3.1 description is at https://publicdatahub.org/openapi.json and covers only the endpoints that are live; a health endpoint is at /api/status.

---

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit