### PR TITLE
feat: add Maven Central Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Logs.to](https://logs.to/) | Generate logs | `apiKey` | Yes | Unknown |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes | Yes |
+| [Maven Central Search](https://search.maven.org/searchservice) | Java/JVM artifact versions and dependency metadata | No | Yes | Yes |
 | [Micro DB](https://m3o.com/db) | Simple database service | `apiKey` | Yes | Unknown |
 | [Micro-SaaS AI Suite](https://microsaas-agent-api.vercel.app/openapi.json) | 8 serverless AI APIs for sentiment analysis, copy generation, email verification, & OCR | `apiKey` | Yes | Unknown |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |


### PR DESCRIPTION
feat: add Maven Central Search API

Java/JVM artifact versions and dependency metadata (No/Yes/Yes) between MAC address vendor lookup and Micro DB.
