### PR TITLE
Add LiveTrafficCam API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2002,6 +2002,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Impala Hotel Bookings](https://docs.impala.travel/docs/booking-api/) | Hotel content, rates and room bookings | `apiKey` | Yes | No |
 | [Izi](http://api-docs.izi.travel/) | Audio guide for travellers | `apiKey` | Yes | Unknown |
 | [Land Transport Authority DataMall, Singapore](https://datamall.lta.gov.sg/content/dam/datamall/datasets/LTA_DataMall_API_User_Guide.pdf) | Singapore transport information | `apiKey` | No | Unknown |
+| [LiveTrafficCam](https://bzsasson.github.io/traffic-camera-sources/api.html) | Live US state DOT traffic cameras with verified live status and measured uptime | No | Yes | No |
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds the LiveTrafficCam public API to Transportation: live US state DOT traffic cameras (WSDOT, Caltrans, UDOT and others) as JSON, with per-camera verified live status from real HTTP checks and a measured per-state uptime endpoint. Free, no auth, no key.

Checklist per CONTRIBUTING: one link, alphabetical order kept, description 79 chars, Auth No, HTTPS Yes, CORS No (verified: no Access-Control-Allow-Origin header), single squashed commit.

Disclosure: I run this API.