### PR TITLE
Add Have They Invaded Yet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EOSL](https://eosl.ai/api/) | Hardware end-of-sale and end-of-service-life dates by part number, source-linked | No | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
 | [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth` | Yes | Unknown |
+| [Have They Invaded Yet](https://havetheyinvadedyet.com/data) | Current invasion-status assessments, temperatures, timestamps, and source-linked updates | No | Yes | Yes |
 | [InfraNode](https://infranode.dev) | Unified German city open data: weather, air quality, EV chargers, transit, demographics | `apiKey` | Yes | Unknown |
 | [i6eal Open AI Data](https://i6eal.de/en/tools/data/) | Open datasets on AI policy, regulation and public-sector adoption in Germany and the EU | No | Yes | Yes |
 | [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What this adds

Adds Have They Invaded Yet to the Open Data category. I maintain the submitted API.

## Requirements checked

- Free, read-only access with no account or API key
- HTTPS documentation and endpoint
- `Access-Control-Allow-Origin: *`
- JSON response with current selected conflict-status assessments, timestamps, temperatures, canonical URLs, and source-linked updates
- Description is 88 characters and the entry is placed alphabetically

Documentation: https://havetheyinvadedyet.com/data
