### PR TITLE
Add SSL & Site Health Monitor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ API | Description | Auth | HTTPS | CORS |
 | [SiteIntel](https://siteintel.duckdns.org) | Extract metadata, tech stack, emails, and screenshots from any URL | `apiKey` | Yes | Unknown |
 | [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |
 | [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
+| [SSL & Site Health Monitor](https://rapidapi.com/lele25896/api/ssl-site-health-monitor) | SSL certificate expiry, uptime, and response time for any domain in one call | `apiKey` | Yes | Unknown |
 | [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
 | [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
 | [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds SSL & Site Health Monitor to the Development category (alphabetically placed after SonarQube).

- Single-call domain health check: SSL certificate validity/expiry, uptime, and response time
- Free tier available (no purchase/device required), HTTPS, auth via apiKey