### PR TITLE
Add Bidledger to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,6 +1172,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AI Law Tracker](https://ai-law-tracker.com/developers) | AI regulation laws by jurisdiction (US, EU, global) as read-only JSON; free tier | apiKey | Yes | Unknown |
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
+| [Bidledger](https://jaydemks.github.io/bidledger/api.html) | Every open public tender in the European Union, rebuilt daily from the official TED data | No | Yes | Yes |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |


### PR DESCRIPTION
Adds Bidledger to the Government category.

**What it is:** a JSON API over every open public tender in the European Union,
rebuilt each day from Tenders Electronic Daily (TED), the EU Official Journal's
procurement supplement.

- **Auth:** No — no key, no sign-up, no rate limit
- **HTTPS:** Yes
- **CORS:** Yes — `Access-Control-Allow-Origin: *`, so it works from the browser
- **Docs:** https://jaydemks.github.io/bidledger/api.html

Endpoints cover open tenders by country and by CPV division, the CPV vocabulary
itself, and a compact search index. Roughly 30,000 live notices at any time,
refreshed daily.

The Government section has US federal contracts and grants but nothing equivalent
for the EU, where the source data is public but only reachable through a portal
built for legal completeness. This fills that gap.

Data is re-used under the European Commission's open data policy; the project is
independent and not affiliated with the EU.

Checked: one API in this PR, single squashed commit, inserted in alphabetical
order, and `scripts/validate/format.py` reports no new findings against master.

---

**Update addressing @ArindamOSS's review.** The 404 was my fault: the project was
renamed from TenderPulse to Bidledger after this PR was opened, because the old
name collided with two existing products, and the old path stopped resolving.

- Link updated to https://jaydemks.github.io/bidledger/api.html — verified 200.
- The entry moved from the T's to the B's, so the alphabetical order still holds.
- Re-ran `scripts/validate/format.py`: byte-identical output to master, no new
  findings.

Sorry for the round trip.
