### PR TITLE
Add School Calendar API to Calendar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Non-Working Days](https://isdayoff.ru) | Simple REST API for checking working, non-working or short days for Russia, CIS, USA and other | No | Yes | Yes |
 | [Public Holidays](https://www.abstractapi.com/holidays-api) | Data on national, regional, and religious holidays via API | `apiKey` | Yes | Yes |
 | [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | Yes | No |
+| [School Calendar API](https://schools-calendar.com) | US public-school district calendars: first day, last day, breaks, and holidays | No | Yes | Yes |
 | [The Calendar](https://the-calendar.net/api/) | Public holidays for US states and 30 countries plus sports and finance calendars as static JSON | No | Yes | Yes |
 | [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | Bank holidays in England and Wales, Scotland and Northern Ireland | No | Yes | Unknown |
 


### PR DESCRIPTION
Adds the **School Calendar API** to the Calendar section.

- **API:** https://schools-calendar.com
- **Description:** US public-school district calendars: first day, last day, breaks, and holidays
- **Auth:** No (public read access; optional API key only raises rate limits)
- **HTTPS:** Yes
- **CORS:** Yes

Entry inserted in alphabetical order between `Russian Calendar` and `The Calendar`. Single-line addition.

<!-- checklist -->
- [x] My addition is in alphabetical order.
- [x] HTTPS/CORS/Auth columns are accurate.
- [x] The entry links to working API documentation.