### PR TITLE
Add Shotanvil API

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
 | [serpstack](https://serpstack.com/) | Real-Time & Accurate Google Search Results API | `apiKey` | Yes | Yes |
 | [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey` | Yes | Unknown |
+| [Shotanvil](https://shotanvil.com) | Screenshot, PDF and HTML rendering API with a free tier, API key or x402 auth | `apiKey` | Yes | No |
 | [SHOUTCLOUD](http://shoutcloud.io/) | ALL-CAPS AS A SERVICE | No | No | Unknown |
 | [SiteIntel](https://siteintel.duckdns.org) | Extract metadata, tech stack, emails, and screenshots from any URL | `apiKey` | Yes | Unknown |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |


### PR DESCRIPTION
Adds [Shotanvil](https://shotanvil.com) to the Development category, alphabetically between Sheetsu and SHOUTCLOUD.

Shotanvil is a warm-pool Playwright screenshot/PDF/HTML-render API with a real free tier (1,000 requests/mo, no credit card), an API key auth path, and an x402 pay-per-call path (no signup). HTTPS-only. CORS is currently restricted to the product's own origins (verified live, not guessed), so the CORS column is set to `No` rather than `Unknown`.

Checked before opening this PR:
- Read CONTRIBUTING.md and the current `scripts/validate/format.py` / `scripts/validate/links.py` validators directly (not going by memory) to match the real column values/enums (`apiKey`, `Yes`/`No`/`Unknown` for CORS) and single-space segment padding.
- Ran `format.py` locally against the edited README — the added line produces zero new errors. (Note: the whole-file alphabetical-order check already reports the same 25 pre-existing category violations on current `master` before this change, confirmed by diffing against the unmodified file — this PR does not introduce or worsen any of those.)
- Ran `links.py` locally against just this PR's diff addition (mirroring `scripts/github_pull_request.sh`) — passes, 0 duplicate/broken links.
- Alphabetical placement double-checked: `SHEETSU` < `SHOTANVIL` < `SHOUTCLOUD`.
- Description is 77 characters (under the 100-char limit), capitalized, no trailing punctuation.
- No existing entry for this API.