### PR TITLE
Add MSC GeoMet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2198,6 +2198,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Meltema](https://meltema.com/docs) | Multi-model weather: GFS, ECMWF AIFS/IFS and a 31-member GEFS ensemble, keyless point forecasts | No | Yes | No |
 | [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
 | [Micro Weather](https://m3o.com/weather/api) | Real time weather forecasts and historic data | `apiKey` | Yes | Unknown |
+| [MSC GeoMet](https://eccc-msc.github.io/open-data/msc-geomet/readme_en/) | Canadian weather, climate and water data via OGC web services | No | Yes | Yes |
 | [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
 | [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |
 | [Open-Meteo](https://open-meteo.com/) | Global weather forecast API for non-commercial use | No | Yes | Yes |


### PR DESCRIPTION
Add [MSC GeoMet](https://eccc-msc.github.io/open-data/msc-geomet/readme_en/) to Weather, alphabetically between Micro Weather and ODWeather.

- Free, no auth (docs: access is anonymous and free of charge)
- HTTPS: Yes, CORS: Yes