### PR TITLE
Add XLSX Inspector API (Development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Web Metadata & Contact Extractor](https://rapidapi.com/josejuanjocoding/api/web-metadata-and-contact-extractor) | Extract SEO metadata, contact emails, social links, and tech stack (<200ms) | `apiKey` | Yes | Yes |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
+| [XLSX Inspector](https://api.lifestep.io) | Inspect the structure of XLSX/XLSM spreadsheets (sheets, formulas, macros, external links) without executing them | No | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 
 

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Web Metadata & Contact Extractor](https://rapidapi.com/josejuanjocoding/api/web-metadata-and-contact-extractor) | Extract SEO metadata, contact emails, social links, and tech stack (<200ms) | `apiKey` | Yes | Yes |
 | [Webclaw](https://webclaw.io/docs/api) | Web content extraction for LLMs with scrape, crawl, search, and summarize | `apiKey` | Yes | Yes |
 | [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey` | Yes | Yes |
-| [XLSX Inspector](https://api.lifestep.io) | Inspect the structure of XLSX/XLSM spreadsheets (sheets, formulas, macros, external links) without executing them | No | Yes | Yes |
+| [XLSX Inspector](https://api.lifestep.io) | Inspect XLSX/XLSM structure: sheets, formulas, macros and external links | No | Yes | Yes |
 | [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey` | Yes | Unknown |
 
 


### PR DESCRIPTION
## Adding XLSX Inspector API

https://api.lifestep.io — a free, read-only API that inspects the structure of XLSX/XLSM spreadsheets (sheet names + hidden state, formula counts, cached errors, merged ranges, external links, macro presence) without opening Excel, recalculating formulas, or executing VBA.

- Auth: No
- HTTPS: Yes
- CORS: Yes
- Live: `GET /health`, `POST /inspect`, OpenAPI at `/openapi.json`, docs at `/docs`

Added alphabetically to the Development category.