### PR TITLE
Add Vega x402 payment-gated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ API | Description | Auth | HTTPS | CORS |
 | [Walltime](https://walltime.info/api.html) | To retrieve Walltime's market info | No | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
 
+| [Vega URL Extractor](https://extract.kramsg1online.com) | Extract clean text from any web page URL via x402 USDC micropayments | `apiKey` | Yes | Yes |
+| [Vega PDF Extractor](https://pdf.kramsg1online.com) | Extract text from PDF files via x402 USDC micropayments | `apiKey` | Yes | Yes |
+| [Vega Summarizer](https://summarize.kramsg1online.com) | Summarize articles and URLs via x402 USDC micropayments | `apiKey` | Yes | Yes |
 **[⬆ Back to Index](#index)**
 <br >
 <br >


### PR DESCRIPTION
Adds three x402 payment-gated APIs to the Blockchain section:

- **Vega URL Extractor** (extract.kramsg1online.com) - $0.05 USDC per call
- **Vega PDF Extractor** (pdf.kramsg1online.com) - $0.05 USDC per call  
- **Vega Summarizer** (summarize.kramsg1online.com) - $0.02 USDC per call

All APIs use EIP-4337 x402 protocol for on-chain USDC payments on Base mainnet.

Wallet: 0x047b2A7fc72862a0e3E772eb53b19d35929BEd46