### PR TITLE
Add Open Source Insights API

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ API | Description | Auth | HTTPS | CORS |
 | [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) | Query information about your favorite Node.js libraries programatically | No | Yes | Unknown |
 | [OneSignal](https://documentation.onesignal.com/docs/onesignal-api) | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App | `apiKey` | Yes | Unknown |
 | [Open Page Rank](https://www.domcop.com/openpagerank/) | API for calculating and comparing metrics of different websites using Page Rank algorithm | `apiKey` | Yes | Unknown |
+| [Open Source Insights](https://docs.deps.dev/api/v3/) | Dependency versions, licenses, advisories and provenance | No | Yes | Yes |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |
 | [OpenQR](https://openqr.uk/api) | Generate QR codes and manage dynamic (editable) QR codes with scan analytics | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Add [Open Source Insights](https://docs.deps.dev/api/v3/) to Development, alphabetically between Open Page Rank and OpenAPIHub.

- Free, no auth (keyless documented examples verified)
- HTTPS: Yes, CORS: Yes