### PR TITLE
Add GlobalEntity API

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Yes | Unknown |
 | [Funding Signals](https://fundingsignals.net/docs) | Companies that just raised funding, scored as sales leads, from public SEC filings | `apiKey` | Yes | No |
+| [GlobalEntity](https://www.globalentityapi.com/docs) | Official company data from 56 European business registers as normalized JSON | `apiKey` | Yes | Yes |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Yes | Unknown |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds GlobalEntity to the Business category.

- Official company data from 56 European business registers (Br&oslash;nn&oslash;ysund, Companies House, CVR, Handelsregister + more) returned as one normalized JSON schema
- Auth: apiKey (x-api-key header)
- HTTPS: Yes, CORS: Yes
- Docs: https://www.globalentityapi.com/docs
- Free 7-day trial (no card)

Alphabetical order preserved (between Funding Signals and Gmail).