### PR TITLE
Update 1inch API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ API | Description | Auth | HTTPS | CORS |
 |:---|:---|:---|:---|:---|
 | [Coinlayer](https://coinlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Real-time Crypto Currency Exchange Rates | `apiKey` | Yes | Unknown |
 | [0x](https://0x.org/api) | API for querying token and pool stats across various liquidity pools | No | Yes | Yes |
-| [1inch](https://1inch.io/api/) | API for querying decentralize exchange | No | Yes | Unknown |
+| [1inch](https://business.1inch.com/portal/documentation) | API for querying decentralize exchange | `apiKey` | Yes | Unknown |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
 | [Alpha (Mossland)](https://alpha.moss.land/developers) | Korean crypto channel stance + RAG Q&A + canonical entity/topic/event store | No | Yes | Yes |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Summary

- Replace the obsolete 1inch documentation URL with the current official documentation portal.
- Correct the existing authentication metadata to API key, which the current documentation requires.

Related to #7089 (the Cryptocurrency / 1inch entry).

## Validation

- Confirmed the previous URL resolves to HTTP 404 and the new documentation and authentication pages return HTTP 200.
- Checked that the updated row retains the required five table columns and that the new URL is not duplicated in README.md.
- The repository full-format script currently reports the same pre-existing failures on upstream master; this one-line change introduces none.

- [x] My submission is formatted according to the contributing guide.
- [x] The existing entry remains in alphabetical order.
- [x] The existing description remains under 100 characters and has no trailing punctuation.
- [x] Each table column is padded with one space on either side.
- [x] I searched relevant issues and pull requests.
- [x] All changes have been squashed into a single commit.