### PR TITLE
Add Proxmint Free Proxies API

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PageCDN](https://pagecdn.com/docs/public-api) | Public API for javascript, css and font libraries on PageCDN | `apiKey` | Yes | Yes |
 | [Phone Specs](https://phone-specs-api-production.up.railway.app/docs) | Real-time smartphone specifications database for 263 devices | No | Yes | Yes |
 | [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey` | Yes | Unknown |
+| [Proxmint Free Proxies](https://proxmint.com/free-proxies#api) | Free live-tested proxy list (HTTP/HTTPS/SOCKS4/SOCKS5), revalidated every 30 min, JSON or txt | No | Yes | Yes |
 | [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey` | Yes | Unknown |
 | [ProxyForge](https://proxyforge.dev) | Free auto-updating list of live-tested proxies (HTTP/HTTPS/SOCKS4/SOCKS5), refreshed every 6 h | No | Yes | Yes |
 | [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds one entry to `### Development`, in alphabetical position between `Postman` and `ProxyCrawl`.

```
| [Proxmint Free Proxies](https://proxmint.com/free-proxies#api) | Free live-tested proxy list (HTTP/HTTPS/SOCKS4/SOCKS5), revalidated every 30 min, JSON or txt | No | Yes | Yes |
```

Checklist:

- No auth — `https://proxmint.com/api/free-proxies` returns 200 with no key
- HTTPS: yes
- CORS: `access-control-allow-origin: *`
- Docs: https://proxmint.com/free-proxies#api
- `?format=txt` returns a plain `ip:port` list for tooling
- Data is CC BY 4.0, advertised via an RFC 8288 `Link` header
- Description is 93 characters
- Alphabetical ordering preserved; one link; single squashed commit
- `python3 scripts/validate/format.py README.md` reports zero errors on the added line

Supersedes #6473, which was opened against a fork branch that had drifted behind master and whose workflow run expired without approval. That PR is now closed; this is the only open one.
