### PR TITLE
Add Comunicate.top API

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
 | [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
 | [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
+| [Comunicate.top](https://comunicate.top/en/documentatie-api) | Catalogue of 3800+ news sites for press releases and advertorials: niches, authority, prices | No | Yes | Yes |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Funding Signals](https://fundingsignals.net/docs) | Companies that just raised funding, scored as sales leads, from public SEC filings | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds **Comunicate.top** to Business, alphabetically between Clearbit Logo and Domainsdb.info.

Free, read-only, no key and no sign-up. Base URL `https://app.comunicate.top/api/v1/public`:

```
GET /public/stats               -> {"publications":3822,"niches":21}
GET /public/niches?locale=en    -> niches with publication counts and average Moz DA
GET /public/niches/{slug}       -> sample publications: domain, DA, PA, turnaround, price
GET /public/statistici-piata    -> authority distribution, turnaround, price per campaign type
```

- Auth: **No** — these routes carry `security: []` in the OpenAPI document
- HTTPS: **Yes**
- CORS: **Yes** — `Access-Control-Allow-Origin: *` on the public GET routes

OpenAPI 3.1: https://comunicate.top/openapi.json · APIs.json: https://comunicate.top/apis.json · `/.well-known/api-catalog` (RFC 9727) is published too.

The paid part of the platform needs an API key, but nothing above does, and no public route writes anything.