### PR TITLE
Add SMHI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2209,6 +2209,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QWeather](https://dev.qweather.com/en/) | Location-based weather data | `apiKey` | Yes | Yes |
 | [Rainbow Weather](https://developer.rainbow.ai/) | Global real-time nowcasting API powered by radar + satellite fusion | `apiKey` | Yes | Unknown |
 | [RainViewer](https://www.rainviewer.com/api.html) | Radar data collected from different websites across the Internet | No | Yes | Unknown |
+| [SMHI](https://opendata.smhi.se/metfcst/snow1gv1) | Weather forecasts and warnings from Sweden | No | Yes | Yes |
 | [Storm Glass](https://stormglass.io/) | Global marine weather from multiple sources | `apiKey` | Yes | Yes |
 | [Tomorrow](https://docs.tomorrow.io) | Weather API Powered by Proprietary Technology | `apiKey` | Yes | Unknown |
 | [US Weather](https://www.weather.gov/documentation/services-web-api) | US National Weather Service | No | Yes | Yes |


### PR DESCRIPTION
Add [SMHI](https://opendata.smhi.se/metfcst/snow1gv1) to Weather, alphabetically between RainViewer and Storm Glass.

- Free, no auth
- HTTPS: Yes, CORS: Yes (Access-Control-Allow-Origin: * observed)
- Docs: current SNOW1gv1 endpoint (old pmp3g retired 2026-03-31)