### PR TITLE
Add OuterCheck (free, no-auth, HTTPS, public API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OpenQR](https://openqr.uk/api) | Generate QR codes and manage dynamic (editable) QR codes with scan analytics | `apiKey` | Yes | Yes |
 | [Orca Scan](https://orcascan.com/guides/free-barcode-image-api-0e4a4fa6) | Generate barcode images (QR, Code 128, EAN, Data Matrix and more) in SVG, PNG, JPG or PDF | No | Yes | Yes |
 | [OutageDeck](https://outagedeck.com/developers/api) | Live status and incidents for 170+ cloud and SaaS providers from official feeds | No | Yes | Yes |
+| [OuterCheck](https://outercheck.com) | Free external verification of a public website's observable state: DNS, TLS, robots, indexability and HTML checks with evidence-first JSON | No | Yes | No |
 | [oyyi](https://oyyi.xyz/docs/1.0) | API for Fake Data, image/video conversion, optimization, pdf optimization and thumbnail generation | No | Yes | Yes |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database for 263 devices | No | Yes | Yes |


### PR DESCRIPTION
Hi! I'm one of the maintainers of OuterCheck.

OuterCheck is a free, self-serve public API that verifies a website the way the outside web sees it: DNS, TLS, robots.txt, indexability and HTML checks, with evidence-first JSON and recheck support. No sign-up and no key required, HTTPS, rate-limited, machine-readable (OpenAPI + llms.txt).

It fits the 'Development' list alongside similar public observability APIs (DownStatus, Host.io, OutageDeck). The entry follows the required format. Happy to adjust anything.