### PR TITLE
Add ArcNautical API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2035,6 +2035,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth` | Yes | Unknown |
 | [apilayer aviationstack](https://aviationstack.com/) | Real-time Flight Status & Global Aviation Data API | `OAuth` | Yes | Unknown |
 | [Apimetro](https://apimetro.dev/swagger/index.html) | Geospatial data for Mexico City public transport system (Metro, Metrobús, Cablebús, RTP, etc.) | No | Yes | Yes |
+| [ArcNautical](https://arcnautical.com/developers/) | Screen any ship by IMO for OFAC/EU/UN/UK sanctions, ownership opacity and a vetting grade | No | Yes | Yes |
 | [Aviation Safety Data](https://himaxym.com/developers) | 164,068 aircraft accident narratives from 128 official investigation authorities, plus FAA data | No | Yes | Yes |
 | [AviationAPI](https://docs.aviationapi.com) | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather | No | Yes | No |
 | [AZ511](https://www.az511.com/developers/doc) | Access traffic data from the ADOT API | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>

Adds ArcNautical under **Transportation**: vessel sanctions screening by IMO number.

- `GET https://arcnautical.com/api/v1/vessels/{imo}/check` — no key, no account, 100 requests/hour per IP, CORS `*`, so it works from a browser page too.
- Returns sanctions status (OFAC SDN, EU, UN, UK OFSI, OpenSanctions), ownership-opacity score and an A–E vetting grade as JSON.
- Docs: https://arcnautical.com/developers/ · OpenAPI 3.1: https://arcnautical.com/api/v1/openapi.json · Postman: https://www.postman.com/arcnautical-6322764/arcnautical-s-workspace/collection/u7ua5ow/arcnautical-api-v1

Try it: `curl https://arcnautical.com/api/v1/vessels/9811000/check`