### PR TITLE
Add SlashYear API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,6 +1546,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
 | [Registrum](https://api.registrum.co.uk/docs) | UK company data: profiles, directors, PSC, iXBRL-parsed financials, ECCTA status | `apiKey` | Yes | No |
 | [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
+| [SlashYear](https://slashyear.com/api) | 86,902 historical events as JSON, each quoted from a cited Wikipedia revision | No | Yes | Yes |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes | Yes |
 | [Statistics of the World](https://statisticsoftheworld.com/api-docs) | Economic data for 218 countries — GDP, population, inflation, and 440+ indicators from IMF and World Bank | No | Yes | Yes |
 | [Teleport](https://developers.teleport.org/) | Quality of Life Data | No | Yes | Unknown |


### PR DESCRIPTION
Adds SlashYear to **Open Data**, in alphabetical position between Scoop.it and Socrata.

| field | value |
| --- | --- |
| Docs | https://slashyear.com/api |
| Auth | No — no key, no signup, no rate limit |
| HTTPS | Yes |
| CORS | Yes — `Access-Control-Allow-Origin: *` on every endpoint |
| Licence | CC BY-SA 4.0 (rows), Apache-2.0 (code) |

86,902 dated historical events across 3,078 years. Every record is one sentence quoted verbatim from a specific English Wikipedia revision and carries that revision id, so any claim built on a row can be checked against its source.

Static JSON, served from the edge:

```
curl https://slashyear.com/api/year/1969.json
curl https://slashyear.com/api/date/july-20.json
curl https://slashyear.com/api/entity/byzantine-empire.json
curl https://slashyear.com/api/openapi.json
```

Fully free and open — not a paid tier, not a lead magnet. Bulk NDJSON dumps with a Frictionless datapackage, an OpenAPI 3 description, and the whole pipeline are open source at https://github.com/ctrl-maud/slashyear.

One link, one section, alphabetical order kept, description is 76 characters.