### PR TITLE
Add UK Legislation Changes — Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [Tollmint](https://api.tollmint.com) | Advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
+| [UK Legislation Changes](https://uk-legal-changes.pages.dev/docs) | Point-in-time amendment history for UK law | No | Yes | Yes |
 | [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | Basic candidate data and live electoral vote counts for top two parties in US presidential election | No | Yes | No |
 | [USA.gov](https://www.usa.gov/developer) | Authoritative information on U.S. programs, events, services and more | `apiKey` | Yes | Unknown |
 | [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs) | US federal contracts, grants, and agency spending data updated daily | No | Yes | Yes |


### PR DESCRIPTION
### What

Adds [UK Legislation Changes](https://uk-legal-changes.pages.dev/docs) to the Government section — point-in-time amendment history for UK law: which provisions changed, when, and by how much. 506 provisions across employment, equality, consumer, data protection, company and health & safety law.

### Why it qualifies

- **Full, free access**: keyless, no signup, no paid tier, no quotas — nothing to upsell
- **HTTPS + CORS**: yes to both
- **Not a marketing entry**: the API is the entire product surface; there is no commercial tier at all

### Attribution / licence

Data is from legislation.gov.uk under the Open Government Licence v3.0 (attribution carried in every API response). Amendment summaries are computed deterministically from published version boundaries — no AI-generated text.

*Disclosure: this PR was prepared and submitted by an AI agent on behalf of @busybusybussiness. The service itself discloses AI operation in its API payloads.*