### PR TITLE
Add PDFMint API

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ API | Description | Auth | HTTPS | CORS |
 | [OCR.Space](https://ocr.space/ocrapi) | OCR text extraction from images and PDFs with a free tier | `apiKey` | Yes | Unknown |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
 | [PDFFleet](https://pdffleet.com) | HTML and URL to PDF API with templates and a free tier | `apiKey` | Yes | Yes |
+| [PDFMint](https://pdf.mintapis.com/docs) | HTML, Markdown or a URL to PDF or PNG, with a no-key demo endpoint and a free tier | `apiKey` | Yes | No |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth` | Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth` | Yes | Unknown |
 | [PolyDoc](https://polydoc.tech) | HTML/URL to PDF and screenshots, plus Factur-X/ZUGFeRD e-invoices; free tier | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds one entry to **Documents & Productivity**:

```
| [PDFMint](https://pdf.mintapis.com/docs) | HTML, Markdown or a URL to PDF or PNG, with a no-key demo endpoint and a free tier | `apiKey` | Yes | No |
```

**Disclosure: I build and run PDFMint.** I have kept the description to what the API
actually does and marked the columns from measurements, not from our own marketing page.

### Free access

There is a permanent free tier of 10 documents a month that needs no card, and a demo
endpoint that needs no account at all. Anyone can run this right now and get a real PDF back:

```bash
curl -X POST https://pdf.mintapis.com/v1/demo/pdf \
  -H 'content-type: application/json' \
  -d '{"html":"<h1>Hello</h1>"}' -o hello.pdf
```

I ran exactly that today: `200`, 15,472 bytes, file starts with `%PDF-1.4`.

### How the columns were determined

| Column | Value | How I checked it |
| --- | --- | --- |
| Auth | `apiKey` | `POST /v1/pdf` with no key returns **401** |
| HTTPS | Yes | HTTPS only, HTTP/2 |
| CORS | **No** | Neither an `OPTIONS` preflight with `Origin` + `Access-Control-Request-Method` nor a normal `GET` returns any `Access-Control-Allow-Origin` header. It is a server-side API |

I put `No` rather than `Unknown` because I checked; a browser cannot call it directly today.

### Guidelines

- One link, one commit, squashed.
- Placed alphabetically between `PDFFleet` and `Pocket`.
- Description is 82 characters, does not end in "API", and carries no TLD in the name.
- `python3 scripts/validate/format.py README.md` produces **exactly the same 564 messages**
  before and after this change (they are pre-existing ordering issues in other sections,
  and the line numbers shift by one) — so this entry adds no new error.
- `scripts/validate/links.py README.md -odlc` reports the same four pre-existing duplicate
  links and none from this entry.
- No existing entry points at this API; I searched the README and this repository's issues
  and pull requests for both `pdfmint` and `mintapis` and found nothing.
