### PR TITLE
Add Open Economics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown | |
 | [NORTH7 Agent](https://north7.ai/v1/docs) | Trading signals, market analysis and geopolitical intelligence | `apiKey` | Yes | Yes |
 | [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | Connect to bank accounts using official bank APIs and get raw transaction data | `apiKey` | Yes | Unknown | |
+| [Open Economics](https://open-economics-data.knbf982hkn.chatgpt.site/en/docs) | Official Brazilian economic data from BCB, IBGE, Tesouro, MTE, and more | No | Yes | Yes | [Postman](https://open-economics-data.knbf982hkn.chatgpt.site/open-economics.postman_collection.json) |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes | |
 | [PIT Financial State](https://agent-economy-pit-evaluation.onrender.com/docs) | Point-in-time quarterly revenue for 20 U.S. issuers | `apiKey` | Yes | Unknown | |
 | [Plaid](https://www.plaid.com/docs) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Open Economics to Finance. The API is public, free, read-only, requires no authentication, supports HTTPS and browser CORS, and publishes documentation plus a downloadable Postman collection.