### PR TITLE
Add Mycelium (corporate carbon emissions) to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |
 | [kanari](https://kanari.io/en/api) | Real-time worldwide wildfire detections, water bomber tracking and open fire archive | No | Yes | Yes |
 | [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Yes | Unknown |
+| [Mycelium](https://api.mycelium.global/docs/v1) | Corporate carbon emissions disclosures (scope 1, 2 and 3), company-reported and estimated | `apiKey` | Yes | Unknown |
 | [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Yes | Unknown |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Mycelium](https://api.mycelium.global/docs/v1) to the Environment section: an open database of corporate carbon emissions disclosures (scope 1, 2 and 3), covering both company-reported figures and modelled estimates, searchable by name, LEI, ISIN or registration number. Free API keys on request. OpenAPI spec: https://api.mycelium.global/openapi/v1.json

- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or PRs
- [x] Any category I am creating has the minimum requirement of 3 items