### PR TITLE
feat: add Dog CEO API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ API | Description | Auth | HTTPS | CORS
 | [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No | |
 | [Cat Facts](https://catfact.ninja/) | Random cat facts | No | Yes | Yes |
 | [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
+| [Dog CEO](https://dog.ceo/dog-api/) | Random dog images and breed information | No | Yes | Yes |
 | [Cats](https://docs.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
 | [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | Random dog facts | No | Yes | Yes |
 | [Dog Facts](https://kinduff.github.io/dog-api/) | Random facts of Dogs | No | Yes | Yes |


### PR DESCRIPTION
Add [Dog CEO](https://dog.ceo/dog-api/) to Animals.
- No auth, HTTPS yes, CORS yes.