### PR TITLE
Add inboxsink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ API | Description | Auth | HTTPS | CORS |
 | [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
 | [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
 | [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
+| [inboxsink](https://inboxsink.com/docs) | Disposable inboxes for end-to-end tests that wait for the email and extract OTP codes | `apiKey` | Yes | No |
 | [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |
 | [Kiprio Email Validate](https://kiprio.com/v1/email-validate) | Free email validation: MX check, disposable detection, syntax | `apiKey` | Yes | Yes |
 | [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |


### PR DESCRIPTION
Adds inboxsink to the **Email** section, in alphabetical order.

Disposable inboxes for end-to-end tests: an inbox is created with an API key, a `wait` endpoint blocks until the email arrives, and verification codes and confirmation links are extracted automatically.

- Free tier: 1,000 API calls a month, no card
- Auth: API key (`Authorization: Bearer`)
- HTTPS: yes; CORS: no (server-side use)
- Docs: https://inboxsink.com/docs

Disclosure: opened by the maintainer of inboxsink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzYjYTiK9zLmVqLpLKUPA8