### PR TITLE
Add x402-list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScriptMasterLabs x402](https://acp-x402-scriptmasterlabs.onrender.com) | 100+ SEC, DeFi, crypto, and macro endpoints for AI agents via x402 micropayments | `apiKey` | Yes | Yes |
 | [ScriptMasterLabs MCP](https://mcp-x402.onrender.com) | Model Context Protocol server with web search, social search & LLM chat paid via x402 | `apiKey` | Yes | Yes |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+| [x402-list](https://x402-list.com) | Directory of paid x402 APIs vetted before an agent pays, with on-chain settlement data | No | Yes | Yes |
 | [Zennet](https://zennet.cloud) | x402 pay-per-use APIs: Polymarket signals, CEX/DEX spreads, contract risk scores, gas oracle | No | Yes | Yes |
 | [ZMOK](https://zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 


### PR DESCRIPTION
Adds x402-list to the Cryptocurrency section.

x402-list.com is a directory of paid x402 APIs. It checks the health and
per-endpoint USD pricing of each service before an agent pays one, and reports
on-chain settlement volume verified from the facilitators.

The directory itself exposes a free public REST API with no authentication for
reads (see https://x402-list.com/api). Auth: No. HTTPS: Yes. CORS: Yes
(Access-Control-Allow-Origin: * on the JSON endpoints).

Checklist:
- One link added (single entry).
- Placed in Cryptocurrency in alphabetical order (between WorldCoinIndex and Zennet).
- Columns padded with one space per side.
- Description under 100 characters.
- Name does not include the TLD and does not end with "API".
- API is publicly reachable and documented.
