### PR TITLE
Add OSV API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,6 +1754,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Yes | Unknown |
 | [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database | No | Yes | Unknown |
 | [Neetix Liveliness](https://liveliness.neetix.in/api-reference) | Face liveness, presentation-attack detection and 1:1 face match for identity verification | `apiKey` | Yes | No |
+| [OSV](https://osv.dev/docs/) | Distributed vulnerability database for open source software | No | Yes | Yes |
 | [Passwordinator](https://github.com/fawazsullia/password-generator/) | Generate random passwords of varying complexities | No | Yes | Yes |
 | [PhishStats](https://phishstats.info/) | Phishing database | No | Yes | Unknown |
 | [Privacy.com](https://privacy.com/developer/docs) | Generate merchant-specific and one-time use credit card numbers that link back to your bank | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Add [OSV](https://osv.dev/docs/) to Security, alphabetically between Neetix Liveliness and Passwordinator.

- Free, no auth (keyless queries verified)
- HTTPS: Yes, CORS: Yes
- Sits next to the listed NVD and VulDB entries