### PR TITLE
Add Breed Health Score API

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ API | Description | Auth | HTTPS | CORS
 |:---|:---|:---|:---|:---|
 | [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | Resource to help get pets adopted | `apiKey` | Yes | Yes |
 | [Axolotl](https://theaxolotlapi.netlify.app/) | Collection of axolotl pictures and facts | No | Yes | No |
+| [Breed Health Score](https://breedhealthscore.com/developers/) | Dog breed health scores, median lifespans and conditions | No | Yes | No |
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
 | [Cat Facts](https://catfact.ninja/) | Random cat facts | No | Yes | Yes |
 | [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |


### PR DESCRIPTION
Adding a free, read-only public API to the **Animals** category.

- **API**: Breed Health Score — dog-breed health data: median lifespan, hereditary-condition summaries and a composite Breed Health Score (0 to 100) for 155 breeds
- **Auth**: No (keyless free tier)
- **HTTPS**: Yes
- **CORS**: No
- **Docs**: https://breedhealthscore.com/developers/ · OpenAPI 3.0.3 at https://breedhealthscore.com/api/v1/openapi.json

Data licensed CC-BY-4.0. Entry inserted alphabetically; one API in this PR per contributing guidelines.