### PR TITLE
Add OpenFoot API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1868,6 +1868,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Odds-API](https://docs.odds-api.io) | Real-time sports betting odds from 265+ bookmakers across 34 sports via REST and WebSocket | `apiKey` | Yes | Yes |
 | [Oddsmagnet](https://data.oddsmagnet.com) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenF1](https://openf1.org/) | Real-time and historical Formula 1 data including laps, car telemetry and positions | No | Yes | Yes |
+| [OpenFoot API](https://openfootapi.com/docs) | Football fixtures, results, standings, lineups, live events and shot-level xG across 75 competitions | `apiKey` | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
 | [Padel Snipe](https://padelsnipe.com/fr/world/api) | 4,000+ mapped padel clubs across 9 European countries with GPS and courts | No | Yes | Yes |
 | [PlayerElo](https://playerelo.football/api-access) | Player-level Elo ratings, predictions and history for 176 football leagues | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds [OpenFoot API](https://openfootapi.com/docs) to Sports & Fitness.

Football fixtures, results, standings, lineups, live event timelines and shot-level xG across 75 competitions, built on named open-data sources.

- One row, alphabetically between `OpenF1` and `OpenLigaDB`
- Auth `apiKey` — free tier is 5,000 requests/month, no card
- HTTPS: yes. CORS: verified `access-control-allow-origin: *` on both preflight and GET before filling the column in
- Docs: https://openfootapi.com/docs · OpenAPI 3.1: https://openfootapi.com/openapi.json