### PR TITLE
Add L2 Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes | Yes |
 | [Jservice](http://jservice.io) | Jeopardy Question Database | No | No | Unknown |
 | [KrakenKeys](https://krakenkeys.com/api-docs) | Steam game key price comparison across 20+ stores, deals, and price history | `apiKey` | Yes | No |
-| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
+| [L2 Calendar](https://l2calendar.com/api/servers) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes | Yes |
 | [Jservice](http://jservice.io) | Jeopardy Question Database | No | No | Unknown |
 | [KrakenKeys](https://krakenkeys.com/api-docs) | Steam game key price comparison across 20+ stores, deals, and price history | `apiKey` | Yes | No |
+| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
 | [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
 | [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | API for Drivers, Karts, Gliders and Courses | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
## API Addition

**API Name:** L2 Calendar API
**Link:** https://l2calendar.com/api/servers
**Category:** Games & Comics

### Description
Public JSON API listing Lineage 2 private servers with names, websites, chronicles (Interlude, High Five, Classic, Essence...), rates and opening dates. Useful for game server trackers, community tools and L2 player dashboards.

### Checklist
- [x] Free access, no auth required
- [x] HTTPS supported
- [x] CORS enabled (Access-Control-Allow-Origin: *)
- [x] Data is public (same servers listed on the site homepage)
- [x] Inserted alphabetically (between Jservice and Lichess)

Verified live: 464 servers, application/json, stable endpoint.