### PR TITLE
feat: add ChEMBL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1690,6 +1690,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | No | Yes | Unknown |
 | [arXiv](https://arxiv.org/help/api/user-manual) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
+| [ChEMBL](https://www.ebi.ac.uk/chembl/api/data/docs) | Bioactivity data on drug-like molecules and targets from EMBL-EBI | No | Yes | Yes |
 | [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | Render LaTeX equations in PNG, GIF, SVG, EMF, PDF, JSON, or download formats with styling options | No | Yes | Unknown |
 | [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
 | [CycleCalcs](https://www.cyclecalcs.com/api.html) | Interpreted astronomy: sun and moon times, moon phases, planets, eclipses, seasons | No | Yes | Yes |


### PR DESCRIPTION
feat: add ChEMBL API

Bioactivity data on drug-like molecules and targets from EMBL-EBI (No/Yes/Yes) in Science & Math, alphabetically between arXiv and CodeCogs.
