### PR TITLE
add Open-Meteo to Environment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Yes | Unknown |
 | [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Yes | Unknown |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
+| [Open-Meteo](https://open-meteo.com/) | Free weather API for non-commercial use | No | Yes | Yes |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |
 | [PM25.in](http://www.pm25.in/api_doc) | Air quality of China | `apiKey` | No | Unknown |
 | [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary of Changes
- Added `Open-Meteo` to the `Environment` section in `README.md`.

## Quality Control Checklist
- [x] **Uniqueness:** Verified `Open-Meteo` is not currently listed in `README.md`.
- [x] **Alphabetization:** Inserted in strict alphabetical order between `OpenAQ` and `PM2.5 Open Data Portal`.
- [x] **Link Health:** Direct canonical link to live weather API (`https://open-meteo.com/`).
- [x] **Formatting:** Follows exact markdown table structure (`API | Description | Auth | HTTPS | CORS`).