### PR TITLE
Add Is This Site Down? to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ API | Description | Auth | HTTPS | CORS |
 | [ipfind.io](https://ipfind.io) | Geographic location of an IP address or any domain name along with some other useful information | `apiKey` | Yes | Yes |
 | [IPify](https://www.ipify.org/) | A simple IP Address API | No | Yes | Unknown |
 | [IPinfo](https://ipinfo.io/developers) | Another simple IP Address API | No | Yes | Unknown |
+| [Is This Site Down?](https://downforjustmeoreveryone.com/api) | Check if any website is down, from two continents; live status, uptime history and TLS expiry | No | Yes | Yes |
 | [isitdownstatus](https://isitdownstatus.com) | Check if websites and online services are currently down | No | Yes | Unknown |
 | [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com) | Package info and download stats on jsDelivr CDN | No | Yes | Yes |
 | [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Is This Site Down?](https://downforjustmeoreveryone.com/api) to the **Development** section.

`GET https://downforjustmeoreveryone.com/api/check?domain=reddit.com` returns JSON: up/down state, HTTP status, latency, resolved IP, redirect target and TLS expiry. Checks run from two regions (Singapore and Boston), so a regional block can be told apart from a real outage. There is also `/api/cert` for certificate expiry and an MCP server at `/mcp` for AI assistants.

### Why it qualifies

- **Full, free access**: no key, no signup, no paid tier — the API is the whole product surface
- **HTTPS + CORS**: yes to both (`Access-Control-Allow-Origin: *`)
- **Not a marketing entry**: nothing is sold; attribution is requested, not required
- **Limits**: 20 requests/min/IP, results cached 30 s per domain so it can't be used to hammer a third-party site

### Verification

- `python scripts/validate/format.py README.md` — the new line adds no error (output is byte-identical to master's, modulo the one-line offset)
- `git diff --check` passes
- Auth / HTTPS / CORS values checked against the live endpoint, not the docs
- No existing entry for this domain, and no competing open PR

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters (93)
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items — N/A, no new category
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

*Disclosure: this PR was prepared by an AI agent on behalf of @sleeby-dev, who owns and operates the service.*
