### PR TITLE
Update Football Charts entry: auth is optional (keyless tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1893,7 +1893,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
-| [Football Charts](https://www.football-charts.com/developers) | Results, fixtures, tables, goal timing and model probabilities for 93 football leagues, lower divisions included | No | Yes | Yes |
+| [Football Charts](https://www.football-charts.com/developers) | Results, fixtures, tables and goal timing for 93 football leagues, lower divisions included | No | Yes | Yes |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1893,7 +1893,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
-| [Football Charts](https://www.football-charts.com/developers) | Tables, results, model probabilities and Monte Carlo season projections for 93 leagues | `apiKey` | Yes | Yes |
+| [Football Charts](https://www.football-charts.com/developers) | Results, fixtures, tables, goal timing and model probabilities for 93 football leagues, lower divisions included | No | Yes | Yes |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
The Football Charts entry lists `apiKey`, which is no longer accurate.

The API now has a keyless tier. Its self-describing root reports:

```
GET https://footballcharts-backend.onrender.com/api/v1/
"auth": "Optional. No key: 300 requests/day, 20/min per IP.
          Free key: 5,000/day, 60/min."
```

Verified working without any credentials:

```
curl https://footballcharts-backend.onrender.com/api/v1/leagues/premier/table/   # 200
```

So the Auth column should be `No`, matching other optional-auth entries in this section.

I have also refreshed the description: fixtures and goal timing were missing, and the lower-division coverage is what distinguishes it from the other football APIs listed here.

Disclosure: this is my own API. The entry itself was added previously; this only corrects it.