### PR TITLE
Add DotaSense Timings API

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Digimon TCG](https://documenter.getpostman.com/view/14059948/TzecB4fH) | Search for Digimon cards in digimoncard.io | No | Yes | Unknown |
 | [Disney](https://disneyapi.dev) | Information of Disney characters | No | Yes | Yes |
 | [Dota 2](https://docs.opendota.com/) | Provides information about Player stats , Match stats, Rankings for Dota 2 | `apiKey` | Yes | Unknown |
+| [DotaSense Timings](https://dotasense.com/cheat-sheet#timing-api) | Reviewed Dota 2 objective timings in JSON and CSV | No | Yes | Yes |
 | [Dungeons and Dragons](https://www.dnd5eapi.co/docs/) | Reference for 5th edition spells, classes, monsters, and more | No | No | No |
 | [Dungeons and Dragons (Alternate)](https://open5e.com/) | Includes all monsters and spells from the SRD (System Reference Document) as well as a search API | No | Yes | Yes |
 | [Eve Online](https://esi.evetech.net/ui) | Third-Party Developer Documentation | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## What this adds

Adds DotaSense Timings to Games & Comics as a free public data API for reviewed Dota 2 objective timings.

- Documentation: https://dotasense.com/cheat-sheet#timing-api
- JSON: https://dotasense.com/dota-2-timings.json
- CSV: https://dotasense.com/dota-2-timings.csv
- Authentication: none
- HTTPS: yes
- CORS: yes (`Access-Control-Allow-Origin: *`)
- Access: fully free; no account, installer, paid plan, or device purchase required

The documentation includes the request URLs, a browser fetch example, response fields, cache guidance, review date, scope, disclaimer, and official Valve sources used for the timing review.

Disclosure: I maintain DotaSense. This entry is for the freely accessible data endpoint itself, not the separate desktop product. I searched open and closed pull requests for an existing DotaSense submission and found none.