### PR TITLE
Add Aviation Safety Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,6 +1983,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth` | Yes | Unknown |
 | [apilayer aviationstack](https://aviationstack.com/) | Real-time Flight Status & Global Aviation Data API | `OAuth` | Yes | Unknown |
 | [Apimetro](https://apimetro.dev/swagger/index.html) | Geospatial data for Mexico City public transport system (Metro, Metrobús, Cablebús, RTP, etc.) | No | Yes | Yes |
+| [Aviation Safety Data](https://himaxym.com/developers) | 164,068 aircraft accident narratives from 128 official investigation authorities, plus FAA data | No | Yes | Yes |
 | [AviationAPI](https://docs.aviationapi.com) | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather | No | Yes | No |
 | [AZ511](https://www.az511.com/developers/doc) | Access traffic data from the ADOT API | `apiKey` | Yes | Unknown |
 | [Bay Area Rapid Transit](http://api.bart.gov) | Stations and predicted arrivals for BART | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds **Aviation Safety Data** to the Transportation section.

- **Docs:** https://himaxym.com/developers
- **OpenAPI 3.0 spec:** https://himaxym.com/api/v1/data/openapi.json
- **Auth:** `No` — every GET endpoint answers without an `Authorization` header at the keyless tier (100 requests/day/IP). A free key raises that to 1,000/day; no purchase is required at any point.
- **HTTPS:** Yes
- **CORS:** Yes (`access-control-allow-origin: *`)

Try it with no signup:

```
curl 'https://himaxym.com/api/v1/data/events?fatal=1&limit=5'
curl 'https://himaxym.com/api/v1/data/wildlife-strikes'
```

The API is a read-only JSON layer over 164,068 accident narratives aggregated from 128 official investigation authorities (NTSB, ATSB, AAIB, BEA, MAK and national agencies), deduplicated into one occurrence-level dataset, plus the FAA wildlife-strike, laser-incident and drone-sighting datasets (US-government public domain). Every record carries its source, attribution and licence.

Checklist:
- [x] Entry added alphabetically within Transportation
- [x] Description under 100 characters
- [x] One link, one commit
- [x] Name does not end with `API` and contains no TLD