### PR TITLE
Add BetTip API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1507,6 +1507,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AcreLens](https://www.acrelens.com) | Land suitability scoring API for any US property: off-grid, rural, recreational, investment | `apiKey` | Yes | Unknown |
 | [API Setu](https://www.apisetu.gov.in/) | An Indian Government platform that provides a lot of APIS for KYC, business, education & employment | No | Yes | Yes |
 | [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
+| [BetTip](https://bettip.co.za/api/) | UK49s, Gosloto and South African lottery results in JSON and CSV | No | Yes | Yes |
 | [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [BTU Graph](https://btugraph.com/data/) | Source-reviewed energy company knowledge graph and directory exports | No | Yes | Yes |


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>


Adds BetTip under Open Data. Submitted by BetTip, the API publisher.

The documentation and a latest-results endpoint returned HTTP 200 over HTTPS without authentication; the JSON response includes Access-Control-Allow-Origin: *. Data is CC BY 4.0 with attribution required. The UK49s archive dates to September 2018 but has gaps; this entry does not claim complete coverage or independently verified update speed. Results only, 18+, not betting advice.

No new category is created. This follows the current five-column Open Data table; no Postman collection is claimed.