### PR TITLE
Add FraudCoins API

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ API | Description | Auth | HTTPS | CORS |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |
+| [FraudCoins](https://fraudcoins.com/data/) | On-chain top-10 holder concentration and contract permissions for crypto tokens | No | Yes | Yes |
 | [Gateio](https://www.gate.io/api2) | API provides spot, margin and futures trading operations | `apiKey` | Yes | Unknown |
 | [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |
 | [Hirak Exchange Rates](https://rates.hirak.site/) | Exchange rates between 162 currency & 300 crypto currency update each 5 min, accurate, no limits | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds FraudCoins to the Cryptocurrency section.

**What it provides:** on-chain top-10 holder concentration per token, corrected by classifying exchange, market-maker, treasury, liquidity-pool, staking, bridge, multisig and burn wallets out of the count — plus the specific wallets excluded from each figure, and owner-permission data for token contracts.

**Meets the contribution requirements:**

| Requirement | Status |
| --- | --- |
| Free access | Yes — fully free, no paid tier, no account, no device purchase |
| Auth | `No` — no key or registration |
| HTTPS | Yes |
| CORS | Yes — `Access-Control-Allow-Origin: *` on all JSON endpoints |
| Rate limit | None |
| Alphabetical order | Inserted between EXMO and Gateio |
| Description length | 79 characters (limit 100) |
| Links added | 1 |
| No TLD in name | "FraudCoins" |

**Verify without an account:**

```
curl https://fraudcoins.com/dataset/v1/index.json      # discovery: all endpoints
curl https://fraudcoins.com/concentration.json          # holder concentration
curl -I https://fraudcoins.com/concentration.json       # shows CORS + CC BY licence header
```

Documentation: https://fraudcoins.com/data/
Licence: CC BY 4.0 · archived with DOI [10.5281/zenodo.22494421](https://doi.org/10.5281/zenodo.22494421)

Not a marketing submission — there is no paid product. The dataset is published openly under CC BY 4.0 and mirrored at https://github.com/devhumancode/fraudcoins-dataset.

I ran `scripts/validate/format.py` locally: 563 errors before and after this change (all pre-existing, on table separator rows), none on the added line.