### PR TITLE
feat: Add MyGene.info API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1715,6 +1715,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Launch Library 2](https://thespacedevs.com/llapi) | Spaceflight launches and events database | No | Yes | Yes |
 | [Materials Platform for Data Science](https://mpds.io) | Curated experimental data for materials science | `apiKey` | Yes | No |
 | [Minor Planet Center](http://www.asterank.com/mpc) | Asterank.com Information | No | No | Unknown |
+| [MyGene.info](https://docs.mygene.info/) | Gene annotation queries and ID lookup | No | Yes | Yes |
 | [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | No |
 | [NASA InSight](https://api.nasa.gov/) | Mars weather data from InSight lander | `apiKey` | Yes | Yes |
 | [NASA ADS](https://ui.adsabs.harvard.edu/help/api/api-docs.html) | NASA Astrophysics Data System | `OAuth` | Yes | Yes |


### PR DESCRIPTION
Add [MyGene.info](https://docs.mygene.info/) to the Science & Math section, alphabetically between Minor Planet Center and NASA.

- API: Gene annotation queries and ID lookup
- Auth: No
- HTTPS: Yes
- CORS: Yes
