### PR TITLE
Add VoxOdds API

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown | |
 | [US Mortgage Calculator](https://www.usmortgagecalc.com/developers/api) | Mortgage payment, amortization, affordability and 50-state property tax data | No | Yes | Yes | |
 | [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes | |
+| [VoxOdds](https://voxodds.com/api) | Polymarket and Kalshi odds, all-in executable quotes, EV checks and audited forecast scores | No | Yes | No | |
 | [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets Stock Comments Sentiment Analysis | No | Yes | Unknown | |
 | [Yahoo Finance](https://www.yahoofinanceapi.com/) | Real time low latency Yahoo Finance API for stock market, crypto currencies, and currency exchange | `apiKey` | Yes | Yes | |
 | [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth` | Yes | Yes | |


### PR DESCRIPTION
Adds **VoxOdds** to Finance (alphabetical, between VAT Validation and WallstreetBets).

- Free, no auth, HTTPS. Live prediction-market odds from Polymarket and Kalshi, natural-language odds answers, all-in executable quotes with order-book depth and venue fees, ranked opportunities, pre-bet EV checks, and an audited AI-vs-market forecast dataset (CC BY 4.0).
- Docs: https://voxodds.com/api · OpenAPI: https://voxodds.com/api/openapi.json · Swagger UI: https://voxodds.com/docs
- Example: `GET https://voxodds.com/api/v1/markets?q=norris&limit=5`
- CORS: not enabled (server-side use). No Postman collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1mooJKJedR9NHDPNAGFkq