### PR TITLE
Remove Chuck Norris Database API (domain repurposed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,7 +988,6 @@ API | Description | Auth | HTTPS | CORS |
 | [Call of Duty Mobile](https://callofdutymobile.vercel.app/)                                 | Unofficial API for CODM player data and daily cache claiming                                        | No              | Yes   | Unknown |
 | [CheapShark](https://www.cheapshark.com/api) | Steam/PC Game Prices and Deals | No | Yes | Yes |
 | [Chess.com](https://www.chess.com/news/view/published-data-api) | Chess.com read-only REST API | No | Yes | Unknown |
-| [Chuck Norris Database](http://www.icndb.com/api/) | Jokes | No | No | Unknown |
 | [Clash of Clans](https://developer.clashofclans.com) | Clash of Clans Game Information | `apiKey` | Yes | Unknown |
 | [Clash Royale](https://developer.clashroyale.com) | Clash Royale Game Information | `apiKey` | Yes | Unknown |
 | [Comic Vine](https://comicvine.gamespot.com/api/documentation) | Comics | No | Yes | Unknown |


### PR DESCRIPTION
removed:
| [Chuck Norris Database](http://www.icndb.com/api/) | Jokes | No | No | Unknown |

as the site is no longer a Chuck Norris jokes site but a gambling site