### PR TITLE
Add PayCrunch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1508,6 +1508,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
 | [Pan Africa Data](https://panafricadata.com) | Macroeconomic and subnational income distribution data for all 54 African countries | `apiKey` | Yes | Unknown |
+| [PayCrunch](https://paycrunch.co/api.html) | US wages for 1,008 occupations and by state, from BLS OEWS May 2025, static JSON, CC BY 4.0 | No | Yes | Yes |
 | [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | News articles and public datasets | `apiKey` | Yes | Unknown |
 | [PublicDataHub](https://publicdatahub.org/api) | US public schools, hospitals and federal agency budgets as JSON/CSV, with provenance | No | Yes | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Adds PayCrunch to Open Data, between Pan Africa Data and PeakMetrics.

Static JSON wage data for 1,008 US occupations: 10th percentile, median, 90th percentile, and the best-paying state for each, from the BLS Occupational Employment and Wage Statistics May 2025 release. It also returns median and 90th percentile by state for 352 occupations across 11,548 area rows, which BLS publishes only inside spreadsheets. No account, no key, no rate limit, no quota — every endpoint is a static file on a CDN. CC BY 4.0, with an OpenAPI 3.1 spec at https://paycrunch.co/openapi.json.

Auth `No` and HTTPS `Yes` are straightforward. CORS `Yes` verified today: `curl -sI -H 'Origin: https://example.com' https://paycrunch.co/api/v1/index.json` returns `access-control-allow-origin: *`.

About a quarter of the job records cover job titles BLS does not track separately. Those carry `"estimated": true` plus a disclaimer field stating they must not be cited as Bureau of Labor Statistics data, so the two kinds of record are always distinguishable from the response alone.