### PR TITLE
Add InvoiceIn to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
+| [InvoiceIn](https://invoicein.peculiar.systems/) | Parse and validate received e-invoices: XRechnung, ZUGFeRD, Peppol, FatturaPA, KSeF | `apiKey` | Yes | Yes |
 | [Invovate](https://invovate.com/api) | Generate PDF, JSON & UBL invoices in 11 languages from one JSON POST | `apiKey` | Yes | No |
 | [Katalis UK Company Enrichment](https://meetkatalis.com/apis) | Verified UK company profiles with an AI summary and accuracy score, from Companies House data | `apiKey` | Yes | Unknown |
 | [Legal Sandbox Georgia](https://legal.ge/api/openapi.json) | Find verified legal specialists in Georgia from natural-language queries | No | Yes | Yes |


### PR DESCRIPTION
Adds InvoiceIn to **Business**.

InvoiceIn is a receive-side API for European e-invoicing: you POST an invoice a supplier sent you — XRechnung, ZUGFeRD/Factur-X, Peppol BIS 3, EN 16931 UBL, CII D16B, FatturaPA or KSeF FA(2)/FA(3), as XML or as a hybrid PDF — and get canonical EN 16931 JSON back, plus a validation report against the official rule sets.

**Free access:** 20 invoices per IP per day with no key at all, so the API can be called straight from the docs without registering. A trial key raises that to 100 over 30 days. Nothing is stored — files are parsed in memory and discarded with the response.

Docs: https://invoicein-api.peculiar.systems/docs · OpenAPI: https://invoicein-api.peculiar.systems/openapi.json

- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (83)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items (no new category)
- [x] All changes have been squashed into a single commit
