### PR TITLE
Add QR Codes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QR code](https://www.qrtag.net/api/) | Create an easy to read QR code and URL shortener | No | Yes | Yes |
 | [QR code](http://goqr.me/api/) | Generate and decode / read QR code graphics | No | Yes | Unknown |
 | [QR Code Crafter](https://qrcodecrafter.com/qr-code-api) | Generate static QR codes in SVG, PNG, JPG, WebP, PDF, or EPS | No | Yes | Yes |
+| [QR Codes](https://qr-api.62-238-102-93.sslip.io/docs) | Generate QR codes via a single GET request, with logo embedding and custom colors | `apiKey` | Yes | No |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds a QR code generation API to the Development section.

- REST API, single `GET /qr` request returns a PNG/JPEG/WEBP QR code
- Supports size, error correction level, foreground/background color, and logo embedding as parameters
- Free tier available (no payment method required), paid tier for higher limits
- Auth via `X-API-Key` header
- Alphabetically placed between "QR Code Crafter" and "Qrcode Monkey"