### PR TITLE
Add Neetix Liveliness API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1737,6 +1737,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |
 | [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Yes | Unknown |
 | [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database | No | Yes | Unknown |
+| [Neetix Liveliness](https://liveliness.neetix.in/api-reference) | Face liveness, presentation-attack detection and 1:1 face match for identity verification | `apiKey` | Yes | No |
 | [Passwordinator](https://github.com/fawazsullia/password-generator/) | Generate random passwords of varying complexities | No | Yes | Yes |
 | [PhishStats](https://phishstats.info/) | Phishing database | No | Yes | Unknown |
 | [Privacy.com](https://privacy.com/developer/docs) | Generate merchant-specific and one-time use credit card numbers that link back to your bank | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds a single entry to the **Security** section (alphabetical order, between *National Vulnerability Database* and *Passwordinator*):

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| Neetix Liveliness | Face liveness, presentation-attack detection and 1:1 face match for identity verification | `apiKey` | Yes | No |

- **HTTPS:** Yes · **Auth:** `apiKey` · **CORS:** No (server-side API)
- **Free access:** self-serve sign-up grants free credits (no card, no device purchase required).
- **Docs:** https://liveliness.neetix.in/api-reference (OpenAPI reference)

Checklist:
- [x] One entry, one link, single squashed commit
- [x] Alphabetical order within the Security section
- [x] Format checked against `scripts/validate/format.py` (5 columns, description 89 chars, backticked auth, valid HTTPS/CORS)
- [x] Title does not end with "API"; no TLD in the name
- [x] Targets `master`