### PR TITLE
Add APIzone API

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey` | Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
+| [APIzone](https://apizone.io/api-docs) | Independent uptime & status monitoring for 200+ popular APIs | No | Yes | Yes |
 | [Aquanode](https://docs.aquanode.io/docs/api/marketplace) | Live GPU rental prices and availability across nine cloud providers | No | Yes | No |
 | [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey` | Yes | Unknown |
 | [Base](https://www.base-api.io/) | Building quick backends | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds APIzone's public status API to the Development section.

- Free, no auth required, HTTPS, CORS enabled (`access-control-allow-origin: *`)
- Docs: https://apizone.io/api-docs
- Returns real-time status + uptime for 200+ popular third-party APIs (Stripe, OpenAI, AWS, GitHub, etc.), from independent synthetic probes rather than vendor-reported status.
- Rate limited 60 req/min per IP, no key needed.

Follows the CONTRIBUTING guidelines: one link, alphabetical placement (between APIs.guru and Aquanode), description under 100 chars, correct table padding.