### PR TITLE
Add gridcarbon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API calculates the impact of common carbon-intensive activities in real time | `apiKey` | Yes | Unknown |
 | [CO2 Offset](https://co2offset.io/api.html) | API calculates and validates the carbon footprint | No | Yes | Unknown |
 | [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Yes | Unknown |
+| [gridcarbon](https://gridcarbon.dev) | Hourly grid carbon intensity in gCO2eq/kWh for 45 zones in Europe, the US and Great Britain | No | Yes | Yes |
 | [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |
 | [kanari](https://kanari.io/en/api) | Real-time worldwide wildfire detections, water bomber tracking and open fire archive | No | Yes | Yes |


### PR DESCRIPTION
Adds **gridcarbon** under Environment.

- Hourly grid carbon intensity in gCO2eq/kWh for 45 zones: 33 European bidding zones (ENTSO-E), 11 US balancing authorities (EIA-930) and Great Britain (NESO).
- Free, no authentication, HTTPS, CORS enabled (`Access-Control-Allow-Origin: *`).
- Docs: https://gridcarbon.dev — OpenAPI 3.1 at https://gridcarbon.dev/openapi.json, methodology and known biases at https://gridcarbon.dev/methodology.
- Example: `curl -s "https://api.gridcarbon.dev/v1/intensity/latest?zone=FR"`
- Public Postman collection (generated from the OpenAPI description): https://www.postman.com/gridcarbon/gridcarbon/collection/o5gdul1/gridcarbon

Disclosure: I run this API. One-person side project; the data is CC BY 4.0.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically (between "Danish data service Energi" and "GrünstromIndex")
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (92)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category)
- [x] All changes have been squashed into a single commit
