### PR TITLE
Add Postproxy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1849,6 +1849,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
 | [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth` | Yes | Unknown |
 | [PostLake](https://postlake.dev/docs/) | One API to publish, schedule, and read analytics across every major social network | `apiKey` | Yes | No |
+| [Postproxy](https://postproxy.dev/getting-started/quickstart/) | Publish posts, comments, DMs, and more | `apiKey` | Yes | No |
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Yes | Unknown |
 | [Publora](https://docs.publora.com) | Publish and schedule posts to ten social networks from one endpoint | `apiKey` | Yes | No |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
### What

Adds **Postproxy** to the **Social** category.

Postproxy is a REST API to publish and schedule posts, and manage comments, direct messages, profiles, and analytics across Facebook, Instagram, TikTok, LinkedIn, YouTube, X/Twitter, Threads, Pinterest, Bluesky, Telegram, and Google Business.

- Docs: https://postproxy.dev/getting-started/quickstart/
- Auth: `apiKey` (Bearer token)
- HTTPS: Yes
- CORS: No (verified — no `Access-Control-Allow-Origin` returned, server-to-server API)
- Free access: free tier available, no purchase required

### Checklist

- [x] Added one API per pull request
- [x] Entry placed in alphabetical order within the Social category
- [x] Description is under 100 characters
- [x] Auth / HTTPS / CORS use allowed values
- [x] Link points to API documentation
- [x] Build validation passes
