### PR TITLE
feat: add ClinicalTrials.gov API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1312,6 +1312,7 @@ API | Description | Auth | HTTPS | CORS |
 API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Clinical Trials Directory](https://trials.starfile.org/api) | Every clinical trial registered with ClinicalTrials.gov, indexed by condition and sponsor | No | Yes | Yes |
+| [ClinicalTrials.gov](https://clinicaltrials.gov/data-api/api) | Worldwide clinical trial registry data from the US National Library of Medicine | No | Yes | Yes |
 | [CMS.gov](https://data.cms.gov/provider-data/) | Access to the data from the CMS - medicare.gov | `apiKey` | Yes | Unknown |
 | [Coronavirus](https://pipedream.com/@pravin/http-api-for-latest-wuhan-coronavirus-data-2019-ncov-p_G6CLVM/readme) | HTTP API for Latest Covid-19 Data | No | Yes | Unknown |
 | [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | UK Government coronavirus data, including deaths and cases by region | No | Yes | Unknown |


### PR DESCRIPTION
feat: add ClinicalTrials.gov API

Worldwide clinical trial registry data from the US National Library of Medicine (No/Yes/Yes) in Health, alphabetically between Clinical Trials Directory and CMS.gov.
