### PR TITLE
Add QiuXiaoCe Football to Sports & FitnessUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1923,6 +1923,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PlayerElo](https://playerelo.football/api-access) | Player-level Elo ratings, predictions and history for 176 football leagues | `apiKey` | Yes | Unknown |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey` | Yes | Unknown |
 | [PropLine](https://prop-line.com) | Real-time player-props betting odds with graded prop resolution across 13 books | `apiKey` | Yes | Unknown |
+| [QiuXiaoCe Football](https://www.qiuxiaoce.com/data-docs/) | Football teams, leagues, standings, scorers and match intelligence data | `No` | `Yes` | `Unknown` |
 | [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 historical data and statistics | No | Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey` | Yes | Unknown |
 | [Sport List & Data](https://developers.decathlon.com/products/sports) | List of and resources related to sports | No | Yes | Yes |


### PR DESCRIPTION
### Description
Adding QiuXiaoCe Football Data API to the `Sports & Fitness` category.

- **API Name**: QiuXiaoCe Football
- **Website & Documentation**: https://www.qiuxiaoce.com/data-docs/
- **Description**: Football teams, leagues, standings, scorers and match intelligence data (73 characters)
- **Auth**: No (Free Tier available for standings, teams, leagues, top scorers without any API key)
- **HTTPS**: Yes
- **CORS**: Unknown

### Example Free Tier Endpoint (No Auth Required)
```bash
curl -s "https://www.qiuxiaoce.com/wp-json/abv2-creator/v1/standings?league=39"
