### PR TITLE
Add Pangolinfo Amazon Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
 | [Octopart](https://octopart.com/api/v4/reference) | Electronic part data for manufacturing, design, and sourcing | `apiKey` | Yes | Unknown |
 | [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
+| [Pangolinfo Amazon Data](https://docs.pangolinfo.com) | Amazon product, review, search and Best Sellers data across 20+ marketplaces | `apiKey` | Yes | Unknown |
 | [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth` | Yes | Unknown |
 | [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
 | [Sparepilot](https://sparepilot.com/developers) | Spare parts catalog, OEM cross-references & price comparison for garden power equipment | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds **Pangolinfo Amazon Data** to the **Shopping** section, alphabetically after OLX Poland.

- Docs: https://docs.pangolinfo.com
- Product page: https://www.pangolinfo.com/amazon-scraper-api/
- Auth: `apiKey`
- Free tier: first 60 API requests/credits are free; no credit card required. Details: https://docs.pangolinfo.com/en-api-reference/authApi/authApi
- HTTPS: Yes
- CORS: Unknown (server-side usage)

The API returns structured JSON for Amazon product details, customer reviews, keyword search results and Best Sellers rankings across 20+ Amazon marketplaces.

Single link, single commit, description under 100 characters, name does not end in "API" and contains no TLD.