### PR TITLE
feat: Add Repology API

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,7 @@ API | Description | Auth | HTTPS | CORS |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
 | [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey` | Yes | Yes |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey` | Yes | No |
+| [Repology](https://repology.org/api/v1) | Package versions across 100+ Linux repos | No | Yes | Unknown |
 | [ReqRes](https://reqres.in/ ) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
 | [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |
 | [RubyGems](https://guides.rubygems.org/rubygems-org-api/) | Ruby gem metadata, versions, dependencies and search | No | Yes | Yes |


### PR DESCRIPTION
Add [Repology](https://repology.org/api/v1) to the Development section, alphabetically between Rejax and ReqRes.

- API: Package versions across 100+ Linux repos
- Auth: No
- HTTPS: Yes
- CORS: Unknown
