### PR TITLE
Update Futures Clock description in Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |
-| [Futures Clock](https://futuresclock.com/en/data-methodology/#open-data) | Trading hours and session windows for 65 futures products on 16 global exchanges | No | Yes | Yes | |
+| [Futures Clock](https://futuresclock.com/en/data-methodology/#open-data) | Trading hours, sessions and reviewed holiday calendars for 69 futures contracts on 14 exchanges | No | Yes | Yes | |
 | [FXNewsBias](https://fxnewsbias.com/developers) | AI-scored news sentiment for the 8 major forex currencies, refreshed every 3 hours | `apiKey` | Yes | Yes | |
 | [Goldprice.dev](https://goldprice.dev/docs) | Cross-validated gold, silver & copper spot, futures & 30-year history in 13 currencies | No | Yes | Unknown | |
 | [Halal Terminal](https://api.halalterminal.com/docs) | Shariah-compliant stock and ETF screening across 5 methodologies, zakat and purification | `apiKey` | Yes | Yes | |


### PR DESCRIPTION
Refreshes the existing Futures Clock entry in the Finance table to its current coverage: 69 futures contracts on 14 exchanges (CME, COMEX, NYMEX, ICE, LME, Eurex, SGX, OSE and China's CFFEX/SHFE/DCE/CZCE/INE/GFEX), and mentions the reviewed holiday calendars the endpoint now carries. Link, Auth (No), HTTPS (Yes) and CORS (Yes) are unchanged; description stays under 100 characters. Free, keyless, no prices or quotes.

Endpoint: https://futuresclock.com/data/trading-hours.json — field reference: https://futuresclock.com/en/data-methodology/#open-data