### PR TITLE
Add Unblock Master IP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,7 @@ API | Description | Auth | HTTPS | CORS |
 | [Telize](https://rapidapi.com/fcambus/api/telize/) | Telize offers location information from any IP address | `apiKey` | Yes | Yes |
 | [TomTom](https://developer.tomtom.com/) | Maps, Directions, Places and Traffic APIs | `apiKey` | Yes | Yes |
 | [Uebermaps](https://uebermaps.com/api/v2) | Discover and share maps with friends | `apiKey` | Yes | Unknown |
+| [Unblock Master IP](https://www.unblockmaster.com/free-ip-api/) | IP geolocation plus datacenter and VPN detection for any IPv4 or IPv6 address | No | Yes | Yes |
 | [US ZipCode](https://www.smarty.com/docs/cloud/us-zipcode-api) | Validate and append data for any US ZipCode | `apiKey` | Yes | Yes |
 | [Utah AGRC](https://api.mapserv.utah.gov) | Utah Web API for geocoding Utah addresses | `apiKey` | Yes | Unknown |
 | [ViaCep](https://viacep.com.br) | Brazil RESTful zip codes API | No | Yes | Unknown |


### PR DESCRIPTION
Adds a free IP geolocation API to **Geocoding**.

| field | value |
| --- | --- |
| Docs | https://www.unblockmaster.com/free-ip-api/ |
| Auth | No — no key, no signup |
| HTTPS | Yes |
| CORS | Yes |

```
curl https://www.unblockmaster.com/api/v1/ip/8.8.8.8
```

Returns country, city, network operator and whether the address belongs to a datacenter or VPN range. `/api/v1/ip` without an address looks up the caller's own IP. 60 requests per minute per client, with `X-RateLimit-Remaining` on every response.

Fully free with no paid tier — there is nothing to upgrade to and no device or service to buy.

Checklist:
- Added to the Geocoding section in alphabetical order
- One link, not already listed
- Description is 77 characters
- `scripts/validate/format.py` output is unchanged from master
- `check_if_link_is_working` passes on the docs link