### PR TITLE
feat: add crt.sh API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Classify](https://classify-web.herokuapp.com/#/api) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
+| [crt.sh](https://crt.sh/) | Certificate Transparency search for subdomains and cert history | No | Yes | Yes |
 | [CSR.plus](https://csr.plus/docs/api) | Generate certificate signing requests and private keys without OpenSSL | No | Yes | Yes |
 | [dead-drop](https://api.dead-drop.xyz/api/v1/docs) | Ephemeral zero-knowledge encrypted data sharing | No | Yes | Yes |
 | [Dehash.lt](https://github.com/Dehash-lt/api) | Hash decryption MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |


### PR DESCRIPTION
Add [crt.sh](https://crt.sh/) to the Security section, placed alphabetically between CRXcavator and CSR.plus.

Entry:
`| [crt.sh](https://crt.sh/) | Certificate Transparency search for subdomains and cert history | No | Yes | Yes |`

- Free, no auth, HTTPS + CORS enabled
- Certificate Transparency log search for subdomains and certificate history
