### PR TITLE
Add TradeDataHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Tenders in Romania](https://tenders.guru/ro/api) | Get data for procurements in Romania in JSON format | No | Yes | Unknown |
 | [Tenders in Spain](https://tenders.guru/es/api) | Get data for procurements in Spain in JSON format | No | Yes | Unknown |
 | [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
+| [TradeDataHub](https://www.tradedatahub.net) | U.S. contractor datasets with a free discovery API for coverage, pricing and masked previews | No | Yes | Yes |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Yes | Unknown |
 | [Village](https://docs.village.ai) | Person and company enrichment plus warm introduction paths through your network | `apiKey` | Yes | Yes |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has a minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[TradeDataHub](https://www.tradedatahub.net) provides a free, keyless, rate-limited public discovery API (HTTPS, CORS enabled, OpenAPI 3.1 spec at https://www.tradedatahub.net/openapi.json, developer docs at https://www.tradedatahub.net/developers/) for browsing U.S. contractor dataset inventory: coverage counts, states, trades, cities, per-dataset pricing, and masked previews. The listed capability is the free discovery API only; no authentication is required for it.