### PR TITLE
Add CoinNudge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ API | Description | Auth | HTTPS | CORS |
 | [CoinLobster](https://coinlobster.com/developers) | Live executed whale trades across 15 exchanges and on-chain DEX with an unusualness radar | No | Yes | Yes |
 | [Coinlore](https://www.coinlore.com/cryptocurrency-data-api) | Cryptocurrencies prices, volume and more | No | Yes | Unknown |
 | [CoinMarketCap](https://coinmarketcap.com/api/) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
+| [CoinNudge](https://coinnudge.site/data/api-docs) | Current crypto market breadth, funding and open-interest research datasets | `apiKey` | Yes | Unknown |
 | [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
 | [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
 | [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds current crypto Research datasets under Cryptocurrency, using the documented free API-key access path. Free accounts can create one key with a shared limit of 60 requests per minute; historical Market Events releases are separate and paid.

Documentation: https://coinnudge.site/data/api-docs
The documentation includes free Research catalog, JSON/CSV endpoints and cURL examples. A public market-breadth snapshot returned HTTP 200 JSON during verification. CORS is marked Unknown; authenticated requests were not tested with a private key.

- [x] Entry follows the existing five-column Cryptocurrency table
- [x] Addition is ordered alphabetically
- [x] Useful description under 100 characters, without ending punctuation
- [x] Columns have one space of padding
- [x] Searched existing issues/PRs and README for duplicates
- [x] No new category; one commit and one README row

Full disclosure: this is my project.