### PR TITLE
Add receivemail.dev to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ API | Description | Auth | HTTPS | CORS |
 | [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
 | [Mailtrap](https://mailtrap.io) | Email API and SMTP for sending transactional and bulk emails, with email testing sandbox for safe development | apiKey | Yes | Unknown |
 | [PostStack](https://poststack.dev/docs) | EU-hosted email API for transactional and marketing email, with contacts, broadcasts, and analytics | `apiKey` | Yes | No |
+| [receivemail.dev](https://receivemail.dev) | Disposable inbox created with one unauthenticated call; read messages with the per-mailbox token it returns | No | Yes | No |
 | [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
 | [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
 | [SMTPfast](https://smtpfa.st/docs) | Send transactional email, manage contacts and broadcasts, free 3,000 emails/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds `receivemail.dev` to the **Email** section.

- Disposable/ephemeral inbox API, in the same family as DropMail, Guerrilla Mail, mail.tm and mail.gw which are already listed.
- Fully free, no account. `POST /mailboxes` needs no authentication and returns an address plus a per-mailbox token used to read that mailbox's messages.
- HTTPS only. No CORS headers (marked `No`).
- Not device- or purchase-gated.

Format matches the existing 5-column table; entry placed alphabetically between PostStack and Sendgrid.