### PR TITLE
feat: add ITBook.store API

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Google Books](https://developers.google.com/books/) | Books | `OAuth` | Yes | Unknown |
 | [GurbaniNow](https://github.com/GurbaniNow/api) | Fast and Accurate Gurbani RESTful API | No | Yes | Unknown |
 | [Gutendex](https://gutendex.com/) | Web-API for fetching data from Project Gutenberg Books Library | No | Yes | Unknown |
+| [ITBook.store](https://api.itbook.store) | Books with title, author, price and ISBN search | No | Yes | Yes |
 | [KDP Intelligence](https://kdp-intelligence-api.vercel.app/docs) | KDP niche demand scores, competition analysis and revenue estimates | No | Yes | Yes |
 | [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | No |
 | [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Yes |


### PR DESCRIPTION
Add ITBook.store API to Books category.

- URL: https://api.itbook.store
- Description: Books with title, author, price and ISBN search
- Auth: No
- HTTPS: Yes
- CORS: Yes

Alphabetically between Gutendex and KDP Intelligence.
