### PR TITLE
Add Ayes and Noes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [AI Law Tracker](https://ai-law-tracker.com/developers) | AI regulation laws by jurisdiction (US, EU, global) as read-only JSON; free tier | apiKey | Yes | Unknown |
+| [Ayes and Noes](https://ayesandnoes.co.uk/developers) | UK House of Commons MPs, parties and recorded votes | No | Yes | Yes |
 | [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |


### PR DESCRIPTION
Adding a free, read-only public API to the **Government** category.

- **API**: Ayes and Noes — UK House of Commons MPs, parties and recorded votes (divisions)
- **Auth**: No (keyless free tier)
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **Docs**: https://ayesandnoes.co.uk/developers · OpenAPI 3.0.3 at https://ayesandnoes.co.uk/api/v1/openapi.json

Built on official UK Parliament open data. Entry inserted alphabetically; one API in this PR per contributing guidelines.