### PR TITLE
Add ipgeolocationapi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipapi.co](https://ipapi.co/api/#introduction) | Find IP address location information | No | Yes | Yes |
 | [IPGEO](https://api.techniknews.net/ipgeo/) | Unlimited free IP Address API with useful information | No | Yes | Unknown |
 | [ipgeolocation](https://ipgeolocation.io/) | IP Geolocation AP with free plan 30k requests per month | `apiKey` | Yes | Yes |
+| [ipgeolocationapi](https://ipgeolocationapi.io/docs) | IP geolocation with ASN, timezone, currency and threat data, 5,000 keyless calls a day | No | Yes | Yes |
 | [IPInfoDB](https://www.ipinfodb.com/api) | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address | `apiKey` | Yes | Unknown |
 | [ipstack](https://ipstack.com/) | Locate and identify website visitors by IP address | `apiKey` | Yes | Unknown |
 | [ipwhois](https://ipwhois.io/documentation) | IP geolocation with country, city, coordinates, ISP, timezone and flag data | No | Yes | Yes |


### PR DESCRIPTION
Adds [ipgeolocationapi](https://ipgeolocationapi.io/docs) to the Geocoding section.

- Free tier: 5,000 requests/day, no API key required for the geolocation fields
- Returns city, country, coordinates, ASN, ISP, timezone, currency and security signals (VPN/proxy/Tor) in one lookup
- HTTPS and CORS enabled (verified: `access-control-allow-origin: *`, OPTIONS preflight 200)
- Documentation: https://ipgeolocationapi.io/docs
- Placed alphabetically in the Geocoding section

Single-line change, single commit.