### PR TITLE
Add PkmnPrices API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Open Trivia](https://opentdb.com/api_config.php) | Trivia Questions | No | Yes | Unknown |
 | [PandaScore](https://developers.pandascore.co/) | E-sports games and results | `apiKey` | Yes | Unknown |
 | [Path of Exile](https://www.pathofexile.com/developer/docs) | Path of Exile Game Information | `OAuth` | Yes | Unknown |
+| [PkmnPrices](https://www.pkmnprices.com/docs) | Pokémon TCG card and sealed prices, sold comps and price history from TCGplayer, Cardmarket, eBay | `apiKey` | Yes | No |
 | [PlayerDB](https://playerdb.co/) | Query Minecraft, Steam and XBox Accounts | No | Yes | Unknown |
 | [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
 | [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi) | The Unofficial GraphQL for PokeAPI | No | Yes | Yes |


### PR DESCRIPTION
Adds PkmnPrices to Games & Comics.

It returns current market prices from TCGplayer (USD) and Cardmarket (EUR), sold eBay comps for raw and graded cards, price history, and sealed products. Docs: https://www.pkmnprices.com/docs

The free tier is 500 credits a day at 60 requests a minute, and it does not ask for a card. I run this API.

Auth is an API key sent in an `x-api-key` header, and everything is over HTTPS. CORS is No: the server only allows its own frontend origin, so a browser call from another site is blocked.

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit
