### PR TITLE
feat: add Urban Dictionary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OwlBot](https://owlbot.info/) | Definitions with example sentence and photo if available | `apiKey` | Yes | Yes |
 | [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data | `apiKey` | Yes | No |
 | [Synonyms](https://www.synonyms.com/synonyms_api.php) | Synonyms, thesaurus and antonyms information for any given word | `apiKey` | Yes | Unknown |
+| [Urban Dictionary](https://api.urbandictionary.com) | Crowdsourced slang definitions and examples | No | Yes | Yes |
 | [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
 | [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
 | [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add Urban Dictionary API to Dictionaries category.

- URL: https://api.urbandictionary.com
- Description: Crowdsourced slang definitions and examples
- Auth: No
- HTTPS: Yes
- CORS: Yes

Alphabetically between Synonyms and Wiktionary.
