### PR TITLE
Add Country Calling Codes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ API | Description | Auth | HTTPS | CORS |
 | [AGPC Domain Check](https://guild.tradeuniquecapital.com/api) | Check a domain's SPF, DKIM, DMARC and MX with a graded shareable report | No | Yes | Yes |
 | [Atomic Mail](https://atomic-mail.github.io/atomic-mail-agentic/) | Email for AI agents: programmatic inbox creation and send/receive over JMAP | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
+| [Country Calling Codes](https://www.countrycalling.codes/developers) | Free OpenAPI + MCP for ITU E.164 calling codes, dialing format, and phone analysis | No | Yes | Unknown |
 | [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
 | [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |
 | [EmailJS](https://www.emailjs.com/docs/) | Send emails directly from client-side JavaScript without a backend server | `apiKey` | Yes | Yes |
@@ -1627,6 +1628,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Numlookup](https://numlookupapi.com) | Phone number validation and carrier lookup API with global coverage | `apiKey` | Yes | Unknown |
 | [Numverify](https://numverify.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Phone number validation | `apiKey` | Yes | Unknown |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
+| [Country Calling Codes](https://www.countrycalling.codes/developers) | Free OpenAPI + MCP for ITU E.164 calling codes, dialing format, and phone analysis | No | Yes | Unknown |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds free OpenAPI+MCP calling-codes API (no auth) under Phone.

- Docs: https://www.countrycalling.codes/developers
- OpenAPI: https://countrycalling.codes/api/calling-codes/openapi.json
- MCP: https://countrycalling.codes/api/mcp