### PR TITLE
Fix OneSignal documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ API | Description | Auth | HTTPS | CORS |
 | [NetworkCalc](https://networkcalc.com/api/docs) | Network calculators, including subnets, DNS, binary, and security tools | No | Yes | Yes |
 | [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) | Query information about your favorite Node.js libraries programatically | No | Yes | Unknown |
 | [NuGet](https://learn.microsoft.com/en-us/nuget/api/overview) | .NET package versions, metadata and search | No | Yes | Yes |
-| [OneSignal](https://documentation.onesignal.com/docs/onesignal-api) | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App | `apiKey` | Yes | Unknown |
+| [OneSignal](https://documentation.onesignal.com/reference/rest-api-overview) | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App | `apiKey` | Yes | Unknown |
 | [Open Page Rank](https://www.domcop.com/openpagerank/) | API for calculating and comparing metrics of different websites using Page Rank algorithm | `apiKey` | Yes | Unknown |
 | [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
 | [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | Really simple API to retrieve Open Graph data from an URL | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Description

Update the OneSignal entry to point to the current official REST API overview.

The previous URL returned HTTP 404. The replacement URL is maintained by OneSignal and currently returns HTTP 200.

This addresses the OneSignal entry reported in #7089.

## Validation

- Verified old URL: HTTP 404
- Verified replacement URL: HTTP 200
- `git diff --check`
- `npx --yes aislop scan --changes --json` (score 100)

No code or runtime behavior changed.

Fixes #7089
