### PR TITLE
Add KmalServico Gold Price Dataset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown | |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown | |
 | [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown | |
+| [KmalServico Gold Price Dataset](https://www.kmalservico.com/data) | Current gold price per gram at 6 purities for 188 countries, JSON, no auth | No | Yes | No |
 | [LiquiLens](https://liquilens.in/developers/) | Public-record bank and lender failure-risk evidence | No | Yes | Yes |
 | [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown | |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown | |


### PR DESCRIPTION
Adds the KmalServico Gold Price Dataset to the Finance section.

The dataset provides current gold price per gram at six purities (24K, 22K, 21K, 18K, 14K, and 10K) for 188 countries.

Access is free, requires no authentication, and uses HTTPS. CORS is not currently supported.

Documentation: https://www.kmalservico.com/data