### PR TITLE
Add Chinese Laws (Government)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
+| [Chinese Laws](https://github.com/lttxzmj/chinese-law-corpus#api免费-json经-jsdelivr-cdn) | 412 Chinese laws and judicial interpretations in force, article-level JSON, plus supreme court cases (CC0) | No | Yes | Yes |
 | [CPFHub](https://cpfhub.io) | Brazilian CPF lookup — returns full name, birth date, and gender for any CPF | `apiKey` | Yes | Yes |
 | [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |
 | [City, Berlin](https://daten.berlin.de/) | Berlin(DE) City Open Data | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Chinese Laws** to Government (alphabetical).

Free, no-auth JSON API over jsDelivr CDN for the 412 Chinese laws and judicial interpretations currently in force (article-level structure, 26k+ articles, curated from official sources) plus 723 supreme court cases. Data is CC0; HTTPS and CORS (`access-control-allow-origin: *`) verified. Docs: the API section of the repo README. Comparable precedent in this section: BCLaws.