### PR TITLE
Add getyoutubetranscript.com API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2175,6 +2175,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Dune](https://github.com/ywalia01/dune-api) | A simple API which provides you with book, character, movie and quotes JSON data | No | Yes | Yes |
 | [Final Space](https://finalspaceapi.com/docs/) | Final Space API | No | Yes | Yes |
 | [Game of Thrones Quotes](https://gameofthronesquotes.xyz/) | Some Game of Thrones quotes | No | Yes | Unknown |
+| [getyoutubetranscript.com](https://getyoutubetranscript.com/docs) | Fetch YouTube video transcripts, search videos/channels, and extract playlist data | `apiKey` | Yes | No |
 | [Harry Potter Charactes](https://hp-api.herokuapp.com/) | Harry Potter Characters Data with with imagery | No | Yes | Unknown |
 | [Hyperserve](https://hyperserve.io/) | Video backend API: upload any format, transcode to MP4, deliver via CDN | `apiKey` | Yes | Yes |
 | [IMDb-API](https://imdb-api.com/) | API for receiving movie, serial and cast information | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds one entry to the Video section: getyoutubetranscript.com, a REST API for fetching YouTube video transcripts, searching videos/channels, and extracting playlist data.

- Free tier (no purchase/device required)
- HTTPS only, apiKey auth
- No CORS support (server-side use only), marked accordingly

Single-line addition, alphabetically placed after "Game of Thrones Quotes".