### PR TITLE
Add Aquanode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
+| [Aquanode](https://docs.aquanode.io/docs/api/marketplace) | Live GPU rental prices and availability across nine cloud providers | No | Yes | No |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |
 | [Base](https://www.base-api.io/) | Building quick backends | `apiKey` | Yes | Yes |
 | [Beeceptor](https://beeceptor.com/) | Build a mock Rest API endpoint in seconds | No | Yes | Yes |


### PR DESCRIPTION
## Add API

`Aquanode` — a free, unauthenticated endpoint returning live GPU rental pricing and availability aggregated across nine cloud providers (Akash, DataCrunch, Hot Aisle, Hyperstack, Massed Compute, RunPod, SimplePod, Vast.ai, Vultr).

- **Category:** Development (inserted alphabetically between APIs.guru and Azure DevOps)
- **Auth:** No
- **HTTPS:** Yes
- **CORS:** No — the endpoint sends no `Access-Control-Allow-Origin`, so it is server-side/CLI use only. This is documented on the docs page.
- **Docs:** https://docs.aquanode.io/docs/api/marketplace
- **Endpoint:** `GET https://server.aquanode.io/api/v1/marketplace`

No API key, no signup, and no purchase of any device or service is required to call it. The docs page carries the full field reference, a `curl` example, and a real response.

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit