### PR TITLE
Add FXpeek — source-linked historical reference exchange rates (CSV/JSON + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Exchangerate.dev](https://exchangerate.dev/docs) | Live & historical FX, 168 pairs back to 1999, Frankfurter-compatible, free 10k/mo | No | Yes | Unknown |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
 | [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | No | Yes | No |
+| [FXpeek](https://fxpeek.com/en/api) | Source-linked historical reference exchange rates with CSV, JSON and an MCP server | No | Yes | Unknown |
 | [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
 | [paralelo.bo](https://paralelo.bo/api) | Bolivia parallel-market USD/BOB exchange rate, aggregated from P2P sources every 60s | No | Yes | Yes |
 | [TaxID](https://www.taxid.dev/docs) | EU VAT number validation with company name and address lookup across all 27 member states | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds FXpeek under Currency Exchange.

- Historical reference exchange rates with a **source link per row** (ECB/Frankfurter-derived), not just a number.
- Free endpoints: /api/rates, /api/history, /api/csv (no key), plus an **MCP server** at /api/mcp and an OpenAPI spec at /openapi.json.
- HTTPS: Yes. Reference data only; not a transaction quote.

Placement: alphabetical, after FreeForexAPI.