### PR TITLE
Add US Mortgage Calculator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Top 5 Stocks](https://top5stocks.netlify.app/developers) | Daily AI-ranked stock and crypto watchlists | No | Yes | Unknown | |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth` | Yes | Yes | |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |
+| [US Mortgage Calculator](https://www.usmortgagecalc.com/developers/api) | Mortgage payment, amortization, affordability and 50-state property tax data | No | Yes | Yes | |
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |
 | [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets Stock Comments Sentiment Analysis | No | Yes | Unknown | |
 | [Yahoo Finance](https://www.yahoofinanceapi.com/) | Real time low latency Yahoo Finance API for stock market, crypto currencies, and currency exchange | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

---

Adds a free US mortgage calculation API to the **Finance** section.

| | |
|---|---|
| Documentation | https://www.usmortgagecalc.com/developers/api |
| OpenAPI | https://www.usmortgagecalc.com/openapi.json |
| Auth | None — no key, no signup, no rate limit |
| HTTPS | Yes |
| CORS | Yes |

Endpoints cover monthly payment and amortization, affordability, refinance break-even, closing costs, PMI and MIP, and property tax reference data for all fifty states. The state data is also published under CC BY 4.0.

Checks run before opening this PR:

- No mortgage or amortization API is currently listed anywhere in the README.
- Alphabetical position is between **Twelve Data** and **VAT Validation**.
- Description is 76 characters and does not end with punctuation.
- `scripts/validate/format.py` reports no errors on the added line, and the repository's total error count is unchanged: 562 before, 562 after.
- HTTPS, CORS and the no-auth behaviour were confirmed by calling the live endpoint cross-origin from a third-party page, rather than assumed from documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WY6ZEBhp1yhG6ktdHHEv3