### PR TITLE
Add Bike Reliability API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2080,6 +2080,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Auto Body Shop Directory](https://autobodyshopnear.com/developers/body-shop-api) | Find auto body shops by ZIP code, city, location, or profile | No | Yes | No |
+| [Bike Reliability](https://bikereliability.co.uk/developers) | UK motorcycle reliability ranked by first-time MOT pass rates | No | Yes | Yes |
 | [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe | No | Yes | No |
 | [CarVector](https://carvector.io/docs) | Vehicle specs, images, recalls, and DTC codes across 1925-2029 | `apiKey` | Yes | Yes |
 | [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding a free, read-only public API to the **Vehicle** category.

- **API**: Bike Reliability — UK motorcycle reliability ranked by real first-time MOT pass rates, with common failure areas
- **Auth**: No (keyless free tier)
- **HTTPS**: Yes
- **CORS**: Yes (`Access-Control-Allow-Origin: *`)
- **Docs**: https://bikereliability.co.uk/developers · OpenAPI 3.0.3 at https://bikereliability.co.uk/api/v1/openapi.json

Derived from DVSA MOT open data. Entry inserted alphabetically; one API in this PR per contributing guidelines.