### PR TITLE
feat: add CalorieNinjas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [BaconMockup](https://baconmockup.com/) | Resizable bacon placeholder images | No | Yes | Yes |
+| [CalorieNinjas](https://calorieninjas.com/api) | Nutrition and calorie data for foods and recipes | \piKey\ | Yes | Yes |
 | [Chomp](https://chompthis.com/api/) | Data about various grocery products and foods | `apiKey` | Yes | Unknown |
 | [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
 | [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add CalorieNinjas API to Food & Drink category.

- URL: https://calorieninjas.com/api
- Description: Nutrition and calorie data for foods and recipes
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes

Alphabetically between BaconMockup and Chomp.
