### PR TITLE
Fix Covalent documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Chainlink](https://chain.link/developer-resources) | Build hybrid smart contracts with Chainlink | No | Yes | Unknown |
 | [Chainpoint](https://tierion.com/chainpoint/) | Chainpoint is a global network for anchoring data to the Bitcoin blockchain | No | Yes | Unknown |
 | [ClearTrace](https://cleartracedata.com/docs) | Cross-frontend DEX attribution and execution quality data across Ethereum and L2s | No | Yes | Yes |
-| [Covalent](https://www.covalenthq.com/docs/api/) | Multi-blockchain data aggregator platform | `apiKey` | Yes | Unknown |
+| [Covalent](https://goldrush.dev/docs/) | Multi-blockchain data aggregator platform | `apiKey` | Yes | Unknown |
 | [Etherscan](https://etherscan.io/apis) | Ethereum explorer API | `apiKey` | Yes | Yes |
 | [Get Started with Web3](https://github.com/beihaili/Get-Started-with-Web3/blob/main/docs/api.md) | Bilingual Web3 lessons, glossary search and role-based learning paths | No | Yes | Yes |
 | [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Update the Covalent entry to point to the current official GoldRush documentation.

The previous documentation URL returns HTTP 404. Covalent is now documented under GoldRush, and the replacement URL currently returns HTTP 200.

This addresses the Covalent entry reported in #7089.

## Validation

- Verified old URL: HTTP 404
- Verified replacement URL: HTTP 200
- `git diff --check`
- `npx --yes aislop scan --changes --json` (score 100)

No code or runtime behavior changed.

Fixes #7089
