### PR TITLE
Add Auregistre API

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
+| [Auregistre](https://auregistre.fr/api) | French company history since 2008 from the BODACC gazette: filings, insolvencies, no key required | No | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |


### PR DESCRIPTION
Free, public REST API for French company history (BODACC filings, insolvency openings) since 2008. No key, no account, rate limited by IP. OpenAPI at https://auregistre.fr/api/openapi.json.