### PR TITLE
Add IBAN Analyzer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |
 | [Helium](https://heliumtrades.com/mcp-page/) | News with media bias scoring, balanced news synthesis, live market data, AI options pricing | No | Yes | Yes | |
 | [Hotstoks](https://hotstoks.com?utm_source=public-apis) | Stock market data powered by SQL | `apiKey` | Yes | Yes | |
+| [IBAN Analyzer](https://iban-analyzer.com/free-iban-api) | Resolve an IBAN to its bank name, BIC, city and address for 60+ countries | No | Yes | Yes | |
 | [IBANforge](https://api.ibanforge.com) | IBAN validation and BIC/SWIFT lookup for 89 countries with 121k+ BIC entries | `apiKey` | Yes | No |
 | [IEX Cloud](https://iexcloud.io/docs/api/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes | |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds IBAN Analyzer to the Finance section.

| Field | Value |
|---|---|
| Auth | `No` — no key, no sign-up |
| HTTPS | Yes |
| CORS | Yes |
| Docs | https://iban-analyzer.com/free-iban-api |

Resolves an IBAN to the institution behind it — bank name, BIC/SWIFT, city and address — for 60+ countries, with the validation breakdown alongside. Reference data is compiled from national registers (Deutsche Bundesbank, Oesterreichische Nationalbank, National Bank of Ukraine, Banka Slovenije, Banco de España, Národná banka Slovenska, Banco Central do Brasil, Bits AS, Finanssiala, Central Bank of Cyprus, GLEIF).

```
curl -X POST https://iban-analyzer.com/api/v1/public/analyze \
  -H "Content-Type: application/json" \
  -d '["DK4890041234567890"]'
```

Free to use with no key and no account, rate limited to 60 lookups per hour. Where no bank is held for an IBAN the response sets `bankDataAvailable: false` rather than guessing.

Checklist:
- [x] One link added
- [x] Alphabetical order within Finance (between Hotstoks and IBANforge)
- [x] Description is 73 characters
- [x] Name does not end with "API" and contains no TLD
- [x] Single squashed commit
- [x] Targets `master`