### PR TITLE
Speed up link validation using concurrent.futures.ThreadPoolExecutor

### DIFF
--- a/scripts/validate/links.py
+++ b/scripts/validate/links.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import random
+import concurrent.futures
 from typing import List, Tuple
 
 import requests
@@ -200,11 +201,16 @@ def check_if_link_is_working(link: str) -> Tuple[bool, str]:
 
 def check_if_list_of_links_are_working(list_of_links: List[str]) -> List[str]:
     error_messages = []
-    for link in list_of_links:
-        has_error, error_message = check_if_link_is_working(link)
-
-        if has_error:
-            error_messages.append(error_message)
+    
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        # Submit all tasks to the executor
+        future_to_link = {executor.submit(check_if_link_is_working, link): link for link in list_of_links}
+        
+        # Iterate over the results as they complete
+        for future in concurrent.futures.as_completed(future_to_link):
+            has_error, error_message = future.result()
+            if has_error:
+                error_messages.append(error_message)
 
     return error_messages
 


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My addition is ordered alphabetically
- [ ] My submission has a useful description
- [ ] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [ ] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

*(Note: Most checkboxes are unchecked because this PR modifies a script, not the API list).*

---

### Description
This PR speeds up the `scripts/validate/links.py` validation script. 

Instead of checking all 1,500+ links sequentially, it now uses Python's built-in `concurrent.futures.ThreadPoolExecutor` (with `max_workers=20`) to process the links concurrently. This drastically reduces the CI validation time without overwhelming remote servers. 

Tested locally via unit tests and against the full `README.md`.

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
