### PR TITLE
Update Currents API entry: free tier is now 250 requests/day

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,7 +1450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mediastack](https://mediastack.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Free, Simple REST API for Live News & Blog Articles | `apiKey` | Yes | Unknown |
 | [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
 | [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
-| [Currents](https://currentsapi.services/) | Real-time and historical global news with multilingual support | `apiKey` | Yes | Yes |
+| [Currents](https://currentsapi.services/) | Real-time and historical global news with multilingual support. Free tier: 250 requests/day, commercial use allowed | `apiKey` | Yes | Yes |
 | [DataCube AI](https://www.datacubeai.space/en/tools/ai-news-api) | Daily curated AI industry news, funding rounds and trends in 8 languages | No | Yes | No |
 | [Feedbin](https://github.com/feedbin/feedbin-api) | RSS reader | `OAuth` | Yes | Unknown |
 | [Florida Man](https://github.com/juliayxhuang/florida-man-api#readme) | Static JSON dataset of 10,000+ Florida Man headlines by date | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1450,7 +1450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mediastack](https://mediastack.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Free, Simple REST API for Live News & Blog Articles | `apiKey` | Yes | Unknown |
 | [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
 | [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
-| [Currents](https://currentsapi.services/) | Real-time and historical global news with multilingual support. Free tier: 250 requests/day, commercial use allowed | `apiKey` | Yes | Yes |
+| [Currents](https://currentsapi.services/) | Real-time and historical global news with multilingual support. Free tier: 250 requests/day | `apiKey` | Yes | Yes |
 | [DataCube AI](https://www.datacubeai.space/en/tools/ai-news-api) | Daily curated AI industry news, funding rounds and trends in 8 languages | No | Yes | No |
 | [Feedbin](https://github.com/feedbin/feedbin-api) | RSS reader | `OAuth` | Yes | Unknown |
 | [Florida Man](https://github.com/juliayxhuang/florida-man-api#readme) | Static JSON dataset of 10,000+ Florida Man headlines by date | No | Yes | Yes |


### PR DESCRIPTION
The Currents API free tier is now **250 requests/day** (UTC reset).

Sources (official):
- Pricing: https://currentsapi.services/en/product/price
- Docs: https://currentsapi.services/en/docs/

This PR only updates the existing entry's description to reflect the current published quota. Display and reuse of news content remain subject to current Terms and publisher permissions; this PR makes no separate rights claim.