### PR TITLE
Add Modelfax API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MediaCraft AI](https://mediacraft-x402-api.onrender.com) | Chinese content compliance review (17 platforms), EN↔CN translation, and SEO optimization. Pay-per-call via x402 (Solana USDC). | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
+| [Modelfax](https://bytebrujo.github.io/modelfax/) | LLM pricing, context windows and deprecation dates, schema-validated and updated daily | No | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
 | [Not Human Search](https://nothumansearch.ai/openapi.yaml) | AI tool discovery with agentic scoring for 8,600+ tools and MCP servers | No | Yes | Yes |
 | [OpenVisionAPI](https://openvisionapi.com) | Open source computer vision API based on open source models | No | Yes | Yes |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Adds Modelfax to **Machine Learning**, between `MessengerX.io` and `NLP Cloud`.

A free, no-auth JSON API for AI model pricing, context windows, and lifecycle dates across OpenAI, Anthropic and Google. The API is static JSON served over HTTPS with open CORS, so it can be fetched straight from a browser:

```
https://bytebrujo.github.io/modelfax/data/openai.json
https://bytebrujo.github.io/modelfax/data/anthropic.json
https://bytebrujo.github.io/modelfax/data/google.json
```

Every record validates against a published JSON Schema, and each one cites the provider page it was read from plus the date it was last verified. The section already has entries covering current LLM prices; what this adds is the lifecycle half, deprecation and retirement dates, which is what tells you when a model you depend on stops answering.

No keys, no rate limits, no signup. Code is MIT, data is CC-BY-4.0.