### PR TITLE
Add CaptureWeb - web rendering API for screenshots, PDFs, markdown, and AI extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping with a simple API | `apiKey` | Yes | Unknown |
 | [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey` | Yes | Unknown |
 | [Scrax](https://rapidapi.com/mtaahoperators/api/scrax) | Web scraping API that only bills for successful scrapes | `apiKey` | Yes | Unknown |
+| [CaptureWeb](https://captureweb.dev) | Screenshots, PDFs, Markdown, HTML, links, brand assets, and AI extraction from any URL | `apiKey` | Yes | Yes |
 | [Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey` | Yes | Yes |
 | [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |


### PR DESCRIPTION
## API Description

**[CaptureWeb](https://captureweb.dev)** is a web rendering API for developers and AI agents. One API key for:

- Screenshots (PNG, JPEG, WebP)
- PDFs from URL or raw HTML
- Markdown & HTML extraction
- Link extraction
- Brand asset extraction (logo, colors, fonts)
- Structured JSON extraction with AI
- Full site crawls

**Auth:** API key  
**HTTPS:** Yes  
**CORS:** Yes  
**Free tier:** 100 credits/month, no credit card required

## Checklist

- [x] Entry is alphabetically sorted within its category
- [x] Entry follows the format: `| [Name](link) | Description | Auth | HTTPS | CORS |`
- [x] Description is clear and under 100 characters
- [x] API has documentation
- [x] API is publicly accessible