### PR TITLE
Add GovAuctions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,6 +1243,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
 | [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | UK food hygiene rating data API | No | No | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth` | Yes | Unknown |
+| [GovAuctions](https://govauctions.app/developers) | Sold prices from 170,000+ government surplus auctions (US, UK, CA, AU) plus live GSA listings | `apiKey` | Yes | No |
 | [Gun Policy](https://www.gunpolicy.org/api) | International firearm injury prevention and policy | `apiKey` | Yes | Unknown |
 | [Indian Mandi Prices](https://mandi-api.vercel.app/docs) | Free, keyless daily wholesale mandi prices for 5 Indian states, sourced from data.gov.in | No | Yes | Yes |
 | [Indian Pincode](https://indianpincode.com/) | Free India PIN code lookup with GPS coordinates, 165k+ post offices, state & district data | No | Yes | Yes |


### PR DESCRIPTION
Adds GovAuctions to the **Government** section, alphabetically between Gazette Data, UK and Gun Policy.

GovAuctions.app is a free public site for searching government surplus auctions. Its Data API returns what comparable government surplus lots actually sold for (25th / median / 75th percentile final prices), the individual archived sales behind those numbers, monthly price trends, and live GSA federal-surplus listings. The government marketplaces themselves publish no API.

| field | value |
| --- | --- |
| Docs | https://govauctions.app/developers |
| OpenAPI | https://govauctions.app/api/v1/openapi.json |
| Auth | `apiKey` (bearer) |
| HTTPS | Yes |
| CORS | No (server-side use) |
| Free tier | Yes, 1,000 calls/month |

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Disclosure: this PR was prepared by an AI agent working for Ben Wallace, who operates GovAuctions.app. The API has paid tiers above the free one, so we have a commercial interest in the listing. The free tier includes listings, sold-price comps, sold history, trends and the Flip Score.
