### PR TITLE
feat: add iNaturalist API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1696,6 +1696,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Europe PMC](https://europepmc.org/RestfulWebService) | Life-science literature search with abstracts, citations and full-text links | No | Yes | Yes |
 | [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |
 | [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
+| [iNaturalist](https://api.inaturalist.org/v1/docs/) | Citizen-science wildlife observations with species identification and mapping | No | Yes | Yes |
 | [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | High Energy Physics info. system | No | Yes | Unknown |
 | [isEven (humor)](https://isevenapi.xyz/) | Check if a number is even | No | Yes | Unknown |
 | [ISRO](https://isro.vercel.app) | ISRO Space Crafts Information | No | Yes | No |


### PR DESCRIPTION
feat: add iNaturalist API

Citizen-science wildlife observations with species identification and mapping (No/Yes/Yes) in Science & Math, alphabetically between iDigBio and inspirehep.net.
