### PR TITLE
Add MadeOnSol API

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [Localbitcoins](https://localbitcoins.com/api-docs/) | P2P platform to buy and sell Bitcoins | No | Yes | Unknown |
+| [MadeOnSol](https://madeonsol.com/developer) | Real-time Solana & Robinhood Chain KOL trades, deployer reputation, and DEX activity | `apiKey` | Yes | Yes |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |


### PR DESCRIPTION
Adds MadeOnSol to the Cryptocurrency section.

- Real-time Solana + Robinhood Chain KOL trades, deployer reputation, and DEX activity API
- Auth: apiKey
- HTTPS: Yes
- CORS: Yes (`Access-Control-Allow-Origin: *`)
- Free tier available (5-minute delayed feeds), paid tiers for real-time
- Docs: https://madeonsol.com/developer