### PR TITLE
feat: add Congress.gov API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,6 +1219,7 @@ API | Description | Auth | HTTPS | CORS |
 | [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
 | [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
 | [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
+| [Congress.gov](https://api.congress.gov/) | Bills, members, committees, nominations and legislative activity from the US Congress | `apiKey` | Yes | Unknown |
 | [Conversor IAE CNAE](https://www.conversoriaecnae.es/api/v1/docs) | Spanish IAE/CNAE tax activity codes, 2009→2025 crosswalk and AEAT obligations | `apiKey` | Yes | No |
 | [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
 | [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
feat: add Congress.gov API

Bills, members, committees, nominations and legislative activity from the US Congress (apiKey/Yes/Unknown) in Government, alphabetically between Colorado Information Marketplace and Conversor IAE CNAE.
