### PR TITLE
Add aikstockdata (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Marketstack](https://marketstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-Time, Intraday & Historical Market Data API | `apiKey` | Yes | Unknown | |
+| [aikstockdata](https://aikstockdata.com/en/api) | KOSPI/KOSDAQ/KONEX daily settled closes, DART filings with receipt times, quarterly earnings | No | Yes | Yes | |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes | |
 | [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | Realtime and historical market data on all US equities and ETFs | `apiKey` | Yes | Yes | |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds one entry to **Finance**, in alphabetical position (before Aletheia).

```
| [aikstockdata](https://aikstockdata.com/en/api) | KOSPI/KOSDAQ/KONEX daily settled closes, DART filings with receipt times, quarterly earnings | No | Yes | Yes | |
```

Korean equities data as plain static JSON. No signup and no API key — the files are pre-built and served from a CDN, so there is nothing to register for and nothing to buy. Derived from Korean government open data: the Financial Services Commission open-data portal (settled closing prices) and the FSS DART filing system. Terms: Non-commercial use with attribution; commercial redistribution is not permitted.

Checked against CONTRIBUTING before opening this:

- **Auth: No** — verified; no credential of any kind is accepted or needed.
- **HTTPS: Yes**
- **CORS: Yes** — verified, `Access-Control-Allow-Origin: *` on `/data/public/today.json` and `/openapi.json`.
- **Description: 92 characters** (limit 100).
- Alphabetical position kept.
- Not a marketing attempt: there is no paid tier, no device to buy, and no account. The whole dataset is downloadable.

Try it without any setup:

```
curl -s https://aikstockdata.com/data/public/today.json
curl -s https://aikstockdata.com/data/public/s/005930.json
```

OpenAPI 3.1 spec: https://aikstockdata.com/openapi.json · catalog of every endpoint with sizes and freshness: https://aikstockdata.com/data/public/index.json
