### PR TITLE
feat: add Wheelwise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2140,6 +2140,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ProblemsByVin](https://problemsbyvin.com/data/) | Owner complaints, recalls and failure-mileage statistics by vehicle make, model and year | No | Yes | Yes |
 | [RevCarData](https://revcardata.com) | 86,000+ global vehicle specifications and EV metrics | `apiKey` | Yes | Yes |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes | Yes |
+| [Wheelwise](https://cars.limoja.ai/api/search?q=BMW&limit=1) | UK used-car listings with fair-price grade, 36-month resale forecast and true monthly cost per advert | No | Yes | No |
 
 **[⬆ Back to Index](#index)**
 <br >


### PR DESCRIPTION
Adds Wheelwise to the Vehicle category (alphabetically after Smartcar).

- **API docs URL:** https://cars.limoja.ai/api/search?q=BMW&limit=1 (live JSON, no auth; also /api/stats, /api/leases, /api/car/{id})
- **Description:** UK used-car listings with fair-price grade, 36-month resale forecast and true monthly cost per advert (400,000+ scored listings)
- **Auth:** No  |  **HTTPS:** Yes  |  **CORS:** No (verified: no Access-Control-Allow-Origin header on responses or OPTIONS preflight)

All figures verifiable live: stats endpoint reports n=417146 scored adverts as of posting.