### PR TITLE
Add Northstar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ API | Description | Auth | HTTPS | CORS |
 | [monerometrics](https://monerometrics.net) | Reorg-aware Monero (XMR) network metrics, mining-pool centralization and chain reorganizations | No | Yes | Yes |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [Nomics](https://nomics.com/docs/) | Historical and realtime cryptocurrency prices and market data | `apiKey` | Yes | Yes |
+| [Northstar](https://crypto.daan.gg/developers/docs) | USD pair-average tickers and candles from live exchanges | `apiKey` | Yes | Unknown |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://www.okex.com/docs/) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## What
Adds Northstar to Cryptocurrency.

Northstar is a live USD pair-average market data API (tickers and candles from exchanges). Free sandbox with an API key. Docs: https://crypto.daan.gg/developers/docs

Auth: `apiKey` (sandbox is free after signup)
HTTPS: Yes
CORS: Unknown

Placed alphabetically after Nomics.

Made with [Cursor](https://cursor.com)