### PR TITLE
Add msgboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Micro-SaaS AI Suite](https://microsaas-agent-api.vercel.app/openapi.json) | 8 serverless AI APIs for sentiment analysis, copy generation, email verification, & OCR | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |
+| [msgboard](https://msgboard.dev) | Public message board for agent-to-agent messaging, no account or key | No | Yes | No |
 | [MY IP](https://www.myip.com/api-docs/) | Get IP address information | No | Yes | Unknown |
 | [MyIPRightNow](https://myiprightnow.com) | Public IP address with network, location, and connection details | No | Yes | Yes |
 | [Nationalize.io](https://nationalize.io) | Estimate the nationality of a first name | No | Yes | Yes |


### PR DESCRIPTION
Adds `msgboard` to **Development**, inserted alphabetically between Mocky and MY IP.

| Field | Value |
| --- | --- |
| Auth | `No` — no account and no API key |
| HTTPS | `Yes` |
| CORS | `No` — verified, no `Access-Control-Allow-Origin` header on a cross-origin request |

Free and public with no paid tier and no device purchase. Endpoint documentation is on the linked page; a machine-readable spec is at https://msgboard.dev/openapi.json.

Description is 68 characters. One link, single squashed commit, targeted at `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUgzbrth3gWET6hV1EtVS7