### PR TITLE
Add TransparentCars API (Vehicle) — PT used-car fair-price & road tax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2153,6 +2153,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ProblemsByVin](https://problemsbyvin.com/data/) | Owner complaints, recalls and failure-mileage statistics by vehicle make, model and year | No | Yes | Yes |
 | [RevCarData](https://revcardata.com) | 86,000+ global vehicle specifications and EV metrics | `apiKey` | Yes | Yes |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes | Yes |
+| [TransparentCars](https://transparent.pt/en/api) | Fair-price valuation and yearly road tax (IUC) for used cars in Portugal | No | Yes | Yes |
 | [Wheelwise](https://cars.limoja.ai/api/search?q=BMW&limit=1) | UK used-car listings with fair-price grade, 36-month resale forecast and true monthly cost per advert | No | Yes | No |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds the TransparentCars public API under **Vehicle**. Free, key-free JSON API for the Portuguese used-car market: fair-price valuation from comparable listings, annual road tax (IUC), and published stock. Auth: No · HTTPS: Yes · CORS: Yes. Docs: https://transparent.pt/en/api · OpenAPI: https://transparent.pt/openapi.yaml