### PR TITLE
Add KPainter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2142,6 +2142,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IMDb-API](https://imdb-api.com/) | API for receiving movie, serial and cast information | `apiKey` | Yes | Unknown |
 | [IMDbOT](https://github.com/SpEcHiDe/IMDbOT) | Unofficial IMDb Movie / Series Information | No | Yes | Yes |
 | [JSON2Video](https://json2video.com) | Create and edit videos programmatically: watermarks,resizing,slideshows,voice-over,text animations | `apiKey` | Yes | No |
+| [KPainter](https://api.kpainter.ai/openapi/v1/docs) | Create video, image, and interactive app outputs from prompts or source files | `apiKey` | Yes | Yes |
 | [KinoPipe](https://kinopipe.com/docs) | Typed hosted video editing operations for agents and automation | `apiKey` | Yes | No |
 | [Lucifer Quotes](https://github.com/shadowoff09/lucifer-quotes) | Returns Lucifer quotes | No | Yes | Unknown |
 | [MCU Countdown](https://github.com/DiljotSG/MCU-Countdown) | A Countdown to the next MCU Film | No | Yes | Yes |


### PR DESCRIPTION
Adds KPainter to the Video category. The linked OpenAPI documentation describes authenticated creation of video, image, and interactive app outputs from prompts or source files.

- [x] Formatted according to the contributing guide
- [x] Ordered alphabetically
- [x] Useful description under 100 characters, without terminal punctuation
- [x] Table columns are padded
- [x] Checked for relevant issues and pull requests
- [x] Single squashed commit