### PR TITLE
Add Motomarks to Vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2133,6 +2133,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Yes | Unknown |
 | [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |
 | [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | Yes | No |
+| [Motomarks](https://motomarks.io/docs) | Car manufacturer logos as PNG and WebP from an image CDN | `apiKey` | Yes | Unknown |
 | [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Yes | Unknown |
 | [ProblemsByVin](https://problemsbyvin.com/data/) | Owner complaints, recalls and failure-mileage statistics by vehicle make, model and year | No | Yes | Yes |
 | [RevCarData](https://revcardata.com) | 86,000+ global vehicle specifications and EV metrics | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Vehicle already covers specs, prices, and telematics. This row is the manufacturer logo image CDN those listings sit next to.

Docs: https://motomarks.io/docs
Auth apiKey. CORS Unknown. HTTPS Yes.
Free tier exists (1,000 requests/day).