### PR TITLE
Add Semantic Scholar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OrbitalWiki](https://orbitalwiki.com/developers) | Catalog of 16,000+ satellites merging CelesTrak, GCAT, Wikidata; free tier included | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
+| [Semantic Scholar](https://api.semanticscholar.org/api-docs/) | Scientific papers, authors, citations and recommendations | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
 | [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
 | [SpaceX](https://api.spacex.land/graphql/) | GraphQL, Company, Ships, launchpad and launch data | No | Yes | Unknown |


### PR DESCRIPTION
Add [Semantic Scholar](https://api.semanticscholar.org/api-docs/) to Science & Math, alphabetically between Remote Calc and SHARE.

- Free, no auth (most endpoints public without authentication)
- HTTPS: Yes, CORS: Yes
- Complements the listed arXiv, OpenAlex and CORE entries