### PR TITLE
Add Right to Disconnect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ API | Description | Auth | HTTPS | CORS |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
 | [Radar CNPJ](https://radar-cnpj.com/api/) | Brazilian companies (CNPJ) lookup and search, with a market check by area and monitoring | No | Yes | No |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
+| [Right to Disconnect](https://righttodisconnect.jdries.nl/api/) | Right-to-disconnect employment law by EU country: binding status, statute, and sanctions | No | Yes | Yes |
 | [Tollmint](https://api.tollmint.com) | Advertising, subscription, AI-disclosure and accessibility rules across the US, EU and UK | No | Yes | Yes |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Yes | Unknown |
 | [UK Legislation Changes](https://uk-legal-changes.pages.dev/docs) | Point-in-time amendment history for UK law | No | Yes | Yes |


### PR DESCRIPTION
Free, public, read-only JSON API: right-to-disconnect employment law status (binding statute / non-binding code of practice / none confirmed) for all 27 EU member states, with the specific statute, sanction, and in-force date where one exists.

- No auth, no rate limit, CORS enabled (`Access-Control-Allow-Origin: *`, verified).
- Backed by a human-readable version at https://righttodisconnect.jdries.nl/ with full sourcing per country.
- Not a product with a paid tier or a device dependency — genuinely free, static JSON, no signup.

Follows the contribution guidelines: alphabetically placed in Government (between Represent by Open North and Tollmint), description under 100 characters, one link, no TLD in the name.