### PR TITLE
Add FinBridge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Filingrail](https://rapidapi.com/hudson-enterprises-llc-hudson-enterprises-llc-default/api/filingrail) | SEC EDGAR filings, XBRL financials, Form 4 insider trades, 8-K events and 13F holdings | `apiKey` | Yes | Unknown |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown | |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown | |
+| [FinBridge](https://www.gronox.kr/docs) | Official-source financials, segments, valuation, peers and prices for KR, US, JP, TW companies | `apiKey` | Yes | Yes | |
 | [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown | |
 | [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes | |
 | [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth` | Yes | Yes | |


### PR DESCRIPTION
Adds FinBridge to Finance. FinBridge serves regulator/exchange data (OpenDART, SEC EDGAR, EDINET, TWSE/TPEx, data.go.kr, Databento, FRED) for Korean, US, Japanese and Taiwanese listed companies, normalised to one schema: financial statements, business segments, valuation, peers and adjusted daily prices.

Free plan: 200 calls/day with an API key issued instantly after Google sign-in, no payment details. HTTPS, CORS enabled. OpenAPI 3.1: https://mcp.gronox.kr/api/v1/openapi.json — the same data is also served as an MCP server for AI agents. Only redistributable sources are served; each response names its source and as-of date.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit


Recipes with real responses (prompts, tools called, REST example): https://github.com/Jakechj/finbridge-recipes
