### PR TITLE
feat: add Official Joke API

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
 | [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |
 | [NaMoMemes](https://github.com/theIYD/NaMoMemes) | Memes on Narendra Modi | No | Yes | Unknown |
+| [Official Joke API](https://official-joke-api.appspot.com) | Random jokes with setup and punchline | No | Yes | Yes |
 | [PotterDB](https://docs.potterdb.com/) | Harry Potter universe database with characters, spells, potions and more | No | Yes | Yes |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
 | [TasteDive](https://tastedive.com/read/api) | Content-based recommendations for movies, music, TV shows, books, games, and podcasts | `apiKey` | Yes | No |


### PR DESCRIPTION
Add Official Joke API to Entertainment category. URL: https://official-joke-api.appspot.com - Random jokes. Auth: No, HTTPS: Yes, CORS: Yes. Alphabetically between NaMoMemes and PotterDB.