### PR TITLE
Add Malwagon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ API | Description | Auth | HTTPS | CORS |
 | [IPWhois.net Blacklist](https://ipwhois.net/blacklist/docs) | Community IP blacklist to check and report abusive IP addresses | No | Yes | Unknown |
 | [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Yes | Unknown |
 | [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | Yes | No |
+| [Malwagon](https://malwagon.com/docs/api) | Detonates files and URLs in instrumented VMs and returns behaviour, IOCs and ATT&CK | `apiKey` | Yes | Unknown |
 | [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Yes | Unknown |
 | [Metacert](https://metacert.com/) | Metacert Link Flagging | `apiKey` | Yes | Unknown |
 | [NoPhishy](https://rapidapi.com/Amiichu/api/exerra-phishing-check/) | Check links to see if they're known phishing attempts | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds the Malwagon API to the Anti-Malware section.

It submits a file or URL for detonation on instrumented Windows and Linux virtual machines and returns the behaviour report, extracted indicators and ATT&CK technique mappings. Documentation is at https://malwagon.com/docs/api

There is a free community tier: an API key is issued without payment details, which is why the entry is listed as `apiKey` rather than requiring a purchase. Placed alphabetically between MalShare and MalwareBazaar, one entry, targeting master.