### PR TITLE
Add flaky API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1896,6 +1896,7 @@ API | Description | Auth | HTTPS | CORS |
 | [FakeJSON](https://fakejson.com) | Service to generate test and fake data | `apiKey` | Yes | Yes |
 | [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
 | [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |
+| [flaky](https://flakyapi.dev) | Fake REST API with chaos controls: force any status code, add latency, or a failure rate | No | Yes | Yes |
 | [GeneradorDNI](https://api.generadordni.es) | Data generator API. Profiles, vehicles, banks and cards, etc | `apiKey` | Yes | Unknown |
 | [ItsThisForThat](https://itsthisforthat.com/api.php) | Generate Random startup ideas | No | Yes | No |
 | [JSONPlaceholder](http://jsonplaceholder.typicode.com/) | Fake data for testing and prototyping | No | No | Unknown |


### PR DESCRIPTION
Adds **flaky** to the Test Data section.

https://flakyapi.dev — a fake REST API with the same resource shapes as the other entries in this section, plus per-request controls the others do not have: any status code, an added delay, or a failure rate, set from the query string.

```
GET /v1/posts?_status=503
GET /v1/posts?_delay=3000
GET /v1/posts?_fail_rate=0.3
```

- **Auth**: `No` — works with no key; a free key only raises the rate limit
- **HTTPS**: `Yes`
- **CORS**: `Yes` — `access-control-allow-origin: *`
- Free and open source (MIT): https://github.com/errohitrana2013/flaky

Checked against CONTRIBUTING before opening: description is 88 characters, alphabetical order preserved between FakeStoreAPI and GeneradorDNI, single space padding on each column, no TLD in the name, one link in this PR.