### PR TITLE
Add BTU Graph API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,6 +1495,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
+| [BTU Graph](https://btugraph.com/data/) | Source-reviewed energy company knowledge graph and directory exports | No | Yes | Yes |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |


### PR DESCRIPTION
Adds one no-auth, HTTPS, CORS-enabled public data API to the Open Data category. The linked documentation exposes versioned JSON/CSV graph data, provenance, a data dictionary, OpenAPI 3.1, and the CC BY 4.0 license scope.\n\nVerified live:\n- `GET https://btugraph.com/graph.json` returns the current 214-node, 900-edge snapshot\n- `GET https://btugraph.com/companies.csv` returns 50 company records\n- CORS response: `Access-Control-Allow-Origin: *`\n- No account or paid service is required